### PR TITLE
perf - add covering indexes and timeline result cache

### DIFF
--- a/migrations/20260225000001_slow_query_optimizations.sql
+++ b/migrations/20260225000001_slow_query_optimizations.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS idx_query_log_source_created;
+CREATE INDEX idx_query_log_source_created
+    ON query_log(query_source, created_at DESC, blocked);
+
+DROP INDEX IF EXISTS idx_clients_ip;
+CREATE INDEX idx_clients_ip
+    ON clients(ip_address, hostname);
+
+ANALYZE query_log;
+ANALYZE clients;


### PR DESCRIPTION
- upgrade idx_query_log_source_created to include blocked column, enabling index-only scan for timeline aggregation across 24h windows
- upgrade idx_clients_ip to include hostname column, eliminating heap fetches in get_recent_paged LEFT JOIN
- add 30s TTL in-memory cache for timeline results using DashMap; 15-min granularity buckets do not require sub-second freshness
- add tests for get_timeline: empty, bucket aggregation, cache hit