### PR TITLE
fix - evict oldest entry instead of arbitrary

### DIFF
--- a/crates/infrastructure/src/dns/block_filter/decision_cache.rs
+++ b/crates/infrastructure/src/dns/block_filter/decision_cache.rs
@@ -131,7 +131,12 @@ impl BlockDecisionCache {
                 self.inner.remove(k);
             }
             if self.inner.len() >= L1_CAPACITY {
-                if let Some(k) = self.inner.iter().map(|e| *e.key()).next() {
+                let oldest = self
+                    .inner
+                    .iter()
+                    .min_by_key(|e| e.value().1)
+                    .map(|e| *e.key());
+                if let Some(k) = oldest {
                     self.inner.remove(&k);
                 }
             }


### PR DESCRIPTION
When BlockDecisionCache reaches L1_CAPACITY and expired-entry batch eviction is insufficient, the fallback now removes the entry with the lowest inserted_at (oldest) rather than whichever entry the iterator happens to return first. This makes eviction deterministic and preferentially reclaims entries closest to natural TTL expiry.