### PR TITLE
feat(api) - add OpenAPI specs and Scalar UI for native and Pi-hole APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,8 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-scalar",
 ]
 
 [[package]]
@@ -856,6 +858,8 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "utoipa",
+ "utoipa-axum",
 ]
 
 [[package]]
@@ -879,6 +883,8 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "utoipa",
+ "utoipa-axum",
 ]
 
 [[package]]
@@ -1627,6 +1633,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2041,6 +2049,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2365,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3419,6 +3445,55 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "utoipa-scalar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,11 @@ mimalloc = { version = "0.1", default-features = false }
 core_affinity = "0.8"
 libc = "0.2.183"
 
+# OpenAPI documentation
+utoipa = { version = "5", features = ["axum_extras", "chrono"] }
+utoipa-axum = "0.2"
+utoipa-scalar = { version = "0.3", features = ["axum"] }
+
 # ============================================================================
 # PERFORMANCE OPTIMIZATION PROFILES
 # ============================================================================

--- a/crates/api-pihole/Cargo.toml
+++ b/crates/api-pihole/Cargo.toml
@@ -19,6 +19,8 @@ tokio.workspace = true
 hostname = "0.4"
 ring.workspace = true
 libc = "0.2"
+utoipa.workspace = true
+utoipa-axum.workspace = true
 
 [dev-dependencies]
 ferrous-dns-infrastructure.workspace = true

--- a/crates/api-pihole/src/dto/action.rs
+++ b/crates/api-pihole/src/dto/action.rs
@@ -1,8 +1,10 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
 /// Pi-hole v6 POST /api/action/* response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ActionResponse {
+    #[schema(value_type = String)]
     pub status: &'static str,
     pub message: String,
 }

--- a/crates/api-pihole/src/dto/auth.rs
+++ b/crates/api-pihole/src/dto/auth.rs
@@ -1,13 +1,14 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// Pi-hole v6 POST /api/auth request body.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct LoginRequest {
     pub password: String,
 }
 
 /// Pi-hole v6 session object returned by GET/POST /api/auth.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SessionInfo {
     pub valid: bool,
     pub totp: bool,
@@ -18,7 +19,7 @@ pub struct SessionInfo {
 }
 
 /// Pi-hole v6 auth response envelope.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct AuthResponse {
     pub session: SessionInfo,
 }

--- a/crates/api-pihole/src/dto/clients.rs
+++ b/crates/api-pihole/src/dto/clients.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// Pi-hole v6 client entry.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PiholeClientEntry {
     pub id: i64,
     pub ip: String,
@@ -16,7 +17,7 @@ pub struct PiholeClientEntry {
 }
 
 /// Pi-hole v6 POST /api/clients request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateClientRequest {
     pub ip: String,
     pub comment: Option<String>,
@@ -24,20 +25,20 @@ pub struct CreateClientRequest {
 }
 
 /// Pi-hole v6 PUT /api/clients/:client request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateClientRequest {
     pub comment: Option<String>,
     pub groups: Option<Vec<i64>>,
 }
 
 /// Pi-hole v6 clients list response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ClientsResponse {
     pub clients: Vec<PiholeClientEntry>,
 }
 
 /// Pi-hole v6 GET /api/clients/_suggestions response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ClientSuggestionsResponse {
     pub suggestions: Vec<String>,
 }

--- a/crates/api-pihole/src/dto/dns.rs
+++ b/crates/api-pihole/src/dto/dns.rs
@@ -1,14 +1,15 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// Pi-hole v6 GET /api/dns/blocking response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct BlockingStatusResponse {
     pub blocking: bool,
     pub timer: Option<u64>,
 }
 
 /// Pi-hole v6 POST /api/dns/blocking request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct SetBlockingRequest {
     pub blocking: bool,
     /// Optional timer in seconds — re-enables blocking after this period.

--- a/crates/api-pihole/src/dto/domains.rs
+++ b/crates/api-pihole/src/dto/domains.rs
@@ -1,11 +1,14 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// Pi-hole v6 domain entry (covers both exact and regex).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PiholeDomainEntry {
     pub id: i64,
     pub domain: String,
+    #[schema(value_type = String)]
     pub r#type: &'static str,
+    #[schema(value_type = String)]
     pub kind: &'static str,
     pub enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -18,7 +21,7 @@ pub struct PiholeDomainEntry {
 }
 
 /// Pi-hole v6 POST/PUT domain request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateDomainRequest {
     pub domain: String,
     pub comment: Option<String>,
@@ -27,13 +30,13 @@ pub struct CreateDomainRequest {
 }
 
 /// Pi-hole v6 batch delete request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct BatchDeleteRequest {
     pub items: Vec<String>,
 }
 
 /// Pi-hole v6 domain list response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct DomainsListResponse {
     pub domains: Vec<PiholeDomainEntry>,
 }

--- a/crates/api-pihole/src/dto/groups.rs
+++ b/crates/api-pihole/src/dto/groups.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// Pi-hole v6 group entry.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PiholeGroupEntry {
     pub id: i64,
     pub name: String,
@@ -15,7 +16,7 @@ pub struct PiholeGroupEntry {
 }
 
 /// Pi-hole v6 POST /api/groups request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateGroupRequest {
     pub name: String,
     pub comment: Option<String>,
@@ -23,7 +24,7 @@ pub struct CreateGroupRequest {
 }
 
 /// Pi-hole v6 PUT /api/groups/:name request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateGroupRequest {
     pub name: Option<String>,
     pub comment: Option<String>,
@@ -31,7 +32,7 @@ pub struct UpdateGroupRequest {
 }
 
 /// Pi-hole v6 groups list response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct GroupsResponse {
     pub groups: Vec<PiholeGroupEntry>,
 }

--- a/crates/api-pihole/src/dto/history.rs
+++ b/crates/api-pihole/src/dto/history.rs
@@ -1,12 +1,13 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
 /// Pi-hole v6 GET /api/history/clients response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct HistoryClientsResponse {
     pub clients: Vec<ClientHistoryEntry>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ClientHistoryEntry {
     pub name: String,
     pub ip: String,

--- a/crates/api-pihole/src/dto/info.rs
+++ b/crates/api-pihole/src/dto/info.rs
@@ -1,7 +1,8 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
 /// Pi-hole v6 GET /api/info/version response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct VersionResponse {
     pub version: String,
     pub branch: String,
@@ -9,7 +10,7 @@ pub struct VersionResponse {
 }
 
 /// Pi-hole v6 GET /api/info/ftl response (FTL daemon info).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct FtlInfoResponse {
     pub pid: u32,
     pub uptime: u64,
@@ -20,28 +21,28 @@ pub struct FtlInfoResponse {
     pub database: FtlDatabaseInfo,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct FtlDatabaseInfo {
     pub gravity: u64,
     pub queries: u64,
 }
 
 /// Pi-hole v6 GET /api/info/system response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SystemInfoResponse {
     pub load: [f64; 3],
     pub memory: MemoryInfo,
     pub disk: DiskInfo,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct MemoryInfo {
     pub total: u64,
     pub used: u64,
     pub percent: f64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct DiskInfo {
     pub total: u64,
     pub used: u64,
@@ -49,13 +50,13 @@ pub struct DiskInfo {
 }
 
 /// Pi-hole v6 GET /api/info/host response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct HostInfoResponse {
     pub hostname: String,
 }
 
 /// Pi-hole v6 GET /api/info/database response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct DatabaseInfoResponse {
     pub queries: u64,
     pub filesize: u64,

--- a/crates/api-pihole/src/dto/lists.rs
+++ b/crates/api-pihole/src/dto/lists.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// Pi-hole v6 adlist/list entry.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PiholeListEntry {
     pub id: i64,
     pub address: String,
@@ -19,7 +20,7 @@ pub struct PiholeListEntry {
 }
 
 /// Pi-hole v6 POST /api/lists request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateListRequest {
     pub address: String,
     pub comment: Option<String>,
@@ -29,7 +30,7 @@ pub struct CreateListRequest {
 }
 
 /// Pi-hole v6 list response envelope.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ListsResponse {
     pub lists: Vec<PiholeListEntry>,
 }

--- a/crates/api-pihole/src/dto/queries.rs
+++ b/crates/api-pihole/src/dto/queries.rs
@@ -1,8 +1,9 @@
 use ferrous_dns_domain::BlockSource;
 use serde::Serialize;
+use utoipa::ToSchema;
 
 /// Pi-hole v6 GET /api/queries response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct QueriesResponse {
     pub queries: Vec<PiholeQueryEntry>,
     pub cursor: Option<i64>,
@@ -15,34 +16,35 @@ pub struct QueriesResponse {
 }
 
 /// Client reference returned inside a query entry.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PiholeClientRef {
     pub ip: String,
     pub name: Option<String>,
 }
 
 /// Reply object in Pi-hole v6 format.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PiholeReply {
     pub r#type: String,
     pub time: f64,
 }
 
 /// Extended DNS Error info.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PiholeEde {
     pub code: i32,
     pub text: Option<String>,
 }
 
 /// Single query entry in Pi-hole v6 format.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PiholeQueryEntry {
     pub id: i64,
     pub time: f64,
     pub r#type: String,
     pub domain: String,
     pub client: PiholeClientRef,
+    #[schema(value_type = String)]
     pub status: &'static str,
     pub dnssec: String,
     pub reply: PiholeReply,
@@ -59,7 +61,7 @@ pub struct PiholeQueryEntry {
 /// Pi-hole v6 GET /api/queries/suggestions response.
 ///
 /// Categories are returned flat at root level (no wrapper object).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SuggestionsResponse {
     pub domain: Vec<String>,
     pub client_ip: Vec<String>,

--- a/crates/api-pihole/src/dto/search.rs
+++ b/crates/api-pihole/src/dto/search.rs
@@ -1,16 +1,19 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
 /// Pi-hole v6 GET /api/search/:domain response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SearchResponse {
     pub results: Vec<SearchResult>,
 }
 
 /// A single search result showing which list matched.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SearchResult {
     pub domain: String,
+    #[schema(value_type = String)]
     pub r#type: &'static str,
+    #[schema(value_type = String)]
     pub kind: &'static str,
     pub source: String,
     pub blocked: bool,

--- a/crates/api-pihole/src/dto/stats.rs
+++ b/crates/api-pihole/src/dto/stats.rs
@@ -1,16 +1,18 @@
 use serde::Serialize;
 use std::collections::HashMap;
+use utoipa::ToSchema;
 
 /// Pi-hole v6 GET /api/stats/summary response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SummaryResponse {
     pub queries: QuerySummary,
     pub clients: ClientSummary,
     pub gravity: GravitySummary,
+    #[schema(value_type = String)]
     pub status: &'static str,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct QuerySummary {
     pub total: u64,
     pub blocked: u64,
@@ -22,13 +24,13 @@ pub struct QuerySummary {
     pub types: HashMap<String, u64>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ClientSummary {
     pub active: u64,
     pub total: u64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct GravitySummary {
     pub domains_being_blocked: u64,
     pub last_update: i64,
@@ -37,12 +39,12 @@ pub struct GravitySummary {
 /// Pi-hole v6 GET /api/stats/history response.
 ///
 /// Each bucket covers 10 minutes. The full 24h window yields 144 buckets.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct HistoryResponse {
     pub history: Vec<HistoryBucket>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct HistoryBucket {
     pub timestamp: i64,
     pub total: u64,
@@ -52,7 +54,7 @@ pub struct HistoryBucket {
 }
 
 /// Pi-hole v6 GET /api/stats/top_domains response (also used for top_blocked).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct TopDomainsResponse {
     pub domains: Vec<TopDomainEntry>,
     pub total_queries: u64,
@@ -60,14 +62,14 @@ pub struct TopDomainsResponse {
 }
 
 /// Single entry in the top domains array.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct TopDomainEntry {
     pub domain: String,
     pub count: u64,
 }
 
 /// Pi-hole v6 GET /api/stats/top_clients response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct TopClientsResponse {
     pub clients: Vec<TopClientEntry>,
     pub total_queries: u64,
@@ -75,7 +77,7 @@ pub struct TopClientsResponse {
 }
 
 /// Single entry in the top clients array.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct TopClientEntry {
     pub ip: String,
     pub name: String,
@@ -83,7 +85,7 @@ pub struct TopClientEntry {
 }
 
 /// Pi-hole v6 GET /api/stats/query_types response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct QueryTypesResponse {
     /// Keys are DNS record type names (e.g. "A", "AAAA", "MX").
     /// Values are percentages (0.0-100.0).
@@ -91,7 +93,7 @@ pub struct QueryTypesResponse {
 }
 
 /// Pi-hole v6 GET /api/stats/recent_blocked response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct RecentBlockedResponse {
     pub domain: Option<String>,
 }

--- a/crates/api-pihole/src/dto/upstreams.rs
+++ b/crates/api-pihole/src/dto/upstreams.rs
@@ -1,8 +1,9 @@
 use serde::Serialize;
 use std::collections::HashMap;
+use utoipa::ToSchema;
 
 /// Pi-hole v6 GET /api/stats/upstreams response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct UpstreamsResponse {
     pub upstreams: HashMap<String, u64>,
     pub forwarded_queries: u64,

--- a/crates/api-pihole/src/handlers/action.rs
+++ b/crates/api-pihole/src/handlers/action.rs
@@ -6,6 +6,16 @@ use tracing::info;
 use crate::{dto::action::ActionResponse, errors::PiholeApiError, state::PiholeAppState};
 
 /// Pi-hole v6 POST /api/action/gravity — trigger blocklist reload.
+#[utoipa::path(
+    post,
+    path = "/action/gravity",
+    tag = "pihole:action",
+    responses(
+        (status = 200, description = "Blocklist reload triggered", body = ActionResponse),
+        (status = 500, description = "Reload failed")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn gravity(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<ActionResponse>, PiholeApiError> {
@@ -20,6 +30,16 @@ pub async fn gravity(
 ///
 /// Re-reads the config file from disk and updates the shared config.
 /// No process restart is needed — Ferrous DNS applies changes in-memory.
+#[utoipa::path(
+    post,
+    path = "/action/restartdns",
+    tag = "pihole:action",
+    responses(
+        (status = 200, description = "Configuration reloaded", body = ActionResponse),
+        (status = 500, description = "Reload failed")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn restartdns(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<ActionResponse>, PiholeApiError> {
@@ -38,6 +58,16 @@ pub async fn restartdns(
 }
 
 /// Pi-hole v6 POST /api/action/flush/logs — cleanup old query logs.
+#[utoipa::path(
+    post,
+    path = "/action/flush/logs",
+    tag = "pihole:action",
+    responses(
+        (status = 200, description = "Query logs flushed", body = ActionResponse),
+        (status = 500, description = "Flush failed")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn flush_logs(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<ActionResponse>, PiholeApiError> {

--- a/crates/api-pihole/src/handlers/auth.rs
+++ b/crates/api-pihole/src/handlers/auth.rs
@@ -11,6 +11,15 @@ use crate::{
 };
 
 /// Pi-hole v6 GET /api/auth — returns current session state.
+#[utoipa::path(
+    get,
+    path = "/auth",
+    tag = "pihole:auth",
+    responses(
+        (status = 200, description = "Current session state", body = AuthResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_session() -> Json<AuthResponse> {
     Json(AuthResponse {
         session: unauthenticated_session("Use POST /api/auth with your password"),
@@ -21,6 +30,17 @@ pub async fn get_session() -> Json<AuthResponse> {
 ///
 /// Uses `LoginUseCase` to create a real Ferrous DNS session.
 /// If no `LoginUseCase` is wired, allows unauthenticated access.
+#[utoipa::path(
+    post,
+    path = "/auth",
+    tag = "pihole:auth",
+    request_body = LoginRequest,
+    responses(
+        (status = 200, description = "Login successful", body = AuthResponse),
+        (status = 401, description = "Incorrect password", body = AuthResponse)
+    ),
+    security()
+)]
 pub async fn login(
     State(state): State<PiholeAppState>,
     Json(body): Json<LoginRequest>,
@@ -83,6 +103,15 @@ pub async fn login(
 }
 
 /// Pi-hole v6 DELETE /api/auth — session logout.
+#[utoipa::path(
+    delete,
+    path = "/auth",
+    tag = "pihole:auth",
+    responses(
+        (status = 204, description = "Session terminated")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn logout() -> StatusCode {
     StatusCode::NO_CONTENT
 }

--- a/crates/api-pihole/src/handlers/clients.rs
+++ b/crates/api-pihole/src/handlers/clients.rs
@@ -40,6 +40,19 @@ fn client_to_entry(c: &ferrous_dns_domain::Client) -> Result<PiholeClientEntry, 
 }
 
 /// Pi-hole v6 GET /api/clients — list all clients.
+#[utoipa::path(
+    get,
+    path = "/clients",
+    tag = "pihole:clients",
+    params(
+        ("limit" = Option<u32>, Query, description = "Page size (default 1000)"),
+        ("offset" = Option<u32>, Query, description = "Offset")
+    ),
+    responses(
+        (status = 200, description = "All clients", body = ClientsResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn list_all(
     State(state): State<PiholeAppState>,
     Query(params): Query<ClientQueryParams>,
@@ -55,6 +68,17 @@ pub async fn list_all(
 }
 
 /// Pi-hole v6 POST /api/clients — create client.
+#[utoipa::path(
+    post,
+    path = "/clients",
+    tag = "pihole:clients",
+    request_body = CreateClientRequest,
+    responses(
+        (status = 201, description = "Client created", body = PiholeClientEntry),
+        (status = 422, description = "Invalid IP address")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn create_client(
     State(state): State<PiholeAppState>,
     Json(body): Json<CreateClientRequest>,
@@ -74,6 +98,20 @@ pub async fn create_client(
 }
 
 /// Pi-hole v6 PUT /api/clients/:client — update client.
+#[utoipa::path(
+    put,
+    path = "/clients/{client}",
+    tag = "pihole:clients",
+    params(
+        ("client" = String, Path, description = "Client IP address")
+    ),
+    request_body = UpdateClientRequest,
+    responses(
+        (status = 200, description = "Client updated", body = PiholeClientEntry),
+        (status = 404, description = "Client not found")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn update_client(
     State(state): State<PiholeAppState>,
     Path(client_ip): Path<String>,
@@ -103,6 +141,19 @@ pub async fn update_client(
 }
 
 /// Pi-hole v6 DELETE /api/clients/:client — delete client.
+#[utoipa::path(
+    delete,
+    path = "/clients/{client}",
+    tag = "pihole:clients",
+    params(
+        ("client" = String, Path, description = "Client IP address")
+    ),
+    responses(
+        (status = 204, description = "Client deleted"),
+        (status = 404, description = "Client not found")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn delete_client(
     State(state): State<PiholeAppState>,
     Path(client_ip): Path<String>,
@@ -126,6 +177,15 @@ pub async fn delete_client(
 }
 
 /// Pi-hole v6 GET /api/clients/_suggestions — IP/hostname suggestions.
+#[utoipa::path(
+    get,
+    path = "/clients/_suggestions",
+    tag = "pihole:clients",
+    responses(
+        (status = 200, description = "Client suggestions", body = ClientSuggestionsResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn suggestions(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<ClientSuggestionsResponse>, PiholeApiError> {
@@ -144,6 +204,16 @@ pub async fn suggestions(
 }
 
 /// Pi-hole v6 POST /api/clients:batchDelete — batch delete clients.
+#[utoipa::path(
+    post,
+    path = "/clients:batchDelete",
+    tag = "pihole:clients",
+    request_body = BatchDeleteRequest,
+    responses(
+        (status = 204, description = "Batch delete completed")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn batch_delete(
     State(state): State<PiholeAppState>,
     Json(body): Json<BatchDeleteRequest>,

--- a/crates/api-pihole/src/handlers/dns.rs
+++ b/crates/api-pihole/src/handlers/dns.rs
@@ -9,6 +9,15 @@ use crate::{
 };
 
 /// Pi-hole v6 GET /api/dns/blocking
+#[utoipa::path(
+    get,
+    path = "/dns/blocking",
+    tag = "pihole:dns",
+    responses(
+        (status = 200, description = "Current blocking status", body = BlockingStatusResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_blocking(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<BlockingStatusResponse>, PiholeApiError> {
@@ -23,6 +32,16 @@ pub async fn get_blocking(
 ///
 /// Sets blocking state. Optionally accepts a `timer` field (seconds) that
 /// automatically re-enables blocking after the timer expires.
+#[utoipa::path(
+    post,
+    path = "/dns/blocking",
+    tag = "pihole:dns",
+    request_body = SetBlockingRequest,
+    responses(
+        (status = 200, description = "Blocking state updated", body = BlockingStatusResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn set_blocking(
     State(state): State<PiholeAppState>,
     Json(body): Json<SetBlockingRequest>,

--- a/crates/api-pihole/src/handlers/domains.rs
+++ b/crates/api-pihole/src/handlers/domains.rs
@@ -61,6 +61,15 @@ fn regex_to_entry(
 }
 
 /// Pi-hole v6 GET /api/domains — list all domains.
+#[utoipa::path(
+    get,
+    path = "/domains",
+    tag = "pihole:domains",
+    responses(
+        (status = 200, description = "All managed and regex domains", body = DomainsListResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn list_all(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<DomainsListResponse>, PiholeApiError> {
@@ -81,6 +90,19 @@ pub async fn list_all(
 }
 
 /// Pi-hole v6 GET /api/domains/:type — list by allow/deny.
+#[utoipa::path(
+    get,
+    path = "/domains/{type}",
+    tag = "pihole:domains",
+    params(
+        ("type" = String, Path, description = "Action type (allow|deny)")
+    ),
+    responses(
+        (status = 200, description = "Domains filtered by action", body = DomainsListResponse),
+        (status = 422, description = "Unknown type")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn list_by_type(
     State(state): State<PiholeAppState>,
     Path(domain_type): Path<String>,
@@ -108,6 +130,19 @@ pub async fn list_by_type(
 }
 
 /// Pi-hole v6 GET /api/domains/:type/:kind — list by type+kind.
+#[utoipa::path(
+    get,
+    path = "/domains/{type}/{kind}",
+    tag = "pihole:domains",
+    params(
+        ("type" = String, Path, description = "Action type (allow|deny)"),
+        ("kind" = String, Path, description = "Match kind (exact|regex)")
+    ),
+    responses(
+        (status = 200, description = "Domains filtered by type and kind", body = DomainsListResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn list_by_type_kind(
     State(state): State<PiholeAppState>,
     Path((domain_type, kind)): Path<(String, String)>,
@@ -142,6 +177,21 @@ pub async fn list_by_type_kind(
 }
 
 /// Pi-hole v6 POST /api/domains/:type/:kind — create domain.
+#[utoipa::path(
+    post,
+    path = "/domains/{type}/{kind}",
+    tag = "pihole:domains",
+    params(
+        ("type" = String, Path, description = "Action type (allow|deny)"),
+        ("kind" = String, Path, description = "Match kind (exact|regex)")
+    ),
+    request_body = CreateDomainRequest,
+    responses(
+        (status = 201, description = "Domain created", body = PiholeDomainEntry),
+        (status = 422, description = "Invalid type or kind")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn create_domain(
     State(state): State<PiholeAppState>,
     Path((domain_type, kind)): Path<(String, String)>,
@@ -187,6 +237,22 @@ pub async fn create_domain(
 }
 
 /// Pi-hole v6 PUT /api/domains/:type/:kind/:domain — update domain.
+#[utoipa::path(
+    put,
+    path = "/domains/{type}/{kind}/{domain}",
+    tag = "pihole:domains",
+    params(
+        ("type" = String, Path, description = "Action type"),
+        ("kind" = String, Path, description = "Match kind"),
+        ("domain" = String, Path, description = "Domain or regex pattern")
+    ),
+    request_body = CreateDomainRequest,
+    responses(
+        (status = 200, description = "Domain updated", body = PiholeDomainEntry),
+        (status = 404, description = "Domain not found")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn update_domain(
     State(state): State<PiholeAppState>,
     Path((domain_type, kind, domain_name)): Path<(String, String, String)>,
@@ -263,6 +329,21 @@ pub async fn update_domain(
 }
 
 /// Pi-hole v6 DELETE /api/domains/:type/:kind/:domain — delete domain.
+#[utoipa::path(
+    delete,
+    path = "/domains/{type}/{kind}/{domain}",
+    tag = "pihole:domains",
+    params(
+        ("type" = String, Path, description = "Action type"),
+        ("kind" = String, Path, description = "Match kind"),
+        ("domain" = String, Path, description = "Domain or regex pattern")
+    ),
+    responses(
+        (status = 204, description = "Domain deleted"),
+        (status = 404, description = "Domain not found")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn delete_domain(
     State(state): State<PiholeAppState>,
     Path((domain_type, kind, domain_name)): Path<(String, String, String)>,
@@ -324,6 +405,16 @@ pub async fn delete_domain(
 /// batch delete URL path (`/domains:batchDelete`) has no type context.
 /// Items are matched by exact domain/pattern across both managed and regex
 /// entries regardless of their action.
+#[utoipa::path(
+    post,
+    path = "/domains:batchDelete",
+    tag = "pihole:domains",
+    request_body = BatchDeleteRequest,
+    responses(
+        (status = 204, description = "Batch delete completed")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn batch_delete(
     State(state): State<PiholeAppState>,
     Json(body): Json<BatchDeleteRequest>,

--- a/crates/api-pihole/src/handlers/groups.rs
+++ b/crates/api-pihole/src/handlers/groups.rs
@@ -26,6 +26,15 @@ fn group_to_entry(g: &ferrous_dns_domain::Group) -> Result<PiholeGroupEntry, Pih
 }
 
 /// Pi-hole v6 GET /api/groups — list all groups.
+#[utoipa::path(
+    get,
+    path = "/groups",
+    tag = "pihole:groups",
+    responses(
+        (status = 200, description = "All groups", body = GroupsResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn list_all(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<GroupsResponse>, PiholeApiError> {
@@ -38,6 +47,16 @@ pub async fn list_all(
 }
 
 /// Pi-hole v6 POST /api/groups — create group.
+#[utoipa::path(
+    post,
+    path = "/groups",
+    tag = "pihole:groups",
+    request_body = CreateGroupRequest,
+    responses(
+        (status = 201, description = "Group created", body = PiholeGroupEntry)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn create_group(
     State(state): State<PiholeAppState>,
     Json(body): Json<CreateGroupRequest>,
@@ -51,6 +70,19 @@ pub async fn create_group(
 }
 
 /// Pi-hole v6 GET /api/groups/:name — get group by name.
+#[utoipa::path(
+    get,
+    path = "/groups/{name}",
+    tag = "pihole:groups",
+    params(
+        ("name" = String, Path, description = "Group name")
+    ),
+    responses(
+        (status = 200, description = "Group entry", body = PiholeGroupEntry),
+        (status = 404, description = "Group not found")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_by_name(
     State(state): State<PiholeAppState>,
     Path(name): Path<String>,
@@ -68,6 +100,20 @@ pub async fn get_by_name(
 }
 
 /// Pi-hole v6 PUT /api/groups/:name — update group.
+#[utoipa::path(
+    put,
+    path = "/groups/{name}",
+    tag = "pihole:groups",
+    params(
+        ("name" = String, Path, description = "Group name")
+    ),
+    request_body = UpdateGroupRequest,
+    responses(
+        (status = 200, description = "Group updated", body = PiholeGroupEntry),
+        (status = 404, description = "Group not found")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn update_group(
     State(state): State<PiholeAppState>,
     Path(name): Path<String>,
@@ -96,6 +142,19 @@ pub async fn update_group(
 }
 
 /// Pi-hole v6 DELETE /api/groups/:name — delete group.
+#[utoipa::path(
+    delete,
+    path = "/groups/{name}",
+    tag = "pihole:groups",
+    params(
+        ("name" = String, Path, description = "Group name")
+    ),
+    responses(
+        (status = 204, description = "Group deleted"),
+        (status = 404, description = "Group not found")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn delete_group(
     State(state): State<PiholeAppState>,
     Path(name): Path<String>,
@@ -119,6 +178,16 @@ pub async fn delete_group(
 }
 
 /// Pi-hole v6 POST /api/groups:batchDelete — batch delete groups.
+#[utoipa::path(
+    post,
+    path = "/groups:batchDelete",
+    tag = "pihole:groups",
+    request_body = BatchDeleteRequest,
+    responses(
+        (status = 204, description = "Batch delete completed")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn batch_delete(
     State(state): State<PiholeAppState>,
     Json(body): Json<BatchDeleteRequest>,

--- a/crates/api-pihole/src/handlers/history.rs
+++ b/crates/api-pihole/src/handlers/history.rs
@@ -11,6 +11,15 @@ use crate::{
 /// Pi-hole v6 GET /api/history/clients
 ///
 /// Returns per-client query totals for the last 24 hours.
+#[utoipa::path(
+    get,
+    path = "/history/clients",
+    tag = "pihole:history",
+    responses(
+        (status = 200, description = "Per-client query totals", body = HistoryClientsResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_history_clients(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<HistoryClientsResponse>, PiholeApiError> {

--- a/crates/api-pihole/src/handlers/info.rs
+++ b/crates/api-pihole/src/handlers/info.rs
@@ -13,6 +13,15 @@ use crate::{
 use super::stats::STATS_PERIOD_HOURS;
 
 /// Pi-hole v6 GET /api/info/version
+#[utoipa::path(
+    get,
+    path = "/info/version",
+    tag = "pihole:info",
+    responses(
+        (status = 200, description = "Version info", body = VersionResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_version() -> Json<VersionResponse> {
     Json(VersionResponse {
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -22,6 +31,15 @@ pub async fn get_version() -> Json<VersionResponse> {
 }
 
 /// Pi-hole v6 GET /api/info/ftl
+#[utoipa::path(
+    get,
+    path = "/info/ftl",
+    tag = "pihole:info",
+    responses(
+        (status = 200, description = "FTL daemon info", body = FtlInfoResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_ftl_info(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<FtlInfoResponse>, PiholeApiError> {
@@ -43,6 +61,15 @@ pub async fn get_ftl_info(
 }
 
 /// Pi-hole v6 GET /api/info/system
+#[utoipa::path(
+    get,
+    path = "/info/system",
+    tag = "pihole:info",
+    responses(
+        (status = 200, description = "Host system info (load, memory, disk)", body = SystemInfoResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_system_info() -> Json<SystemInfoResponse> {
     let (load, mem, disk) = tokio::task::spawn_blocking(|| {
         let load = read_loadavg();
@@ -83,6 +110,15 @@ pub async fn get_system_info() -> Json<SystemInfoResponse> {
 }
 
 /// Pi-hole v6 GET /api/info/host
+#[utoipa::path(
+    get,
+    path = "/info/host",
+    tag = "pihole:info",
+    responses(
+        (status = 200, description = "Host hostname", body = HostInfoResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_host_info() -> Json<HostInfoResponse> {
     let hostname = hostname::get()
         .map(|h| h.to_string_lossy().into_owned())
@@ -91,6 +127,15 @@ pub async fn get_host_info() -> Json<HostInfoResponse> {
 }
 
 /// Pi-hole v6 GET /api/info/database
+#[utoipa::path(
+    get,
+    path = "/info/database",
+    tag = "pihole:info",
+    responses(
+        (status = 200, description = "Query database info", body = DatabaseInfoResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_database_info(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<DatabaseInfoResponse>, PiholeApiError> {

--- a/crates/api-pihole/src/handlers/lists.rs
+++ b/crates/api-pihole/src/handlers/lists.rs
@@ -53,6 +53,15 @@ fn whitelist_to_entry(
 }
 
 /// Pi-hole v6 GET /api/lists — list all adlists.
+#[utoipa::path(
+    get,
+    path = "/lists",
+    tag = "pihole:lists",
+    responses(
+        (status = 200, description = "All adlists (blocklists and whitelists)", body = ListsResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn list_all(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<ListsResponse>, PiholeApiError> {
@@ -73,6 +82,16 @@ pub async fn list_all(
 }
 
 /// Pi-hole v6 POST /api/lists — create adlist.
+#[utoipa::path(
+    post,
+    path = "/lists",
+    tag = "pihole:lists",
+    request_body = CreateListRequest,
+    responses(
+        (status = 201, description = "List created", body = PiholeListEntry)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn create_list(
     State(state): State<PiholeAppState>,
     Json(body): Json<CreateListRequest>,
@@ -111,6 +130,19 @@ pub async fn create_list(
 }
 
 /// Pi-hole v6 GET /api/lists/:id — get by id.
+#[utoipa::path(
+    get,
+    path = "/lists/{id}",
+    tag = "pihole:lists",
+    params(
+        ("id" = i64, Path, description = "List ID")
+    ),
+    responses(
+        (status = 200, description = "List entry", body = PiholeListEntry),
+        (status = 404, description = "List not found")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_by_id(
     State(state): State<PiholeAppState>,
     Path(id): Path<i64>,
@@ -127,6 +159,20 @@ pub async fn get_by_id(
 }
 
 /// Pi-hole v6 PUT /api/lists/:id — update adlist.
+#[utoipa::path(
+    put,
+    path = "/lists/{id}",
+    tag = "pihole:lists",
+    params(
+        ("id" = i64, Path, description = "List ID")
+    ),
+    request_body = CreateListRequest,
+    responses(
+        (status = 200, description = "List updated", body = PiholeListEntry),
+        (status = 404, description = "List not found")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn update_list(
     State(state): State<PiholeAppState>,
     Path(id): Path<i64>,
@@ -173,6 +219,19 @@ pub async fn update_list(
 }
 
 /// Pi-hole v6 DELETE /api/lists/:id — delete adlist.
+#[utoipa::path(
+    delete,
+    path = "/lists/{id}",
+    tag = "pihole:lists",
+    params(
+        ("id" = i64, Path, description = "List ID")
+    ),
+    responses(
+        (status = 204, description = "List deleted"),
+        (status = 404, description = "List not found")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn delete_list(
     State(state): State<PiholeAppState>,
     Path(id): Path<i64>,
@@ -203,6 +262,16 @@ pub async fn delete_list(
 }
 
 /// Pi-hole v6 POST /api/lists:batchDelete — batch delete.
+#[utoipa::path(
+    post,
+    path = "/lists:batchDelete",
+    tag = "pihole:lists",
+    request_body = BatchDeleteRequest,
+    responses(
+        (status = 204, description = "Batch delete completed")
+    ),
+    security(("session_id" = []))
+)]
 pub async fn batch_delete(
     State(state): State<PiholeAppState>,
     Json(body): Json<BatchDeleteRequest>,

--- a/crates/api-pihole/src/handlers/queries.rs
+++ b/crates/api-pihole/src/handlers/queries.rs
@@ -57,6 +57,24 @@ fn pihole_status_to_category(status: &str) -> Option<&'static str> {
 }
 
 /// Pi-hole v6 GET /api/queries
+#[utoipa::path(
+    get,
+    path = "/queries",
+    tag = "pihole:queries",
+    params(
+        ("length" = Option<u32>, Query, description = "Page size"),
+        ("start" = Option<u32>, Query, description = "Offset"),
+        ("cursor" = Option<i64>, Query, description = "Cursor for pagination"),
+        ("domain" = Option<String>, Query, description = "Filter by domain"),
+        ("client" = Option<String>, Query, description = "Filter by client IP"),
+        ("status" = Option<String>, Query, description = "Filter by Pi-hole status"),
+        ("draw" = Option<u32>, Query, description = "DataTables draw counter")
+    ),
+    responses(
+        (status = 200, description = "Paginated query log", body = QueriesResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_queries(
     State(state): State<PiholeAppState>,
     Query(params): Query<QueryParams>,
@@ -138,6 +156,15 @@ pub async fn get_queries(
 ///
 // TODO: extract aggregation into a dedicated use case (GetQuerySuggestionsUseCase)
 // with DISTINCT SQL queries instead of in-memory dedup
+#[utoipa::path(
+    get,
+    path = "/queries/suggestions",
+    tag = "pihole:queries",
+    responses(
+        (status = 200, description = "Filter suggestions for queries UI", body = SuggestionsResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_suggestions(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<SuggestionsResponse>, PiholeApiError> {

--- a/crates/api-pihole/src/handlers/search.rs
+++ b/crates/api-pihole/src/handlers/search.rs
@@ -18,6 +18,19 @@ pub struct SearchParams {
 /// Pi-hole v6 GET /api/search/:domain
 ///
 /// Checks whether a domain would be blocked by the current filter configuration.
+#[utoipa::path(
+    get,
+    path = "/search/{domain}",
+    tag = "pihole:search",
+    params(
+        ("domain" = String, Path, description = "Domain to evaluate against the filter index"),
+        ("client" = Option<String>, Query, description = "Client IP context for group resolution")
+    ),
+    responses(
+        (status = 200, description = "Filter evaluation result", body = SearchResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn search_domain(
     State(state): State<PiholeAppState>,
     Path(domain): Path<String>,

--- a/crates/api-pihole/src/handlers/stats.rs
+++ b/crates/api-pihole/src/handlers/stats.rs
@@ -43,6 +43,20 @@ impl DatabaseQueryParams {
 }
 
 /// Pi-hole v6 GET /api/stats/summary
+#[utoipa::path(
+    get,
+    path = "/stats/summary",
+    tag = "pihole:stats",
+    params(
+        ("from" = Option<f32>, Query, description = "Period in hours (default 24)"),
+        ("limit" = Option<u32>, Query, description = "Max items returned"),
+        ("blocked" = Option<bool>, Query, description = "Filter only blocked")
+    ),
+    responses(
+        (status = 200, description = "Summary statistics", body = SummaryResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_summary(
     State(state): State<PiholeAppState>,
     Query(params): Query<DatabaseQueryParams>,
@@ -106,6 +120,18 @@ pub async fn get_summary(
 ///
 /// Glance pihole-v6 expects exactly 145 buckets of 10-minute intervals (24h + 1).
 /// Buckets with no queries are padded with zeros to guarantee the exact count.
+#[utoipa::path(
+    get,
+    path = "/stats/history",
+    tag = "pihole:stats",
+    params(
+        ("from" = Option<f32>, Query, description = "Period in hours (default 25)")
+    ),
+    responses(
+        (status = 200, description = "Time-series history of queries", body = HistoryResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_history(
     State(state): State<PiholeAppState>,
     Query(params): Query<DatabaseQueryParams>,
@@ -160,6 +186,19 @@ pub async fn get_history(
 }
 
 /// Pi-hole v6 GET /api/stats/top_blocked
+#[utoipa::path(
+    get,
+    path = "/stats/top_blocked",
+    tag = "pihole:stats",
+    params(
+        ("from" = Option<f32>, Query, description = "Period in hours"),
+        ("limit" = Option<u32>, Query, description = "Max items")
+    ),
+    responses(
+        (status = 200, description = "Top blocked domains", body = TopDomainsResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_top_blocked(
     State(state): State<PiholeAppState>,
     Query(params): Query<DatabaseQueryParams>,
@@ -186,6 +225,19 @@ pub async fn get_top_blocked(
 }
 
 /// Pi-hole v6 GET /api/stats/top_clients
+#[utoipa::path(
+    get,
+    path = "/stats/top_clients",
+    tag = "pihole:stats",
+    params(
+        ("from" = Option<f32>, Query, description = "Period in hours"),
+        ("limit" = Option<u32>, Query, description = "Max items")
+    ),
+    responses(
+        (status = 200, description = "Top clients", body = TopClientsResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_top_clients(
     State(state): State<PiholeAppState>,
     Query(params): Query<DatabaseQueryParams>,
@@ -216,6 +268,18 @@ pub async fn get_top_clients(
 }
 
 /// Pi-hole v6 GET /api/stats/query_types
+#[utoipa::path(
+    get,
+    path = "/stats/query_types",
+    tag = "pihole:stats",
+    params(
+        ("from" = Option<f32>, Query, description = "Period in hours")
+    ),
+    responses(
+        (status = 200, description = "Query type distribution", body = QueryTypesResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_query_types(
     State(state): State<PiholeAppState>,
     Query(params): Query<DatabaseQueryParams>,
@@ -244,6 +308,20 @@ pub async fn get_query_types(
 /// Pi-hole v6 GET /api/stats/top_domains
 ///
 /// Returns top allowed domains by default, or top blocked domains when `?blocked=true`.
+#[utoipa::path(
+    get,
+    path = "/stats/top_domains",
+    tag = "pihole:stats",
+    params(
+        ("from" = Option<f32>, Query, description = "Period in hours"),
+        ("limit" = Option<u32>, Query, description = "Max items"),
+        ("blocked" = Option<bool>, Query, description = "Return top blocked instead of top allowed")
+    ),
+    responses(
+        (status = 200, description = "Top domains", body = TopDomainsResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_top_domains(
     State(state): State<PiholeAppState>,
     Query(params): Query<DatabaseQueryParams>,
@@ -288,6 +366,18 @@ pub async fn get_top_domains(
 ///
 /// Returns upstream DNS server usage statistics.
 /// Upstream keys are identified by exclusion of known internal source names.
+#[utoipa::path(
+    get,
+    path = "/stats/upstreams",
+    tag = "pihole:stats",
+    params(
+        ("from" = Option<f32>, Query, description = "Period in hours")
+    ),
+    responses(
+        (status = 200, description = "Upstream usage statistics", body = UpstreamsResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_upstreams(
     State(state): State<PiholeAppState>,
     Query(params): Query<DatabaseQueryParams>,
@@ -315,6 +405,15 @@ pub async fn get_upstreams(
 /// Returns the most recently blocked domain.
 // TODO: replace with a dedicated use case (GetMostRecentBlockedUseCase)
 // using `WHERE blocked = 1 ORDER BY timestamp DESC LIMIT 1` in the repository
+#[utoipa::path(
+    get,
+    path = "/stats/recent_blocked",
+    tag = "pihole:stats",
+    responses(
+        (status = 200, description = "Most recently blocked domain", body = RecentBlockedResponse)
+    ),
+    security(("session_id" = []))
+)]
 pub async fn get_recent_blocked(
     State(state): State<PiholeAppState>,
 ) -> Result<Json<RecentBlockedResponse>, PiholeApiError> {

--- a/crates/api-pihole/src/lib.rs
+++ b/crates/api-pihole/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod dto;
 pub mod errors;
 pub mod handlers;
+pub mod openapi;
 pub mod routes;
 pub mod state;
 mod timestamp;
 
-pub use routes::create_pihole_routes;
+pub use openapi::PiholeApiDoc;
+pub use routes::{create_pihole_router_with_openapi, create_pihole_routes};
 pub use state::PiholeAppState;

--- a/crates/api-pihole/src/openapi.rs
+++ b/crates/api-pihole/src/openapi.rs
@@ -1,0 +1,186 @@
+//! OpenAPI 3.x specification for the Pi-hole v6 compatible API.
+//!
+//! Best-effort implementation aligned with the public Pi-hole v6 surface
+//! documented at <https://pi-hole.net/docs/api>. Divergences are tracked
+//! in the project documentation.
+
+use utoipa::openapi::security::{ApiKey, ApiKeyValue, SecurityScheme};
+use utoipa::{Modify, OpenApi};
+
+use crate::dto;
+
+/// OpenAPI document describing every Pi-hole compatible route.
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Pi-hole v6 Compatible API",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "Pi-hole v6 compatibility layer. Best-effort implementation aligned with pi-hole.net/docs/api — see project docs for divergences."
+    ),
+    modifiers(&SecurityAddon),
+    tags(
+        (name = "pihole:auth", description = "Session authentication"),
+        (name = "pihole:stats", description = "Aggregated statistics"),
+        (name = "pihole:queries", description = "Query log access"),
+        (name = "pihole:dns", description = "DNS blocking control"),
+        (name = "pihole:domains", description = "Managed and regex domains"),
+        (name = "pihole:lists", description = "Blocklist and allowlist sources"),
+        (name = "pihole:groups", description = "Client groups"),
+        (name = "pihole:clients", description = "Client management"),
+        (name = "pihole:info", description = "Runtime, host and database info"),
+        (name = "pihole:action", description = "Administrative actions"),
+        (name = "pihole:history", description = "Historic time-series data"),
+        (name = "pihole:search", description = "Filter evaluation")
+    ),
+    paths(
+        crate::handlers::auth::get_session,
+        crate::handlers::auth::login,
+        crate::handlers::auth::logout,
+        crate::handlers::stats::get_summary,
+        crate::handlers::stats::get_history,
+        crate::handlers::stats::get_top_blocked,
+        crate::handlers::stats::get_top_clients,
+        crate::handlers::stats::get_query_types,
+        crate::handlers::stats::get_top_domains,
+        crate::handlers::stats::get_upstreams,
+        crate::handlers::stats::get_recent_blocked,
+        crate::handlers::history::get_history_clients,
+        crate::handlers::queries::get_queries,
+        crate::handlers::queries::get_suggestions,
+        crate::handlers::search::search_domain,
+        crate::handlers::dns::get_blocking,
+        crate::handlers::dns::set_blocking,
+        crate::handlers::domains::list_all,
+        crate::handlers::domains::list_by_type,
+        crate::handlers::domains::list_by_type_kind,
+        crate::handlers::domains::create_domain,
+        crate::handlers::domains::update_domain,
+        crate::handlers::domains::delete_domain,
+        crate::handlers::domains::batch_delete,
+        crate::handlers::lists::list_all,
+        crate::handlers::lists::create_list,
+        crate::handlers::lists::get_by_id,
+        crate::handlers::lists::update_list,
+        crate::handlers::lists::delete_list,
+        crate::handlers::lists::batch_delete,
+        crate::handlers::groups::list_all,
+        crate::handlers::groups::create_group,
+        crate::handlers::groups::get_by_name,
+        crate::handlers::groups::update_group,
+        crate::handlers::groups::delete_group,
+        crate::handlers::groups::batch_delete,
+        crate::handlers::clients::list_all,
+        crate::handlers::clients::create_client,
+        crate::handlers::clients::update_client,
+        crate::handlers::clients::delete_client,
+        crate::handlers::clients::suggestions,
+        crate::handlers::clients::batch_delete,
+        crate::handlers::info::get_version,
+        crate::handlers::info::get_ftl_info,
+        crate::handlers::info::get_system_info,
+        crate::handlers::info::get_host_info,
+        crate::handlers::info::get_database_info,
+        crate::handlers::action::gravity,
+        crate::handlers::action::restartdns,
+        crate::handlers::action::flush_logs,
+    ),
+    components(schemas(
+        dto::action::ActionResponse,
+        dto::auth::LoginRequest,
+        dto::auth::SessionInfo,
+        dto::auth::AuthResponse,
+        dto::clients::PiholeClientEntry,
+        dto::clients::CreateClientRequest,
+        dto::clients::UpdateClientRequest,
+        dto::clients::ClientsResponse,
+        dto::clients::ClientSuggestionsResponse,
+        dto::dns::BlockingStatusResponse,
+        dto::dns::SetBlockingRequest,
+        dto::domains::PiholeDomainEntry,
+        dto::domains::CreateDomainRequest,
+        dto::domains::BatchDeleteRequest,
+        dto::domains::DomainsListResponse,
+        dto::groups::PiholeGroupEntry,
+        dto::groups::CreateGroupRequest,
+        dto::groups::UpdateGroupRequest,
+        dto::groups::GroupsResponse,
+        dto::history::HistoryClientsResponse,
+        dto::history::ClientHistoryEntry,
+        dto::info::VersionResponse,
+        dto::info::FtlInfoResponse,
+        dto::info::FtlDatabaseInfo,
+        dto::info::SystemInfoResponse,
+        dto::info::MemoryInfo,
+        dto::info::DiskInfo,
+        dto::info::HostInfoResponse,
+        dto::info::DatabaseInfoResponse,
+        dto::lists::PiholeListEntry,
+        dto::lists::CreateListRequest,
+        dto::lists::ListsResponse,
+        dto::queries::QueriesResponse,
+        dto::queries::PiholeClientRef,
+        dto::queries::PiholeReply,
+        dto::queries::PiholeEde,
+        dto::queries::PiholeQueryEntry,
+        dto::queries::SuggestionsResponse,
+        dto::search::SearchResponse,
+        dto::search::SearchResult,
+        dto::stats::SummaryResponse,
+        dto::stats::QuerySummary,
+        dto::stats::ClientSummary,
+        dto::stats::GravitySummary,
+        dto::stats::HistoryResponse,
+        dto::stats::HistoryBucket,
+        dto::stats::TopDomainsResponse,
+        dto::stats::TopDomainEntry,
+        dto::stats::TopClientsResponse,
+        dto::stats::TopClientEntry,
+        dto::stats::QueryTypesResponse,
+        dto::stats::RecentBlockedResponse,
+        dto::upstreams::UpstreamsResponse,
+    ))
+)]
+pub struct PiholeApiDoc;
+
+/// Adds the Pi-hole v6 session header (`X-FTL-SID`) as a reusable security scheme.
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .get_or_insert_with(utoipa::openapi::Components::new);
+        components.add_security_scheme(
+            "session_id",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("X-FTL-SID"))),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openapi_spec_serializes_with_session_security() {
+        let spec = PiholeApiDoc::openapi();
+        let json = serde_json::to_value(&spec).expect("spec must serialize");
+
+        assert_eq!(json["info"]["title"], "Pi-hole v6 Compatible API");
+        assert_eq!(json["info"]["version"], env!("CARGO_PKG_VERSION"));
+        assert!(json["components"]["securitySchemes"]["session_id"].is_object());
+    }
+
+    #[test]
+    fn openapi_spec_contains_critical_paths() {
+        let spec = PiholeApiDoc::openapi();
+        let paths: Vec<&str> = spec.paths.paths.keys().map(|s| s.as_str()).collect();
+
+        for required in ["/auth", "/stats/summary", "/dns/blocking"] {
+            assert!(
+                paths.contains(&required),
+                "missing path {required}; available: {paths:?}"
+            );
+        }
+    }
+}

--- a/crates/api-pihole/src/routes.rs
+++ b/crates/api-pihole/src/routes.rs
@@ -1,134 +1,134 @@
-use axum::{
-    routing::{get, post, put},
-    Router,
-};
+use axum::Router;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 
-use crate::{handlers, state::PiholeAppState};
+use crate::{handlers, openapi::PiholeApiDoc, state::PiholeAppState};
 
 /// Builds the Axum router for all Pi-hole v6 compatible endpoints.
 ///
 /// Mount this at `/api` when `pihole_compat = true` so third-party Pi-hole
 /// dashboards, plugins, and automations work without modification.
 pub fn create_pihole_routes(state: PiholeAppState) -> Router {
-    Router::new()
+    create_pihole_router_with_openapi(state).0
+}
+
+/// Builds the Axum router together with its OpenAPI document.
+///
+/// Returns a tuple `(Router, OpenApi)` so the caller can mount the router and
+/// expose the spec under the same `nest` prefix (e.g. `/openapi.json` + `/docs`).
+pub fn create_pihole_router_with_openapi(
+    state: PiholeAppState,
+) -> (Router, utoipa::openapi::OpenApi) {
+    use utoipa::OpenApi;
+
+    let (router, api) = OpenApiRouter::with_openapi(PiholeApiDoc::openapi())
         // Auth
-        .route(
-            "/auth",
-            get(handlers::auth::get_session)
-                .post(handlers::auth::login)
-                .delete(handlers::auth::logout),
-        )
+        .routes(routes!(
+            handlers::auth::get_session,
+            handlers::auth::login,
+            handlers::auth::logout
+        ))
         // Stats — Phase 1
-        .route("/stats/summary", get(handlers::stats::get_summary))
-        .route("/stats/history", get(handlers::stats::get_history))
-        .route("/stats/top_blocked", get(handlers::stats::get_top_blocked))
-        .route("/stats/top_clients", get(handlers::stats::get_top_clients))
-        .route("/stats/query_types", get(handlers::stats::get_query_types))
-        .route("/stats/top_domains", get(handlers::stats::get_top_domains))
-        .route("/stats/upstreams", get(handlers::stats::get_upstreams))
+        .routes(routes!(handlers::stats::get_summary))
+        .routes(routes!(handlers::stats::get_history))
+        .routes(routes!(handlers::stats::get_top_blocked))
+        .routes(routes!(handlers::stats::get_top_clients))
+        .routes(routes!(handlers::stats::get_query_types))
+        .routes(routes!(handlers::stats::get_top_domains))
+        .routes(routes!(handlers::stats::get_upstreams))
+        .routes(routes!(handlers::stats::get_recent_blocked))
+        // Stats — database aliases (same handlers, different paths — keep but
+        // outside the spec to avoid duplicate operation ids).
         .route(
-            "/stats/recent_blocked",
-            get(handlers::stats::get_recent_blocked),
+            "/stats/database/summary",
+            axum::routing::get(handlers::stats::get_summary),
         )
-        // Stats — database aliases (same handlers, query params for period)
-        .route("/stats/database/summary", get(handlers::stats::get_summary))
         .route(
             "/stats/database/top_domains",
-            get(handlers::stats::get_top_domains),
+            axum::routing::get(handlers::stats::get_top_domains),
         )
         .route(
             "/stats/database/top_clients",
-            get(handlers::stats::get_top_clients),
+            axum::routing::get(handlers::stats::get_top_clients),
         )
         .route(
             "/stats/database/upstreams",
-            get(handlers::stats::get_upstreams),
+            axum::routing::get(handlers::stats::get_upstreams),
         )
         .route(
             "/stats/database/query_types",
-            get(handlers::stats::get_query_types),
+            axum::routing::get(handlers::stats::get_query_types),
         )
         // History — Phase 1
-        .route("/history", get(handlers::stats::get_history))
-        .route(
-            "/history/clients",
-            get(handlers::history::get_history_clients),
-        )
+        .route("/history", axum::routing::get(handlers::stats::get_history))
+        .routes(routes!(handlers::history::get_history_clients))
         // Queries — Phase 2
-        .route("/queries", get(handlers::queries::get_queries))
-        .route(
-            "/queries/suggestions",
-            get(handlers::queries::get_suggestions),
-        )
+        .routes(routes!(handlers::queries::get_queries))
+        .routes(routes!(handlers::queries::get_suggestions))
         // Search — Phase 2
-        .route("/search/{domain}", get(handlers::search::search_domain))
+        .routes(routes!(handlers::search::search_domain))
         // DNS blocking — Phase 3
-        .route(
-            "/dns/blocking",
-            get(handlers::dns::get_blocking).post(handlers::dns::set_blocking),
-        )
+        .routes(routes!(
+            handlers::dns::get_blocking,
+            handlers::dns::set_blocking
+        ))
         // Domains — Phase 4
-        .route("/domains", get(handlers::domains::list_all))
-        .route("/domains/{type}", get(handlers::domains::list_by_type))
-        .route(
-            "/domains/{type}/{kind}",
-            get(handlers::domains::list_by_type_kind).post(handlers::domains::create_domain),
-        )
-        .route(
-            "/domains/{type}/{kind}/{domain}",
-            put(handlers::domains::update_domain).delete(handlers::domains::delete_domain),
-        )
-        .route(
-            "/domains:batchDelete",
-            post(handlers::domains::batch_delete),
-        )
+        .routes(routes!(handlers::domains::list_all))
+        .routes(routes!(handlers::domains::list_by_type))
+        .routes(routes!(
+            handlers::domains::list_by_type_kind,
+            handlers::domains::create_domain
+        ))
+        .routes(routes!(
+            handlers::domains::update_domain,
+            handlers::domains::delete_domain
+        ))
+        .routes(routes!(handlers::domains::batch_delete))
         // Lists — Phase 5
-        .route(
-            "/lists",
-            get(handlers::lists::list_all).post(handlers::lists::create_list),
-        )
-        .route(
-            "/lists/{id}",
-            get(handlers::lists::get_by_id)
-                .put(handlers::lists::update_list)
-                .delete(handlers::lists::delete_list),
-        )
-        .route("/lists:batchDelete", post(handlers::lists::batch_delete))
+        .routes(routes!(
+            handlers::lists::list_all,
+            handlers::lists::create_list
+        ))
+        .routes(routes!(
+            handlers::lists::get_by_id,
+            handlers::lists::update_list,
+            handlers::lists::delete_list
+        ))
+        .routes(routes!(handlers::lists::batch_delete))
         // Groups — Phase 6
-        .route(
-            "/groups",
-            get(handlers::groups::list_all).post(handlers::groups::create_group),
-        )
-        .route(
-            "/groups/{name}",
-            get(handlers::groups::get_by_name)
-                .put(handlers::groups::update_group)
-                .delete(handlers::groups::delete_group),
-        )
-        .route("/groups:batchDelete", post(handlers::groups::batch_delete))
+        .routes(routes!(
+            handlers::groups::list_all,
+            handlers::groups::create_group
+        ))
+        .routes(routes!(
+            handlers::groups::get_by_name,
+            handlers::groups::update_group,
+            handlers::groups::delete_group
+        ))
+        .routes(routes!(handlers::groups::batch_delete))
         // Clients — Phase 6
-        .route(
-            "/clients",
-            get(handlers::clients::list_all).post(handlers::clients::create_client),
-        )
-        .route("/clients/_suggestions", get(handlers::clients::suggestions))
-        .route(
-            "/clients/{client}",
-            put(handlers::clients::update_client).delete(handlers::clients::delete_client),
-        )
-        .route(
-            "/clients:batchDelete",
-            post(handlers::clients::batch_delete),
-        )
+        .routes(routes!(
+            handlers::clients::list_all,
+            handlers::clients::create_client
+        ))
+        .routes(routes!(handlers::clients::suggestions))
+        .routes(routes!(
+            handlers::clients::update_client,
+            handlers::clients::delete_client
+        ))
+        .routes(routes!(handlers::clients::batch_delete))
         // Info — Phase 7
-        .route("/info/version", get(handlers::info::get_version))
-        .route("/info/ftl", get(handlers::info::get_ftl_info))
-        .route("/info/system", get(handlers::info::get_system_info))
-        .route("/info/host", get(handlers::info::get_host_info))
-        .route("/info/database", get(handlers::info::get_database_info))
+        .routes(routes!(handlers::info::get_version))
+        .routes(routes!(handlers::info::get_ftl_info))
+        .routes(routes!(handlers::info::get_system_info))
+        .routes(routes!(handlers::info::get_host_info))
+        .routes(routes!(handlers::info::get_database_info))
         // Actions — Phase 7
-        .route("/action/gravity", post(handlers::action::gravity))
-        .route("/action/restartdns", post(handlers::action::restartdns))
-        .route("/action/flush/logs", post(handlers::action::flush_logs))
+        .routes(routes!(handlers::action::gravity))
+        .routes(routes!(handlers::action::restartdns))
+        .routes(routes!(handlers::action::flush_logs))
         .with_state(state)
+        .split_for_parts();
+
+    (router, api)
 }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -17,6 +17,8 @@ chrono = "0.4"
 hostname = "0.4"
 ring.workspace = true
 subtle = "2"
+utoipa.workspace = true
+utoipa-axum.workspace = true
 
 [dev-dependencies]
 ferrous-dns-infrastructure.workspace = true

--- a/crates/api/src/dto/api_token.rs
+++ b/crates/api/src/dto/api_token.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateApiTokenRequest {
     pub name: String,
     /// Optional custom token value (e.g. import an existing Pi-hole API key).
@@ -8,7 +9,7 @@ pub struct CreateApiTokenRequest {
     pub token: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateApiTokenRequest {
     pub name: String,
     /// Optional new token value. When provided, replaces the existing key.
@@ -16,7 +17,7 @@ pub struct UpdateApiTokenRequest {
     pub token: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct CreatedApiTokenResponse {
     pub id: i64,
     pub name: String,
@@ -25,7 +26,7 @@ pub struct CreatedApiTokenResponse {
     pub created_at: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ApiTokenResponse {
     pub id: i64,
     pub name: String,

--- a/crates/api/src/dto/auth.rs
+++ b/crates/api/src/dto/auth.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct LoginRequest {
     pub username: String,
     pub password: String,
@@ -8,31 +9,31 @@ pub struct LoginRequest {
     pub remember_me: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct LoginResponse {
     pub username: String,
     pub role: String,
     pub expires_at: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct SetupPasswordRequest {
     pub password: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct ChangePasswordRequest {
     pub current_password: String,
     pub new_password: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct AuthStatusResponse {
     pub enabled: bool,
     pub setup_required: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SessionResponse {
     pub id: String,
     pub username: String,

--- a/crates/api/src/dto/backup.rs
+++ b/crates/api/src/dto/backup.rs
@@ -1,7 +1,8 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
 /// HTTP response returned after a successful import operation.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ImportSummaryResponse {
     pub success: bool,
     pub summary: ImportSummaryDto,
@@ -9,7 +10,7 @@ pub struct ImportSummaryResponse {
 }
 
 /// Serializable summary of what was created or skipped during import.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ImportSummaryDto {
     pub config_updated: bool,
     pub groups_imported: usize,

--- a/crates/api/src/dto/block_filter.rs
+++ b/crates/api/src/dto/block_filter.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct BlockFilterStatsResponse {
     pub total_blocked_domains: usize,
 }

--- a/crates/api/src/dto/blocked_service.rs
+++ b/crates/api/src/dto/blocked_service.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_domain::{BlockedService, ServiceDefinition};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ServiceDefinitionResponse {
     pub id: String,
     pub name: String,
@@ -26,7 +27,7 @@ impl ServiceDefinitionResponse {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct BlockedServiceResponse {
     pub id: i64,
     pub service_id: String,
@@ -45,7 +46,7 @@ impl BlockedServiceResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct BlockServiceRequest {
     pub service_id: String,
     pub group_id: i64,

--- a/crates/api/src/dto/blocklist.rs
+++ b/crates/api/src/dto/blocklist.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct BlocklistQuery {
     #[serde(default = "default_limit")]
     pub limit: u32,
@@ -12,7 +13,7 @@ fn default_limit() -> u32 {
     100
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct PaginatedBlocklist {
     pub data: Vec<BlocklistResponse>,
     pub total: u64,
@@ -20,7 +21,7 @@ pub struct PaginatedBlocklist {
     pub offset: u32,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct BlocklistResponse {
     pub domain: String,
     pub added_at: String,

--- a/crates/api/src/dto/blocklist_source.rs
+++ b/crates/api/src/dto/blocklist_source.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_domain::BlocklistSource;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct BlocklistSourceResponse {
     pub id: i64,
     pub name: String,
@@ -28,7 +29,7 @@ impl BlocklistSourceResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateBlocklistSourceRequest {
     pub name: String,
     pub url: Option<String>,
@@ -55,7 +56,7 @@ impl CreateBlocklistSourceRequest {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateBlocklistSourceRequest {
     pub name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_optional_nullable_string")]

--- a/crates/api/src/dto/cache.rs
+++ b/crates/api/src/dto/cache.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct CacheStatsQuery {
     #[serde(default = "default_period")]
     pub period: String,
@@ -10,7 +11,7 @@ fn default_period() -> String {
     "24h".to_string()
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct CacheStatsResponse {
     pub total_entries: usize,
     pub total_hits: u64,
@@ -20,7 +21,7 @@ pub struct CacheStatsResponse {
     pub refresh_rate: f64,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct CacheMetricsResponse {
     pub total_entries: usize,
     pub hits: u64,

--- a/crates/api/src/dto/client.rs
+++ b/crates/api/src/dto/client.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct ClientResponse {
     pub id: i64,
     pub ip_address: String,
@@ -12,7 +13,7 @@ pub struct ClientResponse {
     pub group_id: Option<i64>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct ClientStatsResponse {
     pub total_clients: u64,
     pub active_24h: u64,
@@ -21,7 +22,7 @@ pub struct ClientStatsResponse {
     pub with_hostname: u64,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct ClientsQuery {
     #[serde(default = "default_limit")]
     pub limit: u32,
@@ -35,7 +36,7 @@ fn default_limit() -> u32 {
     100
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema)]
 pub struct UpdateClientRequest {
     pub hostname: Option<String>,
     pub group_id: Option<i64>,

--- a/crates/api/src/dto/client_subnet.rs
+++ b/crates/api/src/dto/client_subnet.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_domain::ClientSubnet;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ClientSubnetResponse {
     pub id: i64,
     pub subnet_cidr: String,
@@ -24,14 +25,14 @@ impl ClientSubnetResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateClientSubnetRequest {
     pub subnet_cidr: String,
     pub group_id: i64,
     pub comment: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateManualClientRequest {
     pub ip_address: String,
     pub group_id: Option<i64>,

--- a/crates/api/src/dto/config.rs
+++ b/crates/api/src/dto/config.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct ConfigResponse {
     pub server: ServerConfigResponse,
     pub dns: DnsConfigResponse,
@@ -12,7 +13,7 @@ pub struct ConfigResponse {
     pub writable: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct AuthConfigResponse {
     pub enabled: bool,
     pub session_ttl_hours: u32,
@@ -21,7 +22,7 @@ pub struct AuthConfigResponse {
     pub login_rate_limit_window_secs: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct ServerConfigResponse {
     pub dns_port: u16,
     pub web_port: u16,
@@ -30,14 +31,14 @@ pub struct ServerConfigResponse {
     pub web_tls: WebTlsConfigResponse,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct WebTlsConfigResponse {
     pub enabled: bool,
     pub tls_cert_path: String,
     pub tls_key_path: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct DnsConfigResponse {
     pub upstream_servers: Vec<String>,
     pub pools: Vec<UpstreamPoolResponse>,
@@ -65,7 +66,7 @@ pub struct DnsConfigResponse {
     pub rate_limit: RateLimitConfigResponse,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct RateLimitConfigResponse {
     pub enabled: bool,
     pub queries_per_second: u32,
@@ -81,7 +82,7 @@ pub struct RateLimitConfigResponse {
     pub dot_max_connections_per_ip: u32,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct UpstreamPoolResponse {
     pub name: String,
     pub strategy: String,
@@ -89,7 +90,7 @@ pub struct UpstreamPoolResponse {
     pub servers: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct HealthCheckResponse {
     pub enabled: bool,
     pub interval_seconds: u64,
@@ -98,25 +99,25 @@ pub struct HealthCheckResponse {
     pub success_threshold: u8,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct BlockingConfigResponse {
     pub enabled: bool,
     pub custom_blocked: Vec<String>,
     pub whitelist: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct LoggingConfigResponse {
     pub level: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct DatabaseConfigResponse {
     pub path: String,
     pub log_queries: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema)]
 pub struct UpdateConfigRequest {
     pub server: Option<ServerConfigUpdate>,
     pub dns: Option<DnsConfigUpdate>,
@@ -124,7 +125,7 @@ pub struct UpdateConfigRequest {
     pub auth: Option<AuthConfigUpdate>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema)]
 pub struct AuthConfigUpdate {
     pub enabled: Option<bool>,
     pub session_ttl_hours: Option<u32>,
@@ -133,20 +134,20 @@ pub struct AuthConfigUpdate {
     pub login_rate_limit_window_secs: Option<u64>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema)]
 pub struct ServerConfigUpdate {
     pub pihole_compat: Option<bool>,
     pub web_tls: Option<WebTlsConfigUpdate>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema)]
 pub struct WebTlsConfigUpdate {
     pub enabled: Option<bool>,
     pub tls_cert_path: Option<String>,
     pub tls_key_path: Option<String>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema)]
 pub struct PoolUpdate {
     pub name: String,
     pub strategy: String,
@@ -154,7 +155,7 @@ pub struct PoolUpdate {
     pub servers: Vec<String>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema)]
 pub struct DnsConfigUpdate {
     pub pools: Option<Vec<PoolUpdate>>,
     pub upstream_servers: Option<Vec<String>>,
@@ -179,7 +180,7 @@ pub struct DnsConfigUpdate {
     pub rate_limit: Option<RateLimitConfigUpdate>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema)]
 pub struct RateLimitConfigUpdate {
     pub enabled: Option<bool>,
     pub queries_per_second: Option<u32>,
@@ -195,14 +196,14 @@ pub struct RateLimitConfigUpdate {
     pub dot_max_connections_per_ip: Option<u32>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema)]
 pub struct BlockingConfigUpdate {
     pub enabled: Option<bool>,
     pub custom_blocked: Option<Vec<String>>,
     pub whitelist: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct SettingsDto {
     pub never_forward_non_fqdn: bool,
 
@@ -215,7 +216,7 @@ pub struct SettingsDto {
     pub local_dns_server: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct SettingsUpdateResponse {
     pub success: bool,
     pub message: String,

--- a/crates/api/src/dto/custom_service.rs
+++ b/crates/api/src/dto/custom_service.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_domain::CustomService;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct CustomServiceResponse {
     pub id: i64,
     pub service_id: String,
@@ -26,14 +27,14 @@ impl CustomServiceResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateCustomServiceRequest {
     pub name: String,
     pub domains: Vec<String>,
     pub category_name: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateCustomServiceRequest {
     pub name: Option<String>,
     pub category_name: Option<String>,

--- a/crates/api/src/dto/dashboard.rs
+++ b/crates/api/src/dto/dashboard.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
 use super::{CacheStatsResponse, QueryRateResponse, StatsResponse, TimelineResponse};
 
@@ -6,7 +7,7 @@ fn default_period() -> String {
     "24h".to_string()
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct DashboardQuery {
     #[serde(default = "default_period")]
     pub period: String,
@@ -14,20 +15,20 @@ pub struct DashboardQuery {
     pub include_timeline: bool,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct TopBlockedDomain {
     pub domain: String,
     pub count: u64,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct TopClient {
     pub ip: String,
     pub hostname: Option<String>,
     pub count: u64,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct DashboardResponse {
     pub stats: StatsResponse,
     pub rate: QueryRateResponse,

--- a/crates/api/src/dto/group.rs
+++ b/crates/api/src/dto/group.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_domain::Group;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GroupResponse {
     pub id: i64,
     pub name: String,
@@ -28,21 +29,21 @@ impl GroupResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateGroupRequest {
     pub name: String,
     pub enabled: Option<bool>,
     pub comment: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateGroupRequest {
     pub name: Option<String>,
     pub enabled: Option<bool>,
     pub comment: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct AssignGroupRequest {
     pub group_id: i64,
 }

--- a/crates/api/src/dto/hostname.rs
+++ b/crates/api/src/dto/hostname.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct HostnameResponse {
     pub hostname: String,
 }

--- a/crates/api/src/dto/local_record.rs
+++ b/crates/api/src/dto/local_record.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct LocalRecordDto {
     pub id: i64,
     pub hostname: String,
@@ -33,7 +34,7 @@ impl LocalRecordDto {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateLocalRecordRequest {
     pub hostname: String,
     pub domain: Option<String>,
@@ -42,7 +43,7 @@ pub struct CreateLocalRecordRequest {
     pub ttl: Option<u32>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateLocalRecordRequest {
     pub hostname: String,
     pub domain: Option<String>,

--- a/crates/api/src/dto/managed_domain.rs
+++ b/crates/api/src/dto/managed_domain.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_domain::ManagedDomain;
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct ManagedDomainQuery {
     #[serde(default = "default_limit")]
     pub limit: u32,
@@ -13,7 +14,7 @@ fn default_limit() -> u32 {
     100
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct PaginatedManagedDomains {
     pub data: Vec<ManagedDomainResponse>,
     pub total: u64,
@@ -21,7 +22,7 @@ pub struct PaginatedManagedDomains {
     pub offset: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ManagedDomainResponse {
     pub id: i64,
     pub name: String,
@@ -52,7 +53,7 @@ impl ManagedDomainResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateManagedDomainRequest {
     pub name: String,
     pub domain: String,
@@ -62,7 +63,7 @@ pub struct CreateManagedDomainRequest {
     pub enabled: Option<bool>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateManagedDomainRequest {
     pub name: Option<String>,
     pub domain: Option<String>,

--- a/crates/api/src/dto/query.rs
+++ b/crates/api/src/dto/query.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct QueryParams {
     #[serde(default = "default_limit")]
     pub limit: u32,
@@ -22,7 +23,7 @@ fn default_limit() -> u32 {
     100
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct PaginatedQueries {
     pub data: Vec<QueryResponse>,
     /// Total records matching the applied filters.
@@ -38,22 +39,31 @@ fn default_period() -> String {
     "24h".to_string()
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct QueryResponse {
     pub timestamp: String,
+    #[schema(value_type = String)]
     pub domain: Arc<str>,
     pub client: String,
+    #[schema(value_type = Option<String>)]
     pub client_hostname: Option<Arc<str>>,
     #[serde(rename = "type")]
+    #[schema(value_type = String)]
     pub record_type: &'static str,
     pub blocked: bool,
     pub response_time_us: Option<u64>,
     pub cache_hit: bool,
     pub cache_refresh: bool,
+    #[schema(value_type = Option<String>)]
     pub dnssec_status: Option<&'static str>,
+    #[schema(value_type = Option<String>)]
     pub upstream_server: Option<Arc<str>>,
+    #[schema(value_type = Option<String>)]
     pub upstream_pool: Option<Arc<str>>,
+    #[schema(value_type = String)]
     pub query_source: &'static str,
+    #[schema(value_type = Option<String>)]
     pub block_source: Option<&'static str>,
+    #[schema(value_type = Option<String>)]
     pub response_status: Option<&'static str>,
 }

--- a/crates/api/src/dto/rate.rs
+++ b/crates/api/src/dto/rate.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct RateQuery {
     #[serde(default = "default_unit")]
     pub unit: String,
@@ -10,7 +11,7 @@ fn default_unit() -> String {
     "second".to_string()
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct QueryRateResponse {
     pub queries: u64,
     pub rate: String,

--- a/crates/api/src/dto/regex_filter.rs
+++ b/crates/api/src/dto/regex_filter.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_domain::RegexFilter;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegexFilterResponse {
     pub id: i64,
     pub name: String,
@@ -30,7 +31,7 @@ impl RegexFilterResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateRegexFilterRequest {
     pub name: String,
     pub pattern: String,
@@ -40,7 +41,7 @@ pub struct CreateRegexFilterRequest {
     pub enabled: Option<bool>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateRegexFilterRequest {
     pub name: Option<String>,
     pub pattern: Option<String>,

--- a/crates/api/src/dto/safe_search.rs
+++ b/crates/api/src/dto/safe_search.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_domain::{SafeSearchConfig, SafeSearchEngine, YouTubeMode};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct SafeSearchConfigResponse {
     pub id: Option<i64>,
     pub group_id: i64,
@@ -26,7 +27,7 @@ impl SafeSearchConfigResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct ToggleSafeSearchRequest {
     pub engine: String,
     pub enabled: bool,

--- a/crates/api/src/dto/schedule.rs
+++ b/crates/api/src/dto/schedule.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_domain::{ScheduleProfile, TimeSlot};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateScheduleProfileRequest {
     pub name: String,
     #[serde(default = "default_timezone")]
@@ -13,14 +14,14 @@ fn default_timezone() -> String {
     "UTC".to_string()
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateScheduleProfileRequest {
     pub name: Option<String>,
     pub timezone: Option<String>,
     pub comment: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct AddTimeSlotRequest {
     pub days: u8,
     pub start_time: String,
@@ -28,12 +29,12 @@ pub struct AddTimeSlotRequest {
     pub action: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct AssignProfileRequest {
     pub profile_id: i64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ScheduleProfileResponse {
     pub id: i64,
     pub name: String,
@@ -56,7 +57,7 @@ impl ScheduleProfileResponse {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct TimeSlotResponse {
     pub id: i64,
     pub profile_id: i64,
@@ -81,14 +82,14 @@ impl TimeSlotResponse {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ScheduleProfileWithSlotsResponse {
     #[serde(flatten)]
     pub profile: ScheduleProfileResponse,
     pub slots: Vec<TimeSlotResponse>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct GroupScheduleResponse {
     pub group_id: i64,
     pub profile_id: i64,

--- a/crates/api/src/dto/stats.rs
+++ b/crates/api/src/dto/stats.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct StatsQuery {
     #[serde(default = "default_period")]
     pub period: String,
@@ -13,7 +14,7 @@ fn default_period() -> String {
 
 pub type QuerySourceStats = HashMap<String, u64>;
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct StatsResponse {
     pub queries_total: u64,
     pub queries_blocked: u64,
@@ -33,13 +34,13 @@ pub struct StatsResponse {
     pub source_stats: QuerySourceStats,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct TypeDistribution {
     pub record_type: String,
     pub percentage: f64,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct TopType {
     pub record_type: String,
     pub count: u64,

--- a/crates/api/src/dto/system_info.rs
+++ b/crates/api/src/dto/system_info.rs
@@ -1,7 +1,8 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
 /// System information snapshot: kernel version, CPU load averages, and memory usage.
-#[derive(Debug, Serialize, Default)]
+#[derive(Debug, Serialize, Default, ToSchema)]
 pub struct SystemInfoResponse {
     pub kernel: String,
     pub load_avg_1m: f32,

--- a/crates/api/src/dto/timeline.rs
+++ b/crates/api/src/dto/timeline.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_application::ports;
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct TimelineBucket {
     pub timestamp: String,
     pub total: u64,
@@ -22,7 +23,7 @@ impl From<ports::TimelineBucket> for TimelineBucket {
     }
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct TimelineResponse {
     pub buckets: Vec<TimelineBucket>,
     pub period: String,
@@ -30,7 +31,7 @@ pub struct TimelineResponse {
     pub total_buckets: usize,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct TimelineQuery {
     #[serde(default = "default_period")]
     pub period: String,

--- a/crates/api/src/dto/tls.rs
+++ b/crates/api/src/dto/tls.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct TlsStatusResponse {
     pub enabled: bool,
     pub cert_exists: bool,
@@ -10,14 +11,14 @@ pub struct TlsStatusResponse {
     pub cert_valid: bool,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct TlsUploadResponse {
     pub success: bool,
     pub message: String,
     pub restart_required: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, IntoParams)]
 pub struct GenerateQuery {
     #[serde(default)]
     pub force: bool,

--- a/crates/api/src/dto/user.rs
+++ b/crates/api/src/dto/user.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateUserRequest {
     pub username: String,
     pub display_name: Option<String>,
@@ -13,7 +14,7 @@ fn default_role() -> String {
     "viewer".to_string()
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct UserResponse {
     pub id: Option<i64>,
     pub username: String,

--- a/crates/api/src/dto/whitelist.rs
+++ b/crates/api/src/dto/whitelist.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct WhitelistResponse {
     pub domain: String,
     pub added_at: String,

--- a/crates/api/src/dto/whitelist_source.rs
+++ b/crates/api/src/dto/whitelist_source.rs
@@ -1,7 +1,8 @@
 use ferrous_dns_domain::WhitelistSource;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct WhitelistSourceResponse {
     pub id: i64,
     pub name: String,
@@ -28,7 +29,7 @@ impl WhitelistSourceResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateWhitelistSourceRequest {
     pub name: String,
     pub url: Option<String>,
@@ -54,7 +55,7 @@ impl CreateWhitelistSourceRequest {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateWhitelistSourceRequest {
     pub name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_optional_nullable_string")]

--- a/crates/api/src/handlers/api_tokens.rs
+++ b/crates/api/src/handlers/api_tokens.rs
@@ -1,10 +1,10 @@
 use axum::{
     extract::{Path, State},
     http::StatusCode,
-    routing::{delete, get, post, put},
-    Json, Router,
+    Json,
 };
 use tracing::debug;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::dto::api_token::{
     ApiTokenResponse, CreateApiTokenRequest, CreatedApiTokenResponse, UpdateApiTokenRequest,
@@ -12,14 +12,21 @@ use crate::dto::api_token::{
 use crate::errors::ApiError;
 use crate::state::AppState;
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/api-tokens", get(get_all_api_tokens))
-        .route("/api-tokens", post(create_api_token))
-        .route("/api-tokens/{id}", put(update_api_token))
-        .route("/api-tokens/{id}", delete(delete_api_token))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_all_api_tokens, create_api_token))
+        .routes(routes!(update_api_token, delete_api_token))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api-tokens",
+    tag = "api_tokens",
+    responses(
+        (status = 200, description = "All API tokens (without secrets)", body = [ApiTokenResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_all_api_tokens(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<ApiTokenResponse>>, ApiError> {
@@ -40,6 +47,17 @@ async fn get_all_api_tokens(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api-tokens",
+    tag = "api_tokens",
+    request_body = CreateApiTokenRequest,
+    responses(
+        (status = 201, description = "Token created (raw token returned only here)", body = CreatedApiTokenResponse),
+        (status = 409, description = "Duplicate token name"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_api_token(
     State(state): State<AppState>,
     Json(req): Json<CreateApiTokenRequest>,
@@ -63,6 +81,18 @@ async fn create_api_token(
     ))
 }
 
+#[utoipa::path(
+    put,
+    path = "/api-tokens/{id}",
+    tag = "api_tokens",
+    params(("id" = i64, Path, description = "Token ID")),
+    request_body = UpdateApiTokenRequest,
+    responses(
+        (status = 200, description = "Token updated", body = ApiTokenResponse),
+        (status = 404, description = "Token not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn update_api_token(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -85,6 +115,17 @@ async fn update_api_token(
     }))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/api-tokens/{id}",
+    tag = "api_tokens",
+    params(("id" = i64, Path, description = "Token ID")),
+    responses(
+        (status = 204, description = "Token deleted"),
+        (status = 404, description = "Token not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_api_token(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/api/src/handlers/auth.rs
+++ b/crates/api/src/handlers/auth.rs
@@ -1,11 +1,11 @@
-use axum::routing::{delete, get, post};
 use axum::{
     extract::{Path, Request, State},
     http::{header, StatusCode},
     response::IntoResponse,
-    Json, Router,
+    Json,
 };
 use tracing::debug;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::dto::auth::{
     AuthStatusResponse, ChangePasswordRequest, LoginRequest, LoginResponse, SessionResponse,
@@ -17,14 +17,23 @@ use crate::state::AppState;
 pub const SESSION_COOKIE_NAME: &str = "ferrous_session";
 
 /// Routes that require authentication (behind require_auth middleware).
-pub fn protected_routes() -> Router<AppState> {
-    Router::new()
-        .route("/auth/password", post(change_password))
-        .route("/auth/sessions", get(get_active_sessions))
-        .route("/auth/sessions/{id}", delete(delete_session))
+pub fn protected_routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(change_password))
+        .routes(routes!(get_active_sessions))
+        .routes(routes!(delete_session))
 }
 
 /// Public: returns auth status (no auth required).
+#[utoipa::path(
+    get,
+    path = "/auth/status",
+    tag = "auth",
+    responses(
+        (status = 200, description = "Authentication status", body = AuthStatusResponse),
+    ),
+    security(),
+)]
 pub async fn get_auth_status_public(
     State(state): State<AppState>,
 ) -> Result<Json<AuthStatusResponse>, ApiError> {
@@ -41,6 +50,18 @@ pub async fn get_auth_status_public(
 }
 
 /// Public: first-run password setup (no auth required).
+#[utoipa::path(
+    post,
+    path = "/auth/setup",
+    tag = "auth",
+    request_body = SetupPasswordRequest,
+    responses(
+        (status = 204, description = "Password configured"),
+        (status = 409, description = "Password already configured"),
+        (status = 400, description = "Invalid password"),
+    ),
+    security(),
+)]
 pub async fn setup_password_public(
     State(state): State<AppState>,
     Json(req): Json<SetupPasswordRequest>,
@@ -51,6 +72,18 @@ pub async fn setup_password_public(
 }
 
 /// Public: login and create session (no auth required).
+#[utoipa::path(
+    post,
+    path = "/auth/login",
+    tag = "auth",
+    request_body = LoginRequest,
+    responses(
+        (status = 200, description = "Login successful, session cookie issued", body = LoginResponse),
+        (status = 401, description = "Invalid credentials"),
+        (status = 429, description = "Too many login attempts"),
+    ),
+    security(),
+)]
 pub async fn login_public(
     State(state): State<AppState>,
     request: Request,
@@ -108,6 +141,15 @@ pub async fn login_public(
 }
 
 /// Public: logout and clear session cookie (no auth required).
+#[utoipa::path(
+    post,
+    path = "/auth/logout",
+    tag = "auth",
+    responses(
+        (status = 204, description = "Session cleared"),
+    ),
+    security(),
+)]
 pub async fn logout_public(State(state): State<AppState>, request: Request) -> impl IntoResponse {
     if let Some(session_id) = extract_session_cookie(&request) {
         let _ = state.auth.logout.execute(&session_id).await;
@@ -121,6 +163,18 @@ pub async fn logout_public(State(state): State<AppState>, request: Request) -> i
     (StatusCode::NO_CONTENT, [(header::SET_COOKIE, clear_cookie)])
 }
 
+#[utoipa::path(
+    post,
+    path = "/auth/password",
+    tag = "auth",
+    request_body = ChangePasswordRequest,
+    responses(
+        (status = 204, description = "Password changed"),
+        (status = 401, description = "Authentication required or current password invalid"),
+        (status = 400, description = "Invalid new password"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn change_password(
     State(state): State<AppState>,
     request: Request,
@@ -159,6 +213,16 @@ async fn change_password(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[utoipa::path(
+    get,
+    path = "/auth/sessions",
+    tag = "auth",
+    responses(
+        (status = 200, description = "Active sessions", body = [SessionResponse]),
+        (status = 401, description = "Authentication required"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_active_sessions(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<SessionResponse>>, ApiError> {
@@ -182,6 +246,18 @@ async fn get_active_sessions(
     ))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/auth/sessions/{id}",
+    tag = "auth",
+    params(("id" = String, Path, description = "Session ID")),
+    responses(
+        (status = 204, description = "Session deleted"),
+        (status = 401, description = "Authentication required"),
+        (status = 404, description = "Session not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_session(
     State(state): State<AppState>,
     Path(id): Path<String>,

--- a/crates/api/src/handlers/backup.rs
+++ b/crates/api/src/handlers/backup.rs
@@ -3,12 +3,12 @@ use axum::{
     extract::{Multipart, State},
     http::{header, StatusCode},
     response::{IntoResponse, Response},
-    routing::{get, post},
-    Json, Router,
+    Json,
 };
 use chrono::Utc;
 use ferrous_dns_application::use_cases::{BackupSnapshot, ImportSummary};
 use tracing::{error, info, instrument};
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::backup::{ImportSummaryDto, ImportSummaryResponse},
@@ -16,12 +16,21 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/config/export", get(export_config))
-        .route("/config/import", post(import_config))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(export_config))
+        .routes(routes!(import_config))
 }
 
+#[utoipa::path(
+    get,
+    path = "/config/export",
+    tag = "backup",
+    responses(
+        (status = 200, description = "Backup JSON download", content_type = "application/json"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_export_config")]
 async fn export_config(State(state): State<AppState>) -> Result<Response, ApiError> {
     let bytes = state.backup.export.execute().await?;
@@ -46,6 +55,17 @@ async fn export_config(State(state): State<AppState>) -> Result<Response, ApiErr
     Ok(response)
 }
 
+#[utoipa::path(
+    post,
+    path = "/config/import",
+    tag = "backup",
+    request_body(content_type = "multipart/form-data", content = String),
+    responses(
+        (status = 200, description = "Import summary", body = ImportSummaryResponse),
+        (status = 400, description = "Invalid backup file"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state, multipart), name = "api_import_config")]
 async fn import_config(
     State(state): State<AppState>,

--- a/crates/api/src/handlers/block_filter.rs
+++ b/crates/api/src/handlers/block_filter.rs
@@ -1,11 +1,21 @@
-use axum::{extract::State, routing::get, Json, Router};
+use axum::{extract::State, Json};
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{dto::block_filter::BlockFilterStatsResponse, state::AppState};
 
-pub fn routes() -> Router<AppState> {
-    Router::new().route("/block-filter/stats", get(get_block_filter_stats))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(get_block_filter_stats))
 }
 
+#[utoipa::path(
+    get,
+    path = "/block-filter/stats",
+    tag = "block_filter",
+    responses(
+        (status = 200, description = "Block filter engine stats", body = BlockFilterStatsResponse),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 pub async fn get_block_filter_stats(
     State(state): State<AppState>,
 ) -> Json<BlockFilterStatsResponse> {

--- a/crates/api/src/handlers/blocked_services.rs
+++ b/crates/api/src/handlers/blocked_services.rs
@@ -2,12 +2,12 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::Json,
-    routing::{delete, get, post},
-    Router,
 };
 use ferrous_dns_domain::DomainError;
 use serde::Deserialize;
 use tracing::debug;
+use utoipa::IntoParams;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::{BlockServiceRequest, BlockedServiceResponse, ServiceDefinitionResponse},
@@ -15,18 +15,23 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/services/catalog", get(get_catalog))
-        .route("/services/catalog/{id}", get(get_catalog_entry))
-        .route("/services", get(get_blocked_services))
-        .route("/services", post(block_service))
-        .route(
-            "/services/{service_id}/groups/{group_id}",
-            delete(unblock_service),
-        )
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_catalog))
+        .routes(routes!(get_catalog_entry))
+        .routes(routes!(get_blocked_services, block_service))
+        .routes(routes!(unblock_service))
 }
 
+#[utoipa::path(
+    get,
+    path = "/services/catalog",
+    tag = "services",
+    responses(
+        (status = 200, description = "Service catalog", body = [ServiceDefinitionResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_catalog(State(state): State<AppState>) -> Json<Vec<ServiceDefinitionResponse>> {
     let services = state.services.get_service_catalog.get_all();
     Json(
@@ -37,6 +42,17 @@ async fn get_catalog(State(state): State<AppState>) -> Json<Vec<ServiceDefinitio
     )
 }
 
+#[utoipa::path(
+    get,
+    path = "/services/catalog/{id}",
+    tag = "services",
+    params(("id" = String, Path, description = "Service ID")),
+    responses(
+        (status = 200, description = "Service definition", body = ServiceDefinitionResponse),
+        (status = 404, description = "Service not found in catalog"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_catalog_entry(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -54,11 +70,21 @@ async fn get_catalog_entry(
     Ok(Json(ServiceDefinitionResponse::from_definition(&def)))
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, IntoParams)]
 struct BlockedServicesQuery {
     group_id: Option<i64>,
 }
 
+#[utoipa::path(
+    get,
+    path = "/services",
+    tag = "services",
+    params(("group_id" = Option<i64>, Query, description = "Optional group filter")),
+    responses(
+        (status = 200, description = "Blocked services", body = [BlockedServiceResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_blocked_services(
     State(state): State<AppState>,
     Query(params): Query<BlockedServicesQuery>,
@@ -82,6 +108,17 @@ async fn get_blocked_services(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/services",
+    tag = "services",
+    request_body = BlockServiceRequest,
+    responses(
+        (status = 201, description = "Service blocked for group", body = BlockedServiceResponse),
+        (status = 409, description = "Service already blocked for this group"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn block_service(
     State(state): State<AppState>,
     Json(req): Json<BlockServiceRequest>,
@@ -98,6 +135,20 @@ async fn block_service(
     ))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/services/{service_id}/groups/{group_id}",
+    tag = "services",
+    params(
+        ("service_id" = String, Path, description = "Service ID"),
+        ("group_id" = i64, Path, description = "Group ID"),
+    ),
+    responses(
+        (status = 204, description = "Service unblocked"),
+        (status = 404, description = "Blocked service not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn unblock_service(
     State(state): State<AppState>,
     Path((service_id, group_id)): Path<(String, i64)>,

--- a/crates/api/src/handlers/blocklist.rs
+++ b/crates/api/src/handlers/blocklist.rs
@@ -9,6 +9,17 @@ use axum::{
 };
 use tracing::{debug, instrument};
 
+#[utoipa::path(
+    get,
+    path = "/blocklist",
+    tag = "blocking",
+    params(BlocklistQuery),
+    responses(
+        (status = 200, description = "Paginated blocklist", body = PaginatedBlocklist),
+        (status = 500, description = "Internal error"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_blocklist")]
 pub async fn get_blocklist(
     State(state): State<AppState>,

--- a/crates/api/src/handlers/blocklist_sources.rs
+++ b/crates/api/src/handlers/blocklist_sources.rs
@@ -2,11 +2,10 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{delete, get, post, put},
-    Router,
 };
 use ferrous_dns_domain::DomainError;
 use tracing::debug;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::{BlocklistSourceResponse, CreateBlocklistSourceRequest, UpdateBlocklistSourceRequest},
@@ -14,15 +13,25 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/blocklist-sources", get(get_all_blocklist_sources))
-        .route("/blocklist-sources", post(create_blocklist_source))
-        .route("/blocklist-sources/{id}", get(get_blocklist_source_by_id))
-        .route("/blocklist-sources/{id}", put(update_blocklist_source))
-        .route("/blocklist-sources/{id}", delete(delete_blocklist_source))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_all_blocklist_sources, create_blocklist_source))
+        .routes(routes!(
+            get_blocklist_source_by_id,
+            update_blocklist_source,
+            delete_blocklist_source
+        ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/blocklist-sources",
+    tag = "blocklist_sources",
+    responses(
+        (status = 200, description = "All blocklist sources", body = [BlocklistSourceResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_all_blocklist_sources(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<BlocklistSourceResponse>>, ApiError> {
@@ -39,6 +48,17 @@ async fn get_all_blocklist_sources(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/blocklist-sources/{id}",
+    tag = "blocklist_sources",
+    params(("id" = i64, Path, description = "Source ID")),
+    responses(
+        (status = 200, description = "Source detail", body = BlocklistSourceResponse),
+        (status = 404, description = "Source not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_blocklist_source_by_id(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -57,6 +77,17 @@ async fn get_blocklist_source_by_id(
     Ok(Json(BlocklistSourceResponse::from_source(source)))
 }
 
+#[utoipa::path(
+    post,
+    path = "/blocklist-sources",
+    tag = "blocklist_sources",
+    request_body = CreateBlocklistSourceRequest,
+    responses(
+        (status = 201, description = "Source created", body = BlocklistSourceResponse),
+        (status = 409, description = "Conflict"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_blocklist_source(
     State(state): State<AppState>,
     Json(req): Json<CreateBlocklistSourceRequest>,
@@ -76,6 +107,18 @@ async fn create_blocklist_source(
     ))
 }
 
+#[utoipa::path(
+    put,
+    path = "/blocklist-sources/{id}",
+    tag = "blocklist_sources",
+    params(("id" = i64, Path, description = "Source ID")),
+    request_body = UpdateBlocklistSourceRequest,
+    responses(
+        (status = 200, description = "Source updated", body = BlocklistSourceResponse),
+        (status = 404, description = "Source not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn update_blocklist_source(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -90,6 +133,17 @@ async fn update_blocklist_source(
     Ok(Json(BlocklistSourceResponse::from_source(source)))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/blocklist-sources/{id}",
+    tag = "blocklist_sources",
+    params(("id" = i64, Path, description = "Source ID")),
+    responses(
+        (status = 204, description = "Source deleted"),
+        (status = 404, description = "Source not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_blocklist_source(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/api/src/handlers/cache.rs
+++ b/crates/api/src/handlers/cache.rs
@@ -10,6 +10,17 @@ use axum::{
 };
 use tracing::{debug, instrument};
 
+#[utoipa::path(
+    get,
+    path = "/cache/stats",
+    tag = "cache",
+    params(CacheStatsQuery),
+    responses(
+        (status = 200, description = "Cache statistics for the period", body = CacheStatsResponse),
+        (status = 500, description = "Internal error"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_cache_stats")]
 pub async fn get_cache_stats(
     State(state): State<AppState>,
@@ -45,6 +56,15 @@ pub async fn get_cache_stats(
     }))
 }
 
+#[utoipa::path(
+    get,
+    path = "/cache/metrics",
+    tag = "cache",
+    responses(
+        (status = 200, description = "Live cache metrics snapshot", body = CacheMetricsResponse),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_cache_metrics")]
 pub async fn get_cache_metrics(State(state): State<AppState>) -> Json<CacheMetricsResponse> {
     debug!("Fetching cache metrics directly from cache");

--- a/crates/api/src/handlers/client_groups.rs
+++ b/crates/api/src/handlers/client_groups.rs
@@ -9,6 +9,18 @@ use crate::{
     state::AppState,
 };
 
+#[utoipa::path(
+    put,
+    path = "/clients/{id}/group",
+    tag = "clients",
+    params(("id" = i64, Path, description = "Client ID")),
+    request_body = AssignGroupRequest,
+    responses(
+        (status = 200, description = "Client assigned to group", body = ClientResponse),
+        (status = 404, description = "Client or group not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 pub async fn assign_client_to_group(
     State(state): State<AppState>,
     Path(client_id): Path<i64>,

--- a/crates/api/src/handlers/client_subnets.rs
+++ b/crates/api/src/handlers/client_subnets.rs
@@ -2,10 +2,9 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{delete, get, post},
-    Router,
 };
 use tracing::{debug, error};
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::{ClientSubnetResponse, CreateClientSubnetRequest},
@@ -13,13 +12,21 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/client-subnets", get(get_all_subnets))
-        .route("/client-subnets", post(create_subnet))
-        .route("/client-subnets/{id}", delete(delete_subnet))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_all_subnets, create_subnet))
+        .routes(routes!(delete_subnet))
 }
 
+#[utoipa::path(
+    get,
+    path = "/client-subnets",
+    tag = "client_subnets",
+    responses(
+        (status = 200, description = "All client subnets", body = [ClientSubnetResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_all_subnets(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<ClientSubnetResponse>>, ApiError> {
@@ -41,6 +48,17 @@ async fn get_all_subnets(
     Ok(Json(responses))
 }
 
+#[utoipa::path(
+    post,
+    path = "/client-subnets",
+    tag = "client_subnets",
+    request_body = CreateClientSubnetRequest,
+    responses(
+        (status = 201, description = "Subnet created", body = ClientSubnetResponse),
+        (status = 409, description = "Subnet conflict"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_subnet(
     State(state): State<AppState>,
     Json(req): Json<CreateClientSubnetRequest>,
@@ -70,6 +88,17 @@ async fn create_subnet(
     ))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/client-subnets/{id}",
+    tag = "client_subnets",
+    params(("id" = i64, Path, description = "Subnet ID")),
+    responses(
+        (status = 204, description = "Subnet deleted"),
+        (status = 404, description = "Subnet not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_subnet(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/api/src/handlers/clients.rs
+++ b/crates/api/src/handlers/clients.rs
@@ -7,6 +7,17 @@ use axum::{
 };
 use tracing::{debug, instrument};
 
+#[utoipa::path(
+    get,
+    path = "/clients",
+    tag = "clients",
+    params(ClientsQuery),
+    responses(
+        (status = 200, description = "Client list", body = [ClientResponse]),
+        (status = 500, description = "Internal error"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_clients")]
 pub async fn get_clients(
     State(state): State<AppState>,
@@ -51,6 +62,16 @@ pub async fn get_clients(
     Ok(Json(response))
 }
 
+#[utoipa::path(
+    get,
+    path = "/clients/stats",
+    tag = "clients",
+    responses(
+        (status = 200, description = "Aggregated client statistics", body = ClientStatsResponse),
+        (status = 500, description = "Internal error"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_client_stats")]
 pub async fn get_client_stats(
     State(state): State<AppState>,

--- a/crates/api/src/handlers/config/get.rs
+++ b/crates/api/src/handlers/config/get.rs
@@ -9,6 +9,15 @@ use crate::{
 use axum::{extract::State, Json};
 use tracing::{debug, instrument};
 
+#[utoipa::path(
+    get,
+    path = "/config",
+    tag = "config",
+    responses(
+        (status = 200, description = "Current configuration", body = ConfigResponse),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_config")]
 pub async fn get_config(State(state): State<AppState>) -> Json<ConfigResponse> {
     debug!("Fetching current configuration");
@@ -116,6 +125,15 @@ pub async fn get_config(State(state): State<AppState>) -> Json<ConfigResponse> {
     })
 }
 
+#[utoipa::path(
+    get,
+    path = "/settings",
+    tag = "config",
+    responses(
+        (status = 200, description = "Current DNS settings", body = crate::dto::SettingsDto),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_settings")]
 pub async fn get_settings(State(state): State<AppState>) -> Json<crate::dto::SettingsDto> {
     debug!("Fetching settings");

--- a/crates/api/src/handlers/config/update.rs
+++ b/crates/api/src/handlers/config/update.rs
@@ -28,6 +28,16 @@ async fn get_writable_config_path(
     Ok(path)
 }
 
+#[utoipa::path(
+    post,
+    path = "/config",
+    tag = "config",
+    request_body = UpdateConfigRequest,
+    responses(
+        (status = 200, description = "Configuration updated"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_update_config")]
 pub async fn update_config(
     State(state): State<AppState>,
@@ -249,6 +259,16 @@ pub async fn update_config(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/settings",
+    tag = "config",
+    request_body = SettingsDto,
+    responses(
+        (status = 200, description = "Settings updated"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_update_settings")]
 pub async fn update_settings(
     State(state): State<AppState>,
@@ -295,6 +315,15 @@ pub async fn update_settings(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/config/reload",
+    tag = "config",
+    responses(
+        (status = 200, description = "Configuration reloaded"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_reload_config")]
 pub async fn reload_config(State(state): State<AppState>) -> Json<serde_json::Value> {
     info!("Config reload requested");

--- a/crates/api/src/handlers/custom_services.rs
+++ b/crates/api/src/handlers/custom_services.rs
@@ -2,11 +2,10 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{delete, get, patch, post},
-    Router,
 };
 use ferrous_dns_domain::DomainError;
 use tracing::debug;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::{CreateCustomServiceRequest, CustomServiceResponse, UpdateCustomServiceRequest},
@@ -14,21 +13,25 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/custom-services", get(list_custom_services))
-        .route("/custom-services", post(create_custom_service))
-        .route("/custom-services/{service_id}", get(get_custom_service))
-        .route(
-            "/custom-services/{service_id}",
-            patch(update_custom_service),
-        )
-        .route(
-            "/custom-services/{service_id}",
-            delete(delete_custom_service),
-        )
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(list_custom_services, create_custom_service))
+        .routes(routes!(
+            get_custom_service,
+            update_custom_service,
+            delete_custom_service
+        ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/custom-services",
+    tag = "custom_services",
+    responses(
+        (status = 200, description = "All custom services", body = [CustomServiceResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn list_custom_services(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<CustomServiceResponse>>, ApiError> {
@@ -42,6 +45,17 @@ async fn list_custom_services(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/custom-services/{service_id}",
+    tag = "custom_services",
+    params(("service_id" = String, Path, description = "Custom service ID")),
+    responses(
+        (status = 200, description = "Custom service detail", body = CustomServiceResponse),
+        (status = 404, description = "Custom service not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_custom_service(
     State(state): State<AppState>,
     Path(service_id): Path<String>,
@@ -60,6 +74,17 @@ async fn get_custom_service(
     Ok(Json(CustomServiceResponse::from_entity(cs)))
 }
 
+#[utoipa::path(
+    post,
+    path = "/custom-services",
+    tag = "custom_services",
+    request_body = CreateCustomServiceRequest,
+    responses(
+        (status = 201, description = "Custom service created", body = CustomServiceResponse),
+        (status = 409, description = "Custom service already exists"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_custom_service(
     State(state): State<AppState>,
     Json(req): Json<CreateCustomServiceRequest>,
@@ -78,6 +103,18 @@ async fn create_custom_service(
     ))
 }
 
+#[utoipa::path(
+    patch,
+    path = "/custom-services/{service_id}",
+    tag = "custom_services",
+    params(("service_id" = String, Path, description = "Custom service ID")),
+    request_body = UpdateCustomServiceRequest,
+    responses(
+        (status = 200, description = "Custom service updated", body = CustomServiceResponse),
+        (status = 404, description = "Custom service not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn update_custom_service(
     State(state): State<AppState>,
     Path(service_id): Path<String>,
@@ -91,6 +128,17 @@ async fn update_custom_service(
     Ok(Json(CustomServiceResponse::from_entity(cs)))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/custom-services/{service_id}",
+    tag = "custom_services",
+    params(("service_id" = String, Path, description = "Custom service ID")),
+    responses(
+        (status = 204, description = "Custom service deleted"),
+        (status = 404, description = "Custom service not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_custom_service(
     State(state): State<AppState>,
     Path(service_id): Path<String>,

--- a/crates/api/src/handlers/dashboard.rs
+++ b/crates/api/src/handlers/dashboard.rs
@@ -16,6 +16,16 @@ use tracing::{error, instrument};
 const DEFAULT_PERIOD_HOURS: f32 = 24.0;
 const TOP_TYPES_LIMIT: usize = 10;
 
+#[utoipa::path(
+    get,
+    path = "/dashboard",
+    tag = "dashboard",
+    params(DashboardQuery),
+    responses(
+        (status = 200, description = "Aggregated dashboard payload", body = DashboardResponse),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_dashboard")]
 pub async fn get_dashboard(
     State(state): State<AppState>,

--- a/crates/api/src/handlers/groups.rs
+++ b/crates/api/src/handlers/groups.rs
@@ -2,10 +2,9 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{delete, get, post, put},
-    Router,
 };
 use tracing::debug;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::{ClientResponse, CreateGroupRequest, GroupResponse, UpdateGroupRequest},
@@ -13,16 +12,22 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/groups", get(get_all_groups))
-        .route("/groups", post(create_group))
-        .route("/groups/{id}", get(get_group_by_id))
-        .route("/groups/{id}", put(update_group))
-        .route("/groups/{id}", delete(delete_group))
-        .route("/groups/{id}/clients", get(get_group_clients))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_all_groups, create_group))
+        .routes(routes!(get_group_by_id, update_group, delete_group))
+        .routes(routes!(get_group_clients))
 }
 
+#[utoipa::path(
+    get,
+    path = "/groups",
+    tag = "groups",
+    responses(
+        (status = 200, description = "All groups", body = [GroupResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_all_groups(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<GroupResponse>>, ApiError> {
@@ -35,6 +40,17 @@ async fn get_all_groups(
     Ok(Json(responses))
 }
 
+#[utoipa::path(
+    get,
+    path = "/groups/{id}",
+    tag = "groups",
+    params(("id" = i64, Path, description = "Group ID")),
+    responses(
+        (status = 200, description = "Group detail", body = GroupResponse),
+        (status = 404, description = "Group not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_group_by_id(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -59,6 +75,17 @@ async fn get_group_by_id(
     Ok(Json(GroupResponse::from_group(group, client_count)))
 }
 
+#[utoipa::path(
+    post,
+    path = "/groups",
+    tag = "groups",
+    request_body = CreateGroupRequest,
+    responses(
+        (status = 201, description = "Group created", body = GroupResponse),
+        (status = 409, description = "Conflict"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_group(
     State(state): State<AppState>,
     Json(req): Json<CreateGroupRequest>,
@@ -80,6 +107,18 @@ async fn create_group(
     ))
 }
 
+#[utoipa::path(
+    put,
+    path = "/groups/{id}",
+    tag = "groups",
+    params(("id" = i64, Path, description = "Group ID")),
+    request_body = UpdateGroupRequest,
+    responses(
+        (status = 200, description = "Group updated", body = GroupResponse),
+        (status = 404, description = "Group not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn update_group(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -99,6 +138,18 @@ async fn update_group(
     Ok(Json(GroupResponse::from_group(group, client_count)))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/groups/{id}",
+    tag = "groups",
+    params(("id" = i64, Path, description = "Group ID")),
+    responses(
+        (status = 204, description = "Group deleted"),
+        (status = 404, description = "Group not found"),
+        (status = 409, description = "Group has assigned clients"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_group(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -107,6 +158,17 @@ async fn delete_group(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[utoipa::path(
+    get,
+    path = "/groups/{id}/clients",
+    tag = "groups",
+    params(("id" = i64, Path, description = "Group ID")),
+    responses(
+        (status = 200, description = "Clients in group", body = [ClientResponse]),
+        (status = 404, description = "Group not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_group_clients(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/api/src/handlers/health.rs
+++ b/crates/api/src/handlers/health.rs
@@ -1,5 +1,14 @@
 use tracing::info;
 
+#[utoipa::path(
+    get,
+    path = "/health",
+    tag = "system",
+    responses(
+        (status = 200, description = "Server is healthy", body = String),
+    ),
+    security(),
+)]
 pub async fn health_check() -> &'static str {
     info!("Health check requested");
     "OK"

--- a/crates/api/src/handlers/hostname.rs
+++ b/crates/api/src/handlers/hostname.rs
@@ -2,6 +2,15 @@ use crate::dto::HostnameResponse;
 use axum::Json;
 use tracing::instrument;
 
+#[utoipa::path(
+    get,
+    path = "/hostname",
+    tag = "system",
+    responses(
+        (status = 200, description = "Server hostname", body = HostnameResponse),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip_all, name = "api_get_hostname")]
 pub async fn get_hostname() -> Json<HostnameResponse> {
     let hostname = hostname::get()

--- a/crates/api/src/handlers/local_records.rs
+++ b/crates/api/src/handlers/local_records.rs
@@ -2,23 +2,27 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{get, post, put},
-    Router,
 };
 use tracing::info;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{dto::local_record::*, errors::ApiError, state::AppState};
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/local-records", get(get_all_records))
-        .route("/local-records", post(create_record))
-        .route(
-            "/local-records/{id}",
-            put(update_record).delete(delete_record),
-        )
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_all_records, create_record))
+        .routes(routes!(update_record, delete_record))
 }
 
+#[utoipa::path(
+    get,
+    path = "/local-records",
+    tag = "local_records",
+    responses(
+        (status = 200, description = "All local DNS records", body = [LocalRecordDto]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_all_records(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<LocalRecordDto>>, ApiError> {
@@ -36,6 +40,17 @@ async fn get_all_records(
     Ok(Json(dtos))
 }
 
+#[utoipa::path(
+    post,
+    path = "/local-records",
+    tag = "local_records",
+    request_body = CreateLocalRecordRequest,
+    responses(
+        (status = 201, description = "Local DNS record created", body = LocalRecordDto),
+        (status = 400, description = "Invalid input"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_record(
     State(state): State<AppState>,
     Json(req): Json<CreateLocalRecordRequest>,
@@ -59,6 +74,18 @@ async fn create_record(
     Ok((StatusCode::CREATED, Json(dto)))
 }
 
+#[utoipa::path(
+    put,
+    path = "/local-records/{id}",
+    tag = "local_records",
+    params(("id" = i64, Path, description = "Local record ID (index)")),
+    request_body = UpdateLocalRecordRequest,
+    responses(
+        (status = 200, description = "Local DNS record updated", body = LocalRecordDto),
+        (status = 404, description = "Record not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn update_record(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -90,6 +117,17 @@ async fn update_record(
     Ok(Json(dto))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/local-records/{id}",
+    tag = "local_records",
+    params(("id" = i64, Path, description = "Local record ID (index)")),
+    responses(
+        (status = 204, description = "Local DNS record deleted"),
+        (status = 404, description = "Record not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_record(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/api/src/handlers/managed_domains.rs
+++ b/crates/api/src/handlers/managed_domains.rs
@@ -2,11 +2,10 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::Json,
-    routing::{delete, get, post, put},
-    Router,
 };
 use ferrous_dns_domain::{DomainAction, DomainError};
 use tracing::debug;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::{
@@ -17,15 +16,26 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/managed-domains", get(get_all_managed_domains))
-        .route("/managed-domains", post(create_managed_domain))
-        .route("/managed-domains/{id}", get(get_managed_domain_by_id))
-        .route("/managed-domains/{id}", put(update_managed_domain))
-        .route("/managed-domains/{id}", delete(delete_managed_domain))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_all_managed_domains, create_managed_domain))
+        .routes(routes!(
+            get_managed_domain_by_id,
+            update_managed_domain,
+            delete_managed_domain
+        ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/managed-domains",
+    tag = "blocking",
+    params(ManagedDomainQuery),
+    responses(
+        (status = 200, description = "Paginated managed domains", body = PaginatedManagedDomains),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_all_managed_domains(
     State(state): State<AppState>,
     Query(params): Query<ManagedDomainQuery>,
@@ -50,6 +60,17 @@ async fn get_all_managed_domains(
     }))
 }
 
+#[utoipa::path(
+    get,
+    path = "/managed-domains/{id}",
+    tag = "blocking",
+    params(("id" = i64, Path, description = "Managed domain ID")),
+    responses(
+        (status = 200, description = "Managed domain detail", body = ManagedDomainResponse),
+        (status = 404, description = "Managed domain not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_managed_domain_by_id(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -68,6 +89,17 @@ async fn get_managed_domain_by_id(
     Ok(Json(ManagedDomainResponse::from_domain(domain)))
 }
 
+#[utoipa::path(
+    post,
+    path = "/managed-domains",
+    tag = "blocking",
+    request_body = CreateManagedDomainRequest,
+    responses(
+        (status = 201, description = "Managed domain created", body = ManagedDomainResponse),
+        (status = 400, description = "Invalid input"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_managed_domain(
     State(state): State<AppState>,
     Json(req): Json<CreateManagedDomainRequest>,
@@ -94,6 +126,18 @@ async fn create_managed_domain(
     ))
 }
 
+#[utoipa::path(
+    put,
+    path = "/managed-domains/{id}",
+    tag = "blocking",
+    params(("id" = i64, Path, description = "Managed domain ID")),
+    request_body = UpdateManagedDomainRequest,
+    responses(
+        (status = 200, description = "Managed domain updated", body = ManagedDomainResponse),
+        (status = 404, description = "Managed domain not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn update_managed_domain(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -126,6 +170,17 @@ async fn update_managed_domain(
     Ok(Json(ManagedDomainResponse::from_domain(domain)))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/managed-domains/{id}",
+    tag = "blocking",
+    params(("id" = i64, Path, description = "Managed domain ID")),
+    responses(
+        (status = 204, description = "Managed domain deleted"),
+        (status = 404, description = "Managed domain not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_managed_domain(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/api/src/handlers/manual_clients.rs
+++ b/crates/api/src/handlers/manual_clients.rs
@@ -11,6 +11,19 @@ use crate::{
     state::AppState,
 };
 
+#[utoipa::path(
+    post,
+    path = "/clients",
+    tag = "clients",
+    request_body = CreateManualClientRequest,
+    responses(
+        (status = 201, description = "Client created", body = ClientResponse),
+        (status = 400, description = "Invalid input"),
+        (status = 401, description = "Authentication required"),
+        (status = 409, description = "Conflict"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 pub async fn create_manual_client(
     State(state): State<AppState>,
     Json(req): Json<CreateManualClientRequest>,
@@ -42,6 +55,19 @@ pub async fn create_manual_client(
     ))
 }
 
+#[utoipa::path(
+    patch,
+    path = "/clients/{id}",
+    tag = "clients",
+    params(("id" = i64, Path, description = "Client ID")),
+    request_body = UpdateClientRequest,
+    responses(
+        (status = 200, description = "Client updated", body = ClientResponse),
+        (status = 404, description = "Client not found"),
+        (status = 400, description = "Invalid input"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 pub async fn update_manual_client(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -65,6 +91,17 @@ pub async fn update_manual_client(
     }))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/clients/{id}",
+    tag = "clients",
+    params(("id" = i64, Path, description = "Client ID")),
+    responses(
+        (status = 204, description = "Client deleted"),
+        (status = 404, description = "Client not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 pub async fn delete_manual_client(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/api/src/handlers/queries.rs
+++ b/crates/api/src/handlers/queries.rs
@@ -11,6 +11,17 @@ use axum::{
 use ferrous_dns_application::use_cases::PagedQueryInput;
 use tracing::{debug, instrument};
 
+#[utoipa::path(
+    get,
+    path = "/queries",
+    tag = "queries",
+    params(QueryParams),
+    responses(
+        (status = 200, description = "Paginated DNS query log", body = PaginatedQueries),
+        (status = 500, description = "Internal error"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_queries")]
 pub async fn get_queries(
     State(state): State<AppState>,

--- a/crates/api/src/handlers/rate.rs
+++ b/crates/api/src/handlers/rate.rs
@@ -10,6 +10,17 @@ use axum::{
 use ferrous_dns_application::use_cases::RateUnit;
 use tracing::{debug, instrument};
 
+#[utoipa::path(
+    get,
+    path = "/stats/rate",
+    tag = "stats",
+    params(RateQuery),
+    responses(
+        (status = 200, description = "Current query rate", body = QueryRateResponse),
+        (status = 500, description = "Internal error"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_query_rate")]
 pub async fn get_query_rate(
     State(state): State<AppState>,

--- a/crates/api/src/handlers/regex_filters.rs
+++ b/crates/api/src/handlers/regex_filters.rs
@@ -2,11 +2,10 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{delete, get, post, put},
-    Router,
 };
 use ferrous_dns_domain::{DomainAction, DomainError};
 use tracing::debug;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::{CreateRegexFilterRequest, RegexFilterResponse, UpdateRegexFilterRequest},
@@ -14,15 +13,25 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/regex-filters", get(get_all_regex_filters))
-        .route("/regex-filters", post(create_regex_filter))
-        .route("/regex-filters/{id}", get(get_regex_filter_by_id))
-        .route("/regex-filters/{id}", put(update_regex_filter))
-        .route("/regex-filters/{id}", delete(delete_regex_filter))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_all_regex_filters, create_regex_filter))
+        .routes(routes!(
+            get_regex_filter_by_id,
+            update_regex_filter,
+            delete_regex_filter
+        ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/regex-filters",
+    tag = "blocking",
+    responses(
+        (status = 200, description = "All regex filters", body = [RegexFilterResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_all_regex_filters(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<RegexFilterResponse>>, ApiError> {
@@ -39,6 +48,17 @@ async fn get_all_regex_filters(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/regex-filters/{id}",
+    tag = "blocking",
+    params(("id" = i64, Path, description = "Regex filter ID")),
+    responses(
+        (status = 200, description = "Regex filter detail", body = RegexFilterResponse),
+        (status = 404, description = "Regex filter not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_regex_filter_by_id(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -57,6 +77,17 @@ async fn get_regex_filter_by_id(
     Ok(Json(RegexFilterResponse::from_domain(filter)))
 }
 
+#[utoipa::path(
+    post,
+    path = "/regex-filters",
+    tag = "blocking",
+    request_body = CreateRegexFilterRequest,
+    responses(
+        (status = 201, description = "Regex filter created", body = RegexFilterResponse),
+        (status = 400, description = "Invalid input"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_regex_filter(
     State(state): State<AppState>,
     Json(req): Json<CreateRegexFilterRequest>,
@@ -90,6 +121,18 @@ async fn create_regex_filter(
     ))
 }
 
+#[utoipa::path(
+    put,
+    path = "/regex-filters/{id}",
+    tag = "blocking",
+    params(("id" = i64, Path, description = "Regex filter ID")),
+    request_body = UpdateRegexFilterRequest,
+    responses(
+        (status = 200, description = "Regex filter updated", body = RegexFilterResponse),
+        (status = 404, description = "Regex filter not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn update_regex_filter(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -122,6 +165,17 @@ async fn update_regex_filter(
     Ok(Json(RegexFilterResponse::from_domain(filter)))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/regex-filters/{id}",
+    tag = "blocking",
+    params(("id" = i64, Path, description = "Regex filter ID")),
+    responses(
+        (status = 204, description = "Regex filter deleted"),
+        (status = 404, description = "Regex filter not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_regex_filter(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/api/src/handlers/safe_search.rs
+++ b/crates/api/src/handlers/safe_search.rs
@@ -2,10 +2,9 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{delete, get, post},
-    Router,
 };
 use ferrous_dns_domain::DomainError;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::{SafeSearchConfigResponse, ToggleSafeSearchRequest},
@@ -13,17 +12,25 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/safe-search/configs", get(get_all_configs))
-        .route("/safe-search/configs/{group_id}", get(get_configs_by_group))
-        .route("/safe-search/configs/{group_id}", post(toggle_config))
-        .route(
-            "/safe-search/configs/{group_id}",
-            delete(delete_configs_by_group),
-        )
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_all_configs))
+        .routes(routes!(
+            get_configs_by_group,
+            toggle_config,
+            delete_configs_by_group
+        ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/safe-search/configs",
+    tag = "safe_search",
+    responses(
+        (status = 200, description = "All Safe Search configurations", body = [SafeSearchConfigResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_all_configs(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<SafeSearchConfigResponse>>, ApiError> {
@@ -36,6 +43,16 @@ async fn get_all_configs(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/safe-search/configs/{group_id}",
+    tag = "safe_search",
+    params(("group_id" = i64, Path, description = "Group ID")),
+    responses(
+        (status = 200, description = "Group's Safe Search configurations", body = [SafeSearchConfigResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_configs_by_group(
     State(state): State<AppState>,
     Path(group_id): Path<i64>,
@@ -49,6 +66,18 @@ async fn get_configs_by_group(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/safe-search/configs/{group_id}",
+    tag = "safe_search",
+    params(("group_id" = i64, Path, description = "Group ID")),
+    request_body = ToggleSafeSearchRequest,
+    responses(
+        (status = 200, description = "Safe Search configuration updated", body = SafeSearchConfigResponse),
+        (status = 400, description = "Invalid engine"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn toggle_config(
     State(state): State<AppState>,
     Path(group_id): Path<i64>,
@@ -71,6 +100,16 @@ async fn toggle_config(
     Ok(Json(SafeSearchConfigResponse::from_entity(config)))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/safe-search/configs/{group_id}",
+    tag = "safe_search",
+    params(("group_id" = i64, Path, description = "Group ID")),
+    responses(
+        (status = 204, description = "Safe Search configurations cleared for group"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_configs_by_group(
     State(state): State<AppState>,
     Path(group_id): Path<i64>,

--- a/crates/api/src/handlers/schedule_profiles.rs
+++ b/crates/api/src/handlers/schedule_profiles.rs
@@ -2,10 +2,9 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{delete, get, post, put},
-    Router,
 };
 use ferrous_dns_domain::ScheduleAction;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::schedule::{
@@ -17,23 +16,28 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/schedule-profiles", get(list_profiles))
-        .route("/schedule-profiles", post(create_profile))
-        .route("/schedule-profiles/{id}", get(get_profile))
-        .route("/schedule-profiles/{id}", put(update_profile))
-        .route("/schedule-profiles/{id}", delete(delete_profile))
-        .route("/schedule-profiles/{id}/slots", post(add_slot))
-        .route(
-            "/schedule-profiles/{id}/slots/{slot_id}",
-            delete(delete_slot),
-        )
-        .route("/groups/{id}/schedule", get(get_group_schedule))
-        .route("/groups/{id}/schedule", put(assign_schedule))
-        .route("/groups/{id}/schedule", delete(unassign_schedule))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(list_profiles, create_profile))
+        .routes(routes!(get_profile, update_profile, delete_profile))
+        .routes(routes!(add_slot))
+        .routes(routes!(delete_slot))
+        .routes(routes!(
+            get_group_schedule,
+            assign_schedule,
+            unassign_schedule
+        ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/schedule-profiles",
+    tag = "schedules",
+    responses(
+        (status = 200, description = "All schedule profiles", body = [ScheduleProfileResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn list_profiles(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<ScheduleProfileResponse>>, ApiError> {
@@ -46,6 +50,17 @@ async fn list_profiles(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/schedule-profiles",
+    tag = "schedules",
+    request_body = CreateScheduleProfileRequest,
+    responses(
+        (status = 201, description = "Profile created", body = ScheduleProfileResponse),
+        (status = 409, description = "Duplicate profile name"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_profile(
     State(state): State<AppState>,
     Json(req): Json<CreateScheduleProfileRequest>,
@@ -61,6 +76,17 @@ async fn create_profile(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/schedule-profiles/{id}",
+    tag = "schedules",
+    params(("id" = i64, Path, description = "Profile ID")),
+    responses(
+        (status = 200, description = "Profile with time slots", body = ScheduleProfileWithSlotsResponse),
+        (status = 404, description = "Profile not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_profile(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -78,6 +104,18 @@ async fn get_profile(
     }))
 }
 
+#[utoipa::path(
+    put,
+    path = "/schedule-profiles/{id}",
+    tag = "schedules",
+    params(("id" = i64, Path, description = "Profile ID")),
+    request_body = UpdateScheduleProfileRequest,
+    responses(
+        (status = 200, description = "Profile updated", body = ScheduleProfileResponse),
+        (status = 404, description = "Profile not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn update_profile(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -91,6 +129,17 @@ async fn update_profile(
     Ok(Json(ScheduleProfileResponse::from_entity(profile)))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/schedule-profiles/{id}",
+    tag = "schedules",
+    params(("id" = i64, Path, description = "Profile ID")),
+    responses(
+        (status = 204, description = "Profile deleted"),
+        (status = 404, description = "Profile not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_profile(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -99,6 +148,18 @@ async fn delete_profile(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[utoipa::path(
+    post,
+    path = "/schedule-profiles/{id}/slots",
+    tag = "schedules",
+    params(("id" = i64, Path, description = "Profile ID")),
+    request_body = AddTimeSlotRequest,
+    responses(
+        (status = 201, description = "Time slot added", body = TimeSlotResponse),
+        (status = 400, description = "Invalid time slot"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn add_slot(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -121,6 +182,20 @@ async fn add_slot(
     ))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/schedule-profiles/{id}/slots/{slot_id}",
+    tag = "schedules",
+    params(
+        ("id" = i64, Path, description = "Profile ID"),
+        ("slot_id" = i64, Path, description = "Time slot ID"),
+    ),
+    responses(
+        (status = 204, description = "Time slot deleted"),
+        (status = 404, description = "Time slot not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_slot(
     State(state): State<AppState>,
     Path((_id, slot_id)): Path<(i64, i64)>,
@@ -129,6 +204,17 @@ async fn delete_slot(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[utoipa::path(
+    get,
+    path = "/groups/{id}/schedule",
+    tag = "schedules",
+    params(("id" = i64, Path, description = "Group ID")),
+    responses(
+        (status = 200, description = "Group's schedule assignment", body = GroupScheduleResponse),
+        (status = 404, description = "Group has no schedule"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_group_schedule(
     State(state): State<AppState>,
     Path(group_id): Path<i64>,
@@ -147,6 +233,17 @@ async fn get_group_schedule(
     }))
 }
 
+#[utoipa::path(
+    put,
+    path = "/groups/{id}/schedule",
+    tag = "schedules",
+    params(("id" = i64, Path, description = "Group ID")),
+    request_body = AssignProfileRequest,
+    responses(
+        (status = 200, description = "Schedule assigned to group", body = GroupScheduleResponse),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn assign_schedule(
     State(state): State<AppState>,
     Path(group_id): Path<i64>,
@@ -163,6 +260,16 @@ async fn assign_schedule(
     }))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/groups/{id}/schedule",
+    tag = "schedules",
+    params(("id" = i64, Path, description = "Group ID")),
+    responses(
+        (status = 204, description = "Schedule unassigned"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn unassign_schedule(
     State(state): State<AppState>,
     Path(group_id): Path<i64>,

--- a/crates/api/src/handlers/stats.rs
+++ b/crates/api/src/handlers/stats.rs
@@ -13,6 +13,17 @@ use tracing::instrument;
 const DEFAULT_PERIOD_HOURS: f32 = 24.0;
 const TOP_TYPES_LIMIT: usize = 10;
 
+#[utoipa::path(
+    get,
+    path = "/stats",
+    tag = "stats",
+    params(StatsQuery),
+    responses(
+        (status = 200, description = "Aggregated query statistics", body = StatsResponse),
+        (status = 500, description = "Internal error"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_stats")]
 pub async fn get_stats(
     State(state): State<AppState>,

--- a/crates/api/src/handlers/system_info.rs
+++ b/crates/api/src/handlers/system_info.rs
@@ -6,6 +6,15 @@ const PROC_VERSION: &str = "/proc/version";
 const PROC_LOADAVG: &str = "/proc/loadavg";
 const PROC_MEMINFO: &str = "/proc/meminfo";
 
+#[utoipa::path(
+    get,
+    path = "/system/info",
+    tag = "system",
+    responses(
+        (status = 200, description = "Host system information", body = SystemInfoResponse),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip_all, name = "api_get_system_info")]
 pub async fn get_system_info() -> Json<SystemInfoResponse> {
     let (version_raw, loadavg_raw, meminfo_raw) = tokio::join!(

--- a/crates/api/src/handlers/timeline.rs
+++ b/crates/api/src/handlers/timeline.rs
@@ -20,6 +20,17 @@ fn parse_granularity(s: &str) -> TimeGranularity {
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/queries/timeline",
+    tag = "queries",
+    params(TimelineQuery),
+    responses(
+        (status = 200, description = "Time-bucketed query counts", body = TimelineResponse),
+        (status = 500, description = "Internal error"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_timeline")]
 pub async fn get_timeline(
     State(state): State<AppState>,

--- a/crates/api/src/handlers/tls.rs
+++ b/crates/api/src/handlers/tls.rs
@@ -12,6 +12,15 @@ use std::path::Path;
 use tracing::info;
 
 /// GET /tls/status — returns certificate status information.
+#[utoipa::path(
+    get,
+    path = "/tls/status",
+    tag = "tls",
+    responses(
+        (status = 200, description = "TLS certificate status", body = TlsStatusResponse),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 pub async fn get_tls_status(State(state): State<AppState>) -> Json<TlsStatusResponse> {
     let config = state.config.read().await;
     let web_tls = &config.server.web_tls;
@@ -32,6 +41,17 @@ pub async fn get_tls_status(State(state): State<AppState>) -> Json<TlsStatusResp
 }
 
 /// POST /tls/upload — receives multipart with `cert` and `key` PEM files.
+#[utoipa::path(
+    post,
+    path = "/tls/upload",
+    tag = "tls",
+    request_body(content_type = "multipart/form-data", content = String),
+    responses(
+        (status = 200, description = "Certificates uploaded", body = TlsUploadResponse),
+        (status = 400, description = "Missing or invalid files"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 pub async fn upload_tls_certs(
     State(state): State<AppState>,
     mut multipart: Multipart,
@@ -88,6 +108,17 @@ pub async fn upload_tls_certs(
 }
 
 /// POST /tls/generate — generates a self-signed certificate.
+#[utoipa::path(
+    post,
+    path = "/tls/generate",
+    tag = "tls",
+    params(GenerateQuery),
+    responses(
+        (status = 200, description = "Self-signed certificate generated", body = TlsUploadResponse),
+        (status = 400, description = "Files already exist (use ?force=true)"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 pub async fn generate_self_signed(
     State(state): State<AppState>,
     Query(query): Query<GenerateQuery>,

--- a/crates/api/src/handlers/upstream.rs
+++ b/crates/api/src/handlers/upstream.rs
@@ -12,6 +12,15 @@ pub struct UpstreamHealthResponse {
     pub servers: HashMap<String, String>,
 }
 
+#[utoipa::path(
+    get,
+    path = "/upstream/health",
+    tag = "system",
+    responses(
+        (status = 200, description = "Per-upstream health status map"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 pub async fn get_upstream_health(State(state): State<AppState>) -> Json<HashMap<String, String>> {
     let mut health_map = HashMap::new();
 
@@ -48,6 +57,15 @@ pub struct UpstreamGroupResponse {
     pub strategy: String,
 }
 
+#[utoipa::path(
+    get,
+    path = "/upstream/health/detail",
+    tag = "system",
+    responses(
+        (status = 200, description = "Detailed upstream health grouped per endpoint"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 pub async fn get_upstream_health_detail(
     State(state): State<AppState>,
 ) -> Json<Vec<UpstreamGroupResponse>> {

--- a/crates/api/src/handlers/users.rs
+++ b/crates/api/src/handlers/users.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
-    routing::{delete, get, post},
-    Json, Router,
+    Json,
 };
 use tracing::debug;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::dto::user::{CreateUserRequest, UserResponse};
 use crate::errors::ApiError;
@@ -14,19 +14,39 @@ use crate::state::AppState;
 use ferrous_dns_application::ports::CreateUserInput;
 use ferrous_dns_domain::User;
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/users", get(get_all_users))
-        .route("/users", post(create_user))
-        .route("/users/{id}", delete(delete_user))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_all_users, create_user))
+        .routes(routes!(delete_user))
 }
 
+#[utoipa::path(
+    get,
+    path = "/users",
+    tag = "users",
+    responses(
+        (status = 200, description = "All users", body = [UserResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_all_users(State(state): State<AppState>) -> Result<Json<Vec<UserResponse>>, ApiError> {
     let users = state.auth.get_users.execute().await?;
     debug!(count = users.len(), "Users retrieved");
     Ok(Json(users.into_iter().map(user_to_response).collect()))
 }
 
+#[utoipa::path(
+    post,
+    path = "/users",
+    tag = "users",
+    request_body = CreateUserRequest,
+    responses(
+        (status = 201, description = "User created", body = UserResponse),
+        (status = 409, description = "Username already taken"),
+        (status = 400, description = "Invalid input"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_user(
     State(state): State<AppState>,
     Json(req): Json<CreateUserRequest>,
@@ -43,6 +63,18 @@ async fn create_user(
     Ok((StatusCode::CREATED, Json(user_to_response(user))))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/users/{id}",
+    tag = "users",
+    params(("id" = i64, Path, description = "User ID")),
+    responses(
+        (status = 204, description = "User deleted"),
+        (status = 404, description = "User not found"),
+        (status = 403, description = "Cannot delete protected user"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_user(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/api/src/handlers/whitelist.rs
+++ b/crates/api/src/handlers/whitelist.rs
@@ -2,6 +2,16 @@ use crate::{dto::WhitelistResponse, errors::ApiError, state::AppState};
 use axum::{extract::State, Json};
 use tracing::{debug, instrument};
 
+#[utoipa::path(
+    get,
+    path = "/whitelist",
+    tag = "blocking",
+    responses(
+        (status = 200, description = "All whitelisted domains", body = [WhitelistResponse]),
+        (status = 500, description = "Internal error"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 #[instrument(skip(state), name = "api_get_whitelist")]
 pub async fn get_whitelist(
     State(state): State<AppState>,

--- a/crates/api/src/handlers/whitelist_sources.rs
+++ b/crates/api/src/handlers/whitelist_sources.rs
@@ -2,11 +2,10 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::{delete, get, post, put},
-    Router,
 };
 use ferrous_dns_domain::DomainError;
 use tracing::debug;
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     dto::{CreateWhitelistSourceRequest, UpdateWhitelistSourceRequest, WhitelistSourceResponse},
@@ -14,15 +13,25 @@ use crate::{
     state::AppState,
 };
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/whitelist-sources", get(get_all_whitelist_sources))
-        .route("/whitelist-sources", post(create_whitelist_source))
-        .route("/whitelist-sources/{id}", get(get_whitelist_source_by_id))
-        .route("/whitelist-sources/{id}", put(update_whitelist_source))
-        .route("/whitelist-sources/{id}", delete(delete_whitelist_source))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_all_whitelist_sources, create_whitelist_source))
+        .routes(routes!(
+            get_whitelist_source_by_id,
+            update_whitelist_source,
+            delete_whitelist_source
+        ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/whitelist-sources",
+    tag = "whitelist_sources",
+    responses(
+        (status = 200, description = "All whitelist sources", body = [WhitelistSourceResponse]),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_all_whitelist_sources(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<WhitelistSourceResponse>>, ApiError> {
@@ -39,6 +48,17 @@ async fn get_all_whitelist_sources(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/whitelist-sources/{id}",
+    tag = "whitelist_sources",
+    params(("id" = i64, Path, description = "Source ID")),
+    responses(
+        (status = 200, description = "Source detail", body = WhitelistSourceResponse),
+        (status = 404, description = "Source not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn get_whitelist_source_by_id(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -57,6 +77,17 @@ async fn get_whitelist_source_by_id(
     Ok(Json(WhitelistSourceResponse::from_source(source)))
 }
 
+#[utoipa::path(
+    post,
+    path = "/whitelist-sources",
+    tag = "whitelist_sources",
+    request_body = CreateWhitelistSourceRequest,
+    responses(
+        (status = 201, description = "Source created", body = WhitelistSourceResponse),
+        (status = 409, description = "Conflict"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn create_whitelist_source(
     State(state): State<AppState>,
     Json(req): Json<CreateWhitelistSourceRequest>,
@@ -76,6 +107,18 @@ async fn create_whitelist_source(
     ))
 }
 
+#[utoipa::path(
+    put,
+    path = "/whitelist-sources/{id}",
+    tag = "whitelist_sources",
+    params(("id" = i64, Path, description = "Source ID")),
+    request_body = UpdateWhitelistSourceRequest,
+    responses(
+        (status = 200, description = "Source updated", body = WhitelistSourceResponse),
+        (status = 404, description = "Source not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn update_whitelist_source(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -90,6 +133,17 @@ async fn update_whitelist_source(
     Ok(Json(WhitelistSourceResponse::from_source(source)))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/whitelist-sources/{id}",
+    tag = "whitelist_sources",
+    params(("id" = i64, Path, description = "Source ID")),
+    responses(
+        (status = 204, description = "Source deleted"),
+        (status = 404, description = "Source not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
 async fn delete_whitelist_source(
     State(state): State<AppState>,
     Path(id): Path<i64>,

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2,12 +2,14 @@ pub mod dto;
 pub mod errors;
 pub mod handlers;
 pub mod middleware;
+pub mod openapi;
 pub mod routes;
 pub mod state;
 pub mod utils;
 
 pub use errors::ApiError;
-pub use routes::create_api_routes;
+pub use openapi::ApiDoc;
+pub use routes::{create_api_router_with_openapi, create_api_routes};
 pub use state::{
     AppState, AuthUseCases, BackupUseCases, BlockingUseCases, ClientUseCases, DnsUseCases,
     GroupUseCases, QueryUseCases, SafeSearchUseCases, ScheduleUseCases, ServiceUseCases,

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -1,0 +1,229 @@
+//! OpenAPI document for the native Ferrous DNS REST API.
+//!
+//! This module defines the [`ApiDoc`] type that aggregates every handler
+//! annotated with `#[utoipa::path]` plus all DTO schemas. The router itself
+//! is assembled in [`crate::routes`] using `utoipa-axum`'s `OpenApiRouter`;
+//! `ApiDoc` is the static counterpart consumed by tooling that needs a
+//! standalone `OpenApi` value (e.g. snapshot tests).
+//!
+//! Two security schemes are advertised:
+//!   * `session_cookie` — `ferrous_session` cookie (browser sessions)
+//!   * `api_key` — `X-Api-Key` header (machine-to-machine)
+//!
+//! Public endpoints (login, logout, setup, status, health) declare
+//! `security()` explicitly to opt out.
+
+use utoipa::{
+    openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
+    Modify, OpenApi,
+};
+
+use crate::dto;
+
+/// Adds the cookie and API-key security schemes to the generated spec.
+pub struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .get_or_insert_with(utoipa::openapi::Components::new);
+
+        components.add_security_scheme(
+            "session_cookie",
+            SecurityScheme::ApiKey(ApiKey::Cookie(ApiKeyValue::new("ferrous_session"))),
+        );
+        components.add_security_scheme(
+            "api_key",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("X-Api-Key"))),
+        );
+    }
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Ferrous DNS API",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "Native REST API for Ferrous DNS — manages blocking, clients, groups, \
+                       DNS cache, schedules, services and authentication. \
+                       Authenticate via the `ferrous_session` cookie or the `X-Api-Key` header."
+    ),
+    tags(
+        (name = "auth", description = "Authentication, sessions and password management"),
+        (name = "users", description = "Local user accounts and roles"),
+        (name = "api_tokens", description = "Machine-to-machine API keys"),
+        (name = "dashboard", description = "Aggregated dashboard payload"),
+        (name = "stats", description = "Query statistics and timelines"),
+        (name = "queries", description = "Recent DNS query log"),
+        (name = "cache", description = "DNS cache statistics and metrics"),
+        (name = "clients", description = "Client inventory and group assignment"),
+        (name = "groups", description = "Client groups"),
+        (name = "client_subnets", description = "CIDR-based group mapping"),
+        (name = "blocking", description = "Blocklist, whitelist, managed domains and regex filters"),
+        (name = "blocklist_sources", description = "External blocklist sources"),
+        (name = "whitelist_sources", description = "External whitelist sources"),
+        (name = "services", description = "Service catalog and per-group service blocking"),
+        (name = "custom_services", description = "User-defined service catalog entries"),
+        (name = "safe_search", description = "Safe Search enforcement per group"),
+        (name = "schedules", description = "Time-based blocking profiles"),
+        (name = "local_records", description = "Locally served DNS records"),
+        (name = "config", description = "Runtime configuration"),
+        (name = "system", description = "Host, hostname and upstream health"),
+        (name = "tls", description = "Web TLS certificate management"),
+        (name = "backup", description = "Configuration export/import"),
+        (name = "block_filter", description = "Block filter engine status"),
+    ),
+    modifiers(&SecurityAddon),
+    components(schemas(
+        // auth
+        dto::auth::LoginRequest,
+        dto::auth::LoginResponse,
+        dto::auth::SetupPasswordRequest,
+        dto::auth::ChangePasswordRequest,
+        dto::auth::AuthStatusResponse,
+        dto::auth::SessionResponse,
+        // api tokens
+        dto::api_token::CreateApiTokenRequest,
+        dto::api_token::UpdateApiTokenRequest,
+        dto::api_token::CreatedApiTokenResponse,
+        dto::api_token::ApiTokenResponse,
+        // users
+        dto::user::CreateUserRequest,
+        dto::user::UserResponse,
+        // backup
+        dto::backup::ImportSummaryResponse,
+        dto::backup::ImportSummaryDto,
+        // block filter
+        dto::block_filter::BlockFilterStatsResponse,
+        // services
+        dto::ServiceDefinitionResponse,
+        dto::BlockedServiceResponse,
+        dto::BlockServiceRequest,
+        dto::CustomServiceResponse,
+        dto::CreateCustomServiceRequest,
+        dto::UpdateCustomServiceRequest,
+        // blocklist
+        dto::BlocklistResponse,
+        dto::PaginatedBlocklist,
+        dto::BlocklistSourceResponse,
+        dto::CreateBlocklistSourceRequest,
+        dto::UpdateBlocklistSourceRequest,
+        // whitelist
+        dto::WhitelistResponse,
+        dto::WhitelistSourceResponse,
+        dto::CreateWhitelistSourceRequest,
+        dto::UpdateWhitelistSourceRequest,
+        // managed domains
+        dto::ManagedDomainResponse,
+        dto::PaginatedManagedDomains,
+        dto::CreateManagedDomainRequest,
+        dto::UpdateManagedDomainRequest,
+        // regex filters
+        dto::RegexFilterResponse,
+        dto::CreateRegexFilterRequest,
+        dto::UpdateRegexFilterRequest,
+        // cache
+        dto::CacheStatsResponse,
+        dto::CacheMetricsResponse,
+        // clients
+        dto::ClientResponse,
+        dto::ClientStatsResponse,
+        dto::UpdateClientRequest,
+        dto::ClientSubnetResponse,
+        dto::CreateClientSubnetRequest,
+        dto::CreateManualClientRequest,
+        // groups
+        dto::GroupResponse,
+        dto::CreateGroupRequest,
+        dto::UpdateGroupRequest,
+        dto::AssignGroupRequest,
+        // config
+        dto::config::ConfigResponse,
+        dto::config::AuthConfigResponse,
+        dto::config::ServerConfigResponse,
+        dto::config::WebTlsConfigResponse,
+        dto::config::DnsConfigResponse,
+        dto::config::RateLimitConfigResponse,
+        dto::config::UpstreamPoolResponse,
+        dto::config::HealthCheckResponse,
+        dto::config::BlockingConfigResponse,
+        dto::config::LoggingConfigResponse,
+        dto::config::DatabaseConfigResponse,
+        dto::config::UpdateConfigRequest,
+        dto::config::AuthConfigUpdate,
+        dto::config::ServerConfigUpdate,
+        dto::config::WebTlsConfigUpdate,
+        dto::config::PoolUpdate,
+        dto::config::DnsConfigUpdate,
+        dto::config::RateLimitConfigUpdate,
+        dto::config::BlockingConfigUpdate,
+        dto::config::SettingsDto,
+        dto::config::SettingsUpdateResponse,
+        // dashboard / stats
+        dto::DashboardResponse,
+        dto::TopBlockedDomain,
+        dto::TopClient,
+        dto::StatsResponse,
+        dto::TypeDistribution,
+        dto::TopType,
+        dto::QueryRateResponse,
+        // queries
+        dto::QueryResponse,
+        dto::PaginatedQueries,
+        // timeline
+        dto::TimelineBucket,
+        dto::TimelineResponse,
+        // safe search
+        dto::SafeSearchConfigResponse,
+        dto::ToggleSafeSearchRequest,
+        // schedule
+        dto::schedule::CreateScheduleProfileRequest,
+        dto::schedule::UpdateScheduleProfileRequest,
+        dto::schedule::AddTimeSlotRequest,
+        dto::schedule::AssignProfileRequest,
+        dto::schedule::ScheduleProfileResponse,
+        dto::schedule::TimeSlotResponse,
+        dto::schedule::ScheduleProfileWithSlotsResponse,
+        dto::schedule::GroupScheduleResponse,
+        // local records
+        dto::LocalRecordDto,
+        dto::CreateLocalRecordRequest,
+        dto::local_record::UpdateLocalRecordRequest,
+        // misc
+        dto::HostnameResponse,
+        dto::SystemInfoResponse,
+        dto::TlsStatusResponse,
+        dto::TlsUploadResponse,
+    )),
+)]
+pub struct ApiDoc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openapi_spec_serializes_with_security_schemes() {
+        let spec = ApiDoc::openapi();
+        let json = serde_json::to_value(&spec).expect("spec must serialize");
+
+        assert_eq!(json["info"]["title"], "Ferrous DNS API");
+        assert_eq!(json["info"]["version"], env!("CARGO_PKG_VERSION"));
+
+        let schemes = &json["components"]["securitySchemes"];
+        assert!(schemes["session_cookie"].is_object());
+        assert!(schemes["api_key"].is_object());
+    }
+
+    #[test]
+    fn openapi_spec_contains_core_schemas() {
+        let spec = ApiDoc::openapi();
+        let json = serde_json::to_value(&spec).expect("spec must serialize");
+        let schemas = &json["components"]["schemas"];
+
+        for required in ["LoginRequest", "QueryResponse", "DashboardResponse"] {
+            assert!(!schemas[required].is_null(), "missing schema {required}");
+        }
+    }
+}

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -1,40 +1,67 @@
 use crate::handlers;
 use crate::middleware::require_auth;
+use crate::openapi::ApiDoc;
 use crate::state::AppState;
-use axum::{
-    middleware,
-    routing::{delete, get, patch, post, put},
-    Router,
-};
+use axum::{middleware, Router};
+use utoipa::OpenApi;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 
-pub fn create_api_routes(state: AppState) -> Router {
-    let public_auth_routes = Router::new()
-        .route("/auth/status", get(handlers::auth::get_auth_status_public))
-        .route("/auth/setup", post(handlers::auth::setup_password_public))
-        .route("/auth/login", post(handlers::auth::login_public))
-        .route("/auth/logout", post(handlers::auth::logout_public));
+/// Builds the API router and returns the matching OpenAPI document.
+///
+/// All handlers exposed here are annotated with `#[utoipa::path]` so the
+/// `OpenApiRouter::routes(routes!(...))` macro registers both the axum
+/// route and its OpenAPI path operation. Submodules that already return a
+/// classic `axum::Router` are merged in via the `From<Router>` impl
+/// (their routes still work but aren't reflected in the spec — each
+/// submodule annotates handlers individually and exposes them via its
+/// own `OpenApiRouter` builder).
+pub fn create_api_router_with_openapi(state: AppState) -> (Router, utoipa::openapi::OpenApi) {
+    let public_routes = OpenApiRouter::new()
+        .routes(routes!(handlers::auth::get_auth_status_public))
+        .routes(routes!(handlers::auth::setup_password_public))
+        .routes(routes!(handlers::auth::login_public))
+        .routes(routes!(handlers::auth::logout_public));
 
-    let protected_routes = Router::new()
-        .route("/health", get(handlers::health_check))
-        .route("/dashboard", get(handlers::get_dashboard))
-        .route("/stats", get(handlers::get_stats))
-        .route("/stats/rate", get(handlers::get_query_rate))
-        .route("/queries/timeline", get(handlers::get_timeline))
-        .route("/queries", get(handlers::get_queries))
-        .route("/blocklist", get(handlers::get_blocklist))
-        .route("/whitelist", get(handlers::get_whitelist))
-        .route("/cache/stats", get(handlers::get_cache_stats))
-        .route("/cache/metrics", get(handlers::get_cache_metrics))
-        .route("/config", get(handlers::get_config))
-        .route("/config", post(handlers::update_config))
-        .route("/config/reload", post(handlers::reload_config))
-        .route("/hostname", get(handlers::get_hostname))
-        .route("/clients", get(handlers::get_clients))
-        .route("/clients", post(handlers::create_manual_client))
-        .route("/clients/stats", get(handlers::get_client_stats))
-        .route("/clients/{id}", patch(handlers::update_manual_client))
-        .route("/clients/{id}", delete(handlers::delete_manual_client))
-        .route("/clients/{id}/group", put(handlers::assign_client_to_group))
+    let core_routes = OpenApiRouter::new()
+        .routes(routes!(handlers::health::health_check))
+        .routes(routes!(handlers::dashboard::get_dashboard))
+        .routes(routes!(handlers::stats::get_stats))
+        .routes(routes!(handlers::rate::get_query_rate))
+        .routes(routes!(handlers::timeline::get_timeline))
+        .routes(routes!(handlers::queries::get_queries))
+        .routes(routes!(handlers::blocklist::get_blocklist))
+        .routes(routes!(handlers::whitelist::get_whitelist))
+        .routes(routes!(handlers::cache::get_cache_stats))
+        .routes(routes!(handlers::cache::get_cache_metrics))
+        .routes(routes!(
+            handlers::config::get::get_config,
+            handlers::config::update::update_config
+        ))
+        .routes(routes!(handlers::config::update::reload_config))
+        .routes(routes!(handlers::hostname::get_hostname))
+        .routes(routes!(
+            handlers::clients::get_clients,
+            handlers::manual_clients::create_manual_client
+        ))
+        .routes(routes!(handlers::clients::get_client_stats))
+        .routes(routes!(
+            handlers::manual_clients::update_manual_client,
+            handlers::manual_clients::delete_manual_client
+        ))
+        .routes(routes!(handlers::client_groups::assign_client_to_group))
+        .routes(routes!(
+            handlers::config::get::get_settings,
+            handlers::config::update::update_settings
+        ))
+        .routes(routes!(handlers::upstream::get_upstream_health))
+        .routes(routes!(handlers::upstream::get_upstream_health_detail))
+        .routes(routes!(handlers::system_info::get_system_info))
+        .routes(routes!(handlers::tls::get_tls_status))
+        .routes(routes!(handlers::tls::upload_tls_certs))
+        .routes(routes!(handlers::tls::generate_self_signed));
+
+    let protected_router = core_routes
         .merge(handlers::groups::routes())
         .merge(handlers::client_subnets::routes())
         .merge(handlers::blocklist_sources::routes())
@@ -43,32 +70,26 @@ pub fn create_api_routes(state: AppState) -> Router {
         .merge(handlers::regex_filters::routes())
         .merge(handlers::blocked_services::routes())
         .merge(handlers::custom_services::routes())
-        .route("/settings", get(handlers::get_settings))
-        .route("/settings", post(handlers::update_settings))
         .merge(handlers::local_records::routes())
         .merge(handlers::block_filter::routes())
         .merge(handlers::safe_search::routes())
         .merge(handlers::schedule_profiles::routes())
-        .route(
-            "/upstream/health",
-            get(handlers::upstream::get_upstream_health),
-        )
-        .route(
-            "/upstream/health/detail",
-            get(handlers::upstream::get_upstream_health_detail),
-        )
-        .route("/system/info", get(handlers::get_system_info))
-        .route("/tls/status", get(handlers::tls::get_tls_status))
-        .route("/tls/upload", post(handlers::tls::upload_tls_certs))
-        .route("/tls/generate", post(handlers::tls::generate_self_signed))
         .merge(handlers::auth::protected_routes())
         .merge(handlers::users::routes())
         .merge(handlers::api_tokens::routes())
         .merge(handlers::backup::routes())
         .layer(middleware::from_fn_with_state(state.clone(), require_auth));
 
-    Router::new()
-        .merge(public_auth_routes)
-        .merge(protected_routes)
+    let (router, openapi) = OpenApiRouter::with_openapi(ApiDoc::openapi())
+        .merge(public_routes)
+        .merge(protected_router)
         .with_state(state)
+        .split_for_parts();
+
+    (router, openapi)
+}
+
+/// Backwards-compatible router builder that drops the OpenAPI document.
+pub fn create_api_routes(state: AppState) -> Router {
+    create_api_router_with_openapi(state).0
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -46,3 +46,5 @@ dashmap.workspace = true
 rustc-hash.workspace = true
 reqwest.workspace = true
 ring.workspace = true
+utoipa.workspace = true
+utoipa-scalar.workspace = true

--- a/crates/cli/src/server/web.rs
+++ b/crates/cli/src/server/web.rs
@@ -3,16 +3,17 @@ use axum::{
     http::{header, HeaderValue, Method},
     response::{Html, IntoResponse},
     routing::get,
-    Router,
+    Json, Router,
 };
-use ferrous_dns_api::{create_api_routes, AppState};
-use ferrous_dns_api_pihole::{create_pihole_routes, PiholeAppState};
+use ferrous_dns_api::{create_api_router_with_openapi, AppState};
+use ferrous_dns_api_pihole::{create_pihole_router_with_openapi, PiholeAppState};
 use ferrous_dns_infrastructure::dns::server::DnsServerHandler;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tracing::info;
+use utoipa_scalar::{Scalar, Servable};
 
 use super::web_tls;
 
@@ -119,12 +120,41 @@ fn create_app(
     pihole_compat: bool,
     doh_handler: Option<Arc<DnsServerHandler>>,
 ) -> Router {
+    let (ferrous_router, ferrous_openapi) = create_api_router_with_openapi(ferrous_state);
+    let ferrous_branch = Router::new()
+        .route(
+            "/openapi.json",
+            get({
+                let spec = ferrous_openapi.clone();
+                move || {
+                    let spec = spec.clone();
+                    async move { Json(spec) }
+                }
+            }),
+        )
+        .merge(Router::from(Scalar::with_url("/docs", ferrous_openapi)))
+        .merge(ferrous_router);
+
     let router = if pihole_compat {
+        let (pihole_router, pihole_openapi) = create_pihole_router_with_openapi(pihole_state);
+        let pihole_branch = Router::new()
+            .route(
+                "/openapi.json",
+                get({
+                    let spec = pihole_openapi.clone();
+                    move || {
+                        let spec = spec.clone();
+                        async move { Json(spec) }
+                    }
+                }),
+            )
+            .merge(Router::from(Scalar::with_url("/docs", pihole_openapi)))
+            .merge(pihole_router);
         Router::new()
-            .nest("/api", create_pihole_routes(pihole_state))
-            .nest("/ferrous/api", create_api_routes(ferrous_state))
+            .nest("/api", pihole_branch)
+            .nest("/ferrous/api", ferrous_branch)
     } else {
-        Router::new().nest("/api", create_api_routes(ferrous_state))
+        Router::new().nest("/api", ferrous_branch)
     };
 
     let mut app = router

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,6 +15,20 @@ When `pihole_compat = true`, the Ferrous API moves to `/ferrous/api/*` and the P
 
 ---
 
+## Interactive Documentation (OpenAPI / Scalar)
+
+Both APIs publish an OpenAPI 3.x specification and ship a built-in [Scalar](https://scalar.com) UI for interactive exploration. The endpoints are public — no authentication is required to read the spec or open the UI.
+
+| Mode | OpenAPI spec | Interactive docs |
+|:-----|:-------------|:-----------------|
+| Normal | `GET /api/openapi.json` | `GET /api/docs` |
+| Pi-hole compat (native API) | `GET /ferrous/api/openapi.json` | `GET /ferrous/api/docs` |
+| Pi-hole compat (Pi-hole API) | `GET /api/openapi.json` | `GET /api/docs` |
+
+The spec describes every handler, request/response schema, parameter and security scheme (`session_cookie` + `X-Api-Key` for the native API, `X-FTL-SID` for the Pi-hole layer). It can be fed into any OpenAPI-aware tool (Postman, openapi-generator, schemathesis, …) to produce clients or contract tests.
+
+---
+
 ## Authentication
 
 When authentication is enabled (`[auth]` section in config), all API endpoints require either a valid session cookie or an API token — except the public auth endpoints listed below.


### PR DESCRIPTION
- Add utoipa, utoipa-axum and utoipa-scalar workspace dependencies
- Derive ToSchema on every public DTO in ferrous-dns-api (~70 types) and ferrous-dns-api-pihole (43 types)
- Annotate every handler with #[utoipa::path] across both crates (~75 native + 46 Pi-hole compat endpoints)
- Add ApiDoc and PiholeApiDoc OpenAPI roots with SecurityAddon (cookie + X-Api-Key for native; X-FTL-SID for Pi-hole)
- Migrate route builders to OpenApiRouter, exposing create_api_router_with_openapi and create_pihole_router_with_openapi
- Mount /openapi.json (JSON spec) and /docs (Scalar UI) co-located with each router so both normal and pihole_compat layouts work
- Add smoke tests covering spec serialization, security schemes and critical schemas/paths
- Document the new endpoints in docs/api.md