### PR TITLE
fix - stale records never refreshed and inflight zombie entries

### DIFF
--- a/crates/infrastructure/src/dns/cache/storage.rs
+++ b/crates/infrastructure/src/dns/cache/storage.rs
@@ -152,7 +152,6 @@ impl DnsCache {
             let now_secs = coarse_now_secs();
 
             if record.is_stale_usable_at_secs(now_secs) {
-                record.try_set_refreshing();
                 self.metrics.hits.fetch_add(1, AtomicOrdering::Relaxed);
                 record.record_hit();
                 return Some((


### PR DESCRIPTION
BUG #2 (HIGH): get() was calling try_set_refreshing() on stale records and ignoring the return value. When the background refresh job ran, try_set_refreshing() returned false (flag already set), so the stale record was never added to refresh candidates and never renewed. Stale window would expire causing a cache miss and an upstream call. Fix: remove the try_set_refreshing() call from the stale path in get(); FLAG_REFRESHING management is the exclusive responsibility of get_refresh_candidates().

BUG #1 (MEDIUM): resolve_as_leader() did not clean up the inflight DashMap entry if the leader future was cancelled (e.g. server shutdown or request timeout). The zombie entry trapped subsequent queries for the same domain as followers waiting indefinitely on a dead channel. Additionally, the follower fallback called self.inner.resolve() directly, bypassing inflight deduplication.
Fix: add InflightLeaderGuard with a Drop impl that removes the entry and sends None to wake followers on cancellation. Change follower fallback to call self.resolve() to re-enter the full leader/follower election cycle.