### PR TITLE
perf - embed migrations at compile time and add cache…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 thiserror = "2"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite","migrate"], default-features = false }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "migrate", "macros"], default-features = false }
 chrono = "0.4.43"
 hickory-server = "0.26.0-alpha.1"
 hickory-proto = { version = "0.26.0-alpha.1", features = ["dnssec-ring"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,11 @@ RUN mkdir -p crates/cli/src crates/domain/src crates/application/src \
     cargo build --release && \
     rm -rf crates/*/src
 
-# Copy actual source code and web assets (required for include_str! at compile time)
+# Copy actual source code, web assets, and migrations
+# (required for include_str! and sqlx::migrate! at compile time)
 COPY crates/ ./crates/
 COPY web/ ./web/
+COPY migrations/ ./migrations/
 
 # Build the application (static binary)
 # Touch all source files to ensure cargo detects changes vs stub artifacts (timestamp fix)

--- a/crates/application/src/use_cases/queries/get_stats.rs
+++ b/crates/application/src/use_cases/queries/get_stats.rs
@@ -2,6 +2,7 @@ use crate::ports::QueryLogRepository;
 use ferrous_dns_domain::{query_log::QueryStats, DomainError};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
 
 const CACHE_TTL: Duration = Duration::from_secs(10);
 
@@ -14,6 +15,7 @@ struct CachedStats {
 pub struct GetQueryStatsUseCase {
     repository: Arc<dyn QueryLogRepository>,
     cache: RwLock<Option<CachedStats>>,
+    refresh_lock: Mutex<()>,
 }
 
 impl GetQueryStatsUseCase {
@@ -21,10 +23,22 @@ impl GetQueryStatsUseCase {
         Self {
             repository,
             cache: RwLock::new(None),
+            refresh_lock: Mutex::new(()),
         }
     }
 
     pub async fn execute(&self, period_hours: f32) -> Result<QueryStats, DomainError> {
+        {
+            let guard = self.cache.read().unwrap();
+            if let Some(ref cached) = *guard {
+                if cached.period_hours == period_hours && cached.computed_at.elapsed() < CACHE_TTL {
+                    return Ok(cached.data.clone());
+                }
+            }
+        }
+
+        let _lock = self.refresh_lock.lock().await;
+
         {
             let guard = self.cache.read().unwrap();
             if let Some(ref cached) = *guard {

--- a/crates/infrastructure/src/database/mod.rs
+++ b/crates/infrastructure/src/database/mod.rs
@@ -1,10 +1,8 @@
 use ferrous_dns_domain::config::DatabaseConfig;
-use sqlx::migrate::Migrator;
 use sqlx::sqlite::{
     SqliteConnectOptions, SqliteConnection, SqliteJournalMode, SqlitePool, SqlitePoolOptions,
     SqliteSynchronous,
 };
-use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -52,8 +50,7 @@ pub async fn create_write_pool(
     .execute(&pool)
     .await?;
 
-    let migrator = Migrator::new(Path::new("./migrations")).await?;
-    migrator.run(&pool).await?;
+    sqlx::migrate!("../../migrations").run(&pool).await?;
 
     sqlx::query("PRAGMA optimize").execute(&pool).await?;
 


### PR DESCRIPTION
… stampede guards

Migrations are now embedded in the binary via sqlx::migrate!() macro instead of reading from the filesystem at runtime. This eliminates deployment failures when the migrations/ directory is missing on the target machine.

Added tokio::sync::Mutex stampede guards to all dashboard cache use cases (GetQueryStatsUseCase, GetCacheStatsUseCase, GetQueryRateUseCase, timeline cache) using a double-check pattern so only one task refreshes the cache while others wait, preventing N parallel identical DB queries on cache expiry.