### PR TITLE
feat - add wire data caching for non-A/AAAA record types

### DIFF
--- a/crates/application/src/ports/dns_resolver.rs
+++ b/crates/application/src/ports/dns_resolver.rs
@@ -41,6 +41,14 @@ impl DnsResolution {
         }
     }
 
+    /// Returns true when the resolution carries useful response data
+    /// (IP addresses or raw wire bytes from upstream).
+    pub fn has_response_data(&self) -> bool {
+        !self.addresses.is_empty()
+            || self.upstream_wire_data.is_some()
+            || !self.cname_chain.is_empty()
+    }
+
     pub fn with_dnssec(
         addresses: Vec<IpAddr>,
         cache_hit: bool,

--- a/crates/application/src/use_cases/dns/handle_dns_query.rs
+++ b/crates/application/src/use_cases/dns/handle_dns_query.rs
@@ -208,7 +208,7 @@ impl HandleDnsQueryUseCase {
         }
 
         if let Some(cached) = self.resolver.try_cache(&dns_query) {
-            if !cached.addresses.is_empty() {
+            if cached.has_response_data() {
                 self.log(&QueryLog {
                     cache_hit: true,
                     dnssec_status: cached.dnssec_status,

--- a/crates/infrastructure/src/dns/cache/data.rs
+++ b/crates/infrastructure/src/dns/cache/data.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -37,10 +38,6 @@ impl DnssecStatus {
         }
     }
 
-    pub fn from_string(s: &str) -> Option<Self> {
-        s.parse().ok()
-    }
-
     pub fn from_option_string(opt: Option<String>) -> Self {
         opt.and_then(|s| s.parse().ok()).unwrap_or(Self::Unknown)
     }
@@ -57,6 +54,9 @@ pub enum CachedData {
 
     CanonicalName(Arc<str>),
 
+    /// Raw upstream DNS wire bytes for non-A/AAAA record types (HTTPS, MX, TXT, etc.).
+    WireData(Bytes),
+
     NegativeResponse,
 }
 
@@ -65,6 +65,7 @@ impl CachedData {
         match self {
             CachedData::IpAddresses(entry) => entry.addresses.is_empty(),
             CachedData::CanonicalName(name) => name.is_empty(),
+            CachedData::WireData(bytes) => bytes.is_empty(),
             CachedData::NegativeResponse => false,
         }
     }
@@ -83,6 +84,13 @@ impl CachedData {
     pub fn as_canonical_name(&self) -> Option<&Arc<str>> {
         match self {
             CachedData::CanonicalName(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn as_wire_data(&self) -> Option<&Bytes> {
+        match self {
+            CachedData::WireData(bytes) => Some(bytes),
             _ => None,
         }
     }

--- a/crates/infrastructure/src/dns/cache/refresh.rs
+++ b/crates/infrastructure/src/dns/cache/refresh.rs
@@ -27,10 +27,6 @@ impl DnsCache {
             }
 
             let key = entry.key();
-            if matches!(key.record_type, RecordType::HTTPS) {
-                continue;
-            }
-
             let hit_count = record.counters.hit_count.load(AtomicOrdering::Relaxed);
             let last_access = record.counters.last_access.load(AtomicOrdering::Relaxed);
             let age_since_access = now.saturating_sub(last_access);

--- a/crates/infrastructure/src/dns/cache/storage.rs
+++ b/crates/infrastructure/src/dns/cache/storage.rs
@@ -274,9 +274,9 @@ impl DnsCache {
         let record = CachedRecord::new(data, ttl, record_type, dnssec_status);
         let expires_secs = record.expires_at_secs;
 
+        self.bloom.set(&key);
         match self.cache.entry(key) {
             dashmap::Entry::Vacant(e) => {
-                self.bloom.set(e.key());
                 e.insert(record);
                 self.metrics
                     .insertions
@@ -435,6 +435,8 @@ impl DnsCache {
         }
     }
 
+    /// L1 thread-local cache only holds IP addresses (A/AAAA).
+    /// WireData, CanonicalName, and NegativeResponse stay in L2 only.
     fn promote_to_l1(
         &self,
         domain: &str,

--- a/crates/infrastructure/src/dns/cache_maintenance.rs
+++ b/crates/infrastructure/src/dns/cache_maintenance.rs
@@ -1,4 +1,4 @@
-use super::cache::{coarse_clock, CachedAddresses, DnsCache};
+use super::cache::{coarse_clock, CachedAddresses, CachedData, DnsCache};
 
 use async_trait::async_trait;
 use ferrous_dns_application::ports::{
@@ -53,20 +53,30 @@ impl DnsCacheMaintenance {
         let query = DnsQuery::new(domain, *record_type);
 
         match resolver.resolve(&query).await {
-            Ok(resolution) if !resolution.addresses.is_empty() => {
+            Ok(resolution)
+                if !resolution.addresses.is_empty() || resolution.upstream_wire_data.is_some() =>
+            {
                 let response_time = start.elapsed().as_micros() as u64;
 
                 let dnssec_status: Option<super::cache::DnssecStatus> =
                     resolution.dnssec_status.and_then(|s| s.parse().ok());
 
+                let new_data = if !resolution.addresses.is_empty() {
+                    CachedData::IpAddresses(CachedAddresses {
+                        addresses: Arc::clone(&resolution.addresses),
+                    })
+                } else if let Some(ref wire_bytes) = resolution.upstream_wire_data {
+                    CachedData::WireData(wire_bytes.clone())
+                } else {
+                    return Ok(false);
+                };
+
                 let refreshed = cache.refresh_record(
                     domain,
                     record_type,
-                    None,
-                    super::cache::CachedData::IpAddresses(CachedAddresses {
-                        addresses: Arc::clone(&resolution.addresses),
-                    }),
-                    dnssec_status.map(|_| super::cache::DnssecStatus::Unknown),
+                    resolution.min_ttl,
+                    new_data,
+                    dnssec_status,
                 );
 
                 if !refreshed {
@@ -104,7 +114,7 @@ impl DnsCacheMaintenance {
                     record_type = %record_type,
                     cache_hit = resolution.cache_hit,
                     dnssec_status = ?resolution.dnssec_status,
-                    response_time_ms = response_time,
+                    response_time_us = response_time,
                     "Cache entry refreshed with new DNSSEC validation"
                 );
 

--- a/crates/infrastructure/src/dns/resolver/cache_layer.rs
+++ b/crates/infrastructure/src/dns/resolver/cache_layer.rs
@@ -4,6 +4,7 @@ use super::super::cache::{
 };
 use super::super::prefetch::PrefetchPredictor;
 use async_trait::async_trait;
+use bytes::Bytes;
 use dashmap::DashMap;
 use ferrous_dns_application::ports::{DnsResolution, DnsResolver, EMPTY_CNAME_CHAIN};
 use std::sync::LazyLock;
@@ -21,6 +22,7 @@ struct InflightResult {
     cname_chain: Arc<[Arc<str>]>,
     dnssec_status: Option<&'static str>,
     min_ttl: Option<u32>,
+    upstream_wire_data: Option<Bytes>,
 }
 
 type InflightSender = Arc<watch::Sender<Option<Arc<InflightResult>>>>;
@@ -93,7 +95,19 @@ impl CachedResolver {
                         negative_soa_ttl: None,
                         upstream_wire_data: None,
                     },
-                    CachedData::CanonicalName(_) => DnsResolution {
+                    CachedData::CanonicalName(name) => DnsResolution {
+                        addresses: Arc::clone(&EMPTY_ADDRESSES),
+                        cache_hit: true,
+                        local_dns: false,
+                        dnssec_status: dnssec_str,
+                        cname_chain: Arc::from([Arc::clone(&name)]),
+                        upstream_server: None,
+                        upstream_pool: None,
+                        min_ttl: remaining_ttl,
+                        negative_soa_ttl: None,
+                        upstream_wire_data: None,
+                    },
+                    CachedData::WireData(bytes) => DnsResolution {
                         addresses: Arc::clone(&EMPTY_ADDRESSES),
                         cache_hit: true,
                         local_dns: false,
@@ -103,7 +117,7 @@ impl CachedResolver {
                         upstream_pool: None,
                         min_ttl: remaining_ttl,
                         negative_soa_ttl: None,
-                        upstream_wire_data: None,
+                        upstream_wire_data: Some(bytes),
                     },
                     CachedData::NegativeResponse => DnsResolution {
                         addresses: Arc::clone(&EMPTY_ADDRESSES),
@@ -135,17 +149,32 @@ impl CachedResolver {
 
     fn store_in_cache(&self, query: &DnsQuery, resolution: &DnsResolution) {
         if resolution.addresses.is_empty() {
-            let ttl = resolution
-                .negative_soa_ttl
-                .map(clamp_negative_ttl)
-                .unwrap_or_else(|| self.negative_ttl_tracker.record_and_get_ttl(&query.domain));
-            self.cache.insert(
-                query.domain.as_ref(),
-                query.record_type,
-                CachedData::NegativeResponse,
-                ttl,
-                Some(DnssecStatus::Insecure),
-            );
+            if let Some(ref wire_data) = resolution.upstream_wire_data {
+                let ttl = resolution.min_ttl.unwrap_or(self.cache_ttl).max(1);
+                let dnssec_status = resolution
+                    .dnssec_status
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(DnssecStatus::Insecure);
+                self.cache.insert(
+                    query.domain.as_ref(),
+                    query.record_type,
+                    CachedData::WireData(wire_data.clone()),
+                    ttl,
+                    Some(dnssec_status),
+                );
+            } else {
+                let ttl = resolution
+                    .negative_soa_ttl
+                    .map(clamp_negative_ttl)
+                    .unwrap_or_else(|| self.negative_ttl_tracker.record_and_get_ttl(&query.domain));
+                self.cache.insert(
+                    query.domain.as_ref(),
+                    query.record_type,
+                    CachedData::NegativeResponse,
+                    ttl,
+                    Some(DnssecStatus::Insecure),
+                );
+            }
         } else {
             let addresses = Arc::clone(&resolution.addresses);
             let dnssec_status = resolution
@@ -204,7 +233,7 @@ impl CachedResolver {
                     upstream_pool: None,
                     min_ttl: result.min_ttl,
                     negative_soa_ttl: None,
-                    upstream_wire_data: None,
+                    upstream_wire_data: result.upstream_wire_data.clone(),
                 });
             }
         }
@@ -220,12 +249,12 @@ impl CachedResolver {
                 upstream_pool: None,
                 min_ttl: result.min_ttl,
                 negative_soa_ttl: None,
-                upstream_wire_data: None,
+                upstream_wire_data: result.upstream_wire_data.clone(),
             });
         }
 
         if let Some(cached) = self.check_cache(query) {
-            return if cached.addresses.is_empty() {
+            return if !cached.has_response_data() {
                 Err(DomainError::NxDomain)
             } else {
                 Ok(cached)
@@ -262,6 +291,7 @@ impl CachedResolver {
                         cname_chain: Arc::clone(&resolution.cname_chain),
                         dnssec_status: resolution.dnssec_status,
                         min_ttl: resolution.min_ttl,
+                        upstream_wire_data: resolution.upstream_wire_data.clone(),
                     });
                     let _ = tx.send(Some(inflight));
                 }
@@ -287,7 +317,7 @@ impl DnsResolver for CachedResolver {
 
     async fn resolve(&self, query: &DnsQuery) -> Result<DnsResolution, DomainError> {
         if let Some(cached) = self.check_cache(query) {
-            return if cached.addresses.is_empty() {
+            return if !cached.has_response_data() {
                 Err(DomainError::NxDomain)
             } else {
                 Ok(cached)
@@ -299,6 +329,15 @@ impl DnsResolver for CachedResolver {
 
         if !is_leader {
             return self.resolve_as_follower(query, rx).await;
+        }
+
+        if let Some(cached) = self.check_cache(query) {
+            self.inflight.remove(&key);
+            return if !cached.has_response_data() {
+                Err(DomainError::NxDomain)
+            } else {
+                Ok(cached)
+            };
         }
 
         self.resolve_as_leader(query, key).await

--- a/crates/infrastructure/src/dns/server.rs
+++ b/crates/infrastructure/src/dns/server.rs
@@ -76,11 +76,12 @@ impl DnsServerHandler {
 
         if addresses.is_empty() {
             if let Some(ref wire_data) = resolution.upstream_wire_data {
-                if let Ok(message) = Message::from_vec(wire_data) {
-                    for record in message.name_servers() {
-                        resp.add_name_server(record.clone());
-                    }
+                let mut response = wire_data.to_vec();
+                if response.len() >= 2 {
+                    response[0] = (query_id >> 8) as u8;
+                    response[1] = query_id as u8;
                 }
+                return Some(response);
             }
         } else {
             let record_name = query_info.name().clone();
@@ -157,18 +158,37 @@ impl RequestHandler for DnsServerHandler {
         let addresses = resolution.addresses;
 
         if addresses.is_empty() {
+            if let Some(ref wire_data) = resolution.upstream_wire_data {
+                if let Ok(message) = Message::from_vec(wire_data) {
+                    let answers: Vec<Record> = message.answers().to_vec();
+                    let authority: Vec<Record> = message.name_servers().to_vec();
+                    let additional: Vec<Record> = message.additionals().to_vec();
+                    let builder = MessageResponseBuilder::from_message_request(request);
+                    let mut header = *request.header();
+                    header.set_message_type(MessageType::Response);
+                    header.set_recursion_available(true);
+                    let response = builder.build(
+                        header,
+                        answers.iter(),
+                        authority.iter(),
+                        &[],
+                        additional.iter(),
+                    );
+                    return match response_handle.send_response(response).await {
+                        Ok(info) => info,
+                        Err(e) => {
+                            error!(error = %e, "Failed to send wire data response");
+                            ResponseInfo::from(*request.header())
+                        }
+                    };
+                }
+            }
             debug!(domain = %domain_ref, "No records found (NODATA)");
             let builder = MessageResponseBuilder::from_message_request(request);
             let mut header = *request.header();
             header.set_message_type(MessageType::Response);
             header.set_recursion_available(true);
-            let authority_records: Vec<Record> = resolution
-                .upstream_wire_data
-                .as_ref()
-                .and_then(|wire_data| Message::from_vec(wire_data).ok())
-                .map(|msg| msg.name_servers().to_vec())
-                .unwrap_or_default();
-            let response = builder.build(header, &[], authority_records.iter(), &[], &[]);
+            let response = builder.build(header, &[], &[], &[], &[]);
             return match response_handle.send_response(response).await {
                 Ok(info) => info,
                 Err(e) => {


### PR DESCRIPTION
Previously only A/AAAA queries were cached correctly as IpAddresses. All other types (HTTPS, MX, TXT, DS, SRV, etc.) were stored as NegativeResponse, causing false NXDOMAIN on 2nd query, lost answer records, and incorrect TTL handling.

Add CachedData::WireData(Bytes) variant that stores raw upstream DNS wire bytes in the DashMap cache with proper TTL clamping, bloom filter, eviction, and stale-serve support. Wire data flows through the full cache pipeline including background refresh jobs and inflight coalescing.

Also fixes pre-existing issues found during review:
- CanonicalName cache hits no longer return false NXDOMAIN
- DNSSEC status preserved on cache refresh (was mapped to Unknown)
- HTTPS records included in refresh candidates (stale-serve covers short TTLs)
- Dead code removed (DnssecStatus::from_string)