### PR TITLE
fix - prevent bloom filter decay and ensure refresh hits upstream

### DIFF
--- a/crates/cli/src/di/dns.rs
+++ b/crates/cli/src/di/dns.rs
@@ -62,15 +62,12 @@ impl DnsServices {
             cache.set_stale_refresh_sender(stale_tx);
 
             let resolver_for_maintenance: Arc<dyn ferrous_dns_application::ports::DnsResolver> =
-                Arc::new(
-                    HickoryDnsResolver::new_with_pools(
-                        pool_manager_clone.clone(),
-                        timeout_ms,
-                        false,
-                        None,
-                    )?
-                    .with_cache(cache.clone(), config.dns.cache_ttl),
-                );
+                Arc::new(HickoryDnsResolver::new_with_pools(
+                    pool_manager_clone.clone(),
+                    timeout_ms,
+                    false,
+                    None,
+                )?);
 
             DnsCacheMaintenance::start_stale_listener(
                 cache.clone(),

--- a/crates/infrastructure/src/dns/cache/storage.rs
+++ b/crates/infrastructure/src/dns/cache/storage.rs
@@ -165,8 +165,11 @@ impl DnsCache {
         domain: &Arc<str>,
         record_type: &RecordType,
     ) -> Option<(CachedData, Option<DnssecStatus>, Option<u32>)> {
+        let borrowed = BorrowedKey::new(domain.as_ref(), *record_type);
+
         if let Some((arc_data, remaining_ttl)) = l1_get(domain.as_ref(), record_type) {
             self.metrics.hits.fetch_add(1, AtomicOrdering::Relaxed);
+            self.bloom.set(&borrowed);
             return Some((
                 CachedData::IpAddresses(super::data::CachedAddresses {
                     addresses: arc_data,
@@ -176,7 +179,6 @@ impl DnsCache {
             ));
         }
 
-        let borrowed = BorrowedKey::new(domain.as_ref(), *record_type);
         let in_bloom = self.bloom.check(&borrowed);
 
         if !in_bloom {
@@ -201,6 +203,7 @@ impl DnsCache {
                     .stale_hits
                     .fetch_add(1, AtomicOrdering::Relaxed);
                 record.record_hit();
+                self.bloom.set(&borrowed);
                 if let Some(tx) = self.stale_refresh_tx.get() {
                     if record.try_set_refreshing()
                         && tx.try_send((Arc::clone(domain), key.record_type)).is_err()


### PR DESCRIPTION
Three bugs were causing cache entries to go upstream unnecessarily:

1. Stale-serve path in DnsCache::get() did not call bloom.set(), causing bloom filter bits to decay after 2 rotations (~120s) while entries were still stale-usable in L2.

2. L1 cache hits bypassed bloom.set() entirely. Popular entries served exclusively from thread-local L1 would lose bloom bits, causing cache misses when L1 evicted them.

3. The maintenance resolver wrapped the cache via .with_cache(), so refresh_entry() read stale data from cache instead of querying upstream. Entries were "refreshed" with their own cached data indefinitely.