### PR TITLE
feat - configurable blocked query response mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,4 +352,6 @@ CLAUDE.md
 .crushignore
 AGENTS.md
 AGENT-*.md
+# Keep the repo-root AGENTS.md (team-shared Claude Code / agent instructions)
+!/AGENTS.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# AGENTS.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Working directory
+
+The Cargo workspace lives in `ferrous-dns/` (this directory). Run all `cargo`/`make` commands from here, not from the parent `ferrous-networking/` wrapper directory.
+
+## Build, test, lint, format
+
+- Build: `cargo build` (debug) / `cargo build --release`
+- Test (all): `cargo test --all-features --workspace`
+  - Unit only: `cargo test --lib --all-features --workspace`
+  - Integration only: `cargo test --test '*' --all-features --workspace`
+  - Doc tests: `cargo test --doc --all-features --workspace`
+- Format: `cargo fmt --all` (check: `cargo fmt --all -- --check`)
+- Lint: `cargo clippy --all-targets --all-features --workspace -- -D warnings` (warnings are errors — this gates CI)
+- Aggregates: `make ci` (fmt-check + clippy + test), `make pre-commit` (fmt + clippy + test)
+- Run: `./target/release/ferrous-dns --config ferrous-dns.toml`
+
+No `rustfmt.toml` or `clippy.toml` — formatting/linting use defaults; the only enforced deviation is `-D warnings`.
+
+## Project structure
+
+```
+ferrous-dns/
+├── crates/         Cargo workspace members (Rust source)
+├── tests/          integration tests & benchmarks crate (flows/, performance/, common/)
+├── web/            Web UI — static HTML/CSS/JS in web/static/, served by the binary
+├── migrations/     SQLite schema migrations, applied at runtime via sqlx::migrate!
+├── docs/           MkDocs documentation source (own guidance in docs/CLAUDE.md)
+├── site/           generated MkDocs output — do not hand-edit
+├── bench/          benchmark harness & competitor configs (Pi-hole, AdGuard, unbound, …)
+├── scripts/        release & version-bump scripts (release.sh, bump-version.sh)
+├── docker/         container entrypoint (Dockerfile* and docker-compose.yml at repo root)
+├── Cargo.toml      workspace manifest
+├── Makefile        aggregate targets (make ci, make pre-commit, …)
+└── ferrous-dns.toml  example/runtime config
+```
+
+### Architecture (the `crates/` workspace)
+
+Cargo workspace (edition 2021, `resolver = "2"`) following Clean Architecture — respect the dependency direction:
+
+- `crates/domain` — pure business logic. **Keep dependency-light: no I/O, no async runtime, no frameworks.**
+- `crates/application` — use cases and ports (traits).
+- `crates/infrastructure` — adapters that implement the ports: SQLite (sqlx), cache, DNS resolvers (hickory), TLS/transport (DoT/DoH/DoQ/H3). Feature flags: `dns-over-rustls`, `dns-over-https`, `dns-over-quic`, `dns-over-h3` (all default-on).
+- `crates/jobs` — background jobs.
+- `crates/api` — REST API (axum 0.8) + OpenAPI (utoipa).
+- `crates/api-pihole` — Pi-hole v6 API compatibility layer.
+- `crates/cli` — binary crate, produces the `ferrous-dns` executable.
+- `tests/` — integration tests & benchmarks crate (also a workspace member).
+
+## Gotchas
+
+- hickory is pinned to an **alpha** (`0.26.0-alpha.1`); its API may shift between versions.
+- The `release` profile uses `panic = "abort"` — release builds don't unwind, so panic-catching behaves differently than in debug.
+- sqlx uses **runtime queries + `sqlx::migrate!`**, not compile-time `query!` macros. There is **no build-time `DATABASE_URL`** requirement and no `.sqlx` offline cache. Migrations live in `migrations/`.
+- Error handling: return `Result`, never `panic!` on bad input.
+- Committed DB artifacts (`ferrous-dns.db`, `-wal`, `-shm`) exist in the tree — don't edit or commit changes to them.
+- `tests/performance/competitor_comparison.rs` is `#[ignore]`d (needs external DNS servers running) and won't run in normal `cargo test`.
+- Runtime env vars: `FERROUS_CONFIG`, `FERROUS_DNS_PORT` (53), `FERROUS_WEB_PORT` (8080), `FERROUS_BIND_ADDRESS`, `FERROUS_DATABASE`, `FERROUS_LOG_LEVEL`; `RUST_LOG=debug` for debug logging.
+
+## Repo etiquette
+
+- Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`).
+- Branch naming: `feature/`, `fix/`, `docs/`, `refactor/`, `test/`.
+- Releases via `./scripts/release.sh [major|minor|patch]` (runs tests + fmt + clippy, bumps versions, tags).
+- Docs site (MkDocs) has its own guidance in `docs/CLAUDE.md`; public docs are written in English.
+
+## Skills
+
+- `/verify-ci` — run the full local CI gate (`make ci`: fmt-check + clippy `-D warnings` + tests) before marking work done or committing.
+- `/sync-agents` — re-scan the project and refresh the structural sections of both AGENTS.md files when crates, folders, migrations, or feature flags change.
+
+## Tooling
+
+- A PostToolUse hook runs `rustfmt` on every edited `.rs` file automatically (configured in the wrapper-dir `.claudin/settings.json`, outside this repo).
+
+To refine: `/skills` (skills), `/hooks` (hooks), `/permissions` (viewer for permission rules — edit `settings.json` directly to change them).

--- a/crates/api/src/dto/config.rs
+++ b/crates/api/src/dto/config.rs
@@ -104,6 +104,25 @@ pub struct BlockingConfigResponse {
     pub enabled: bool,
     pub custom_blocked: Vec<String>,
     pub whitelist: Vec<String>,
+    pub block_mode: String,
+    pub block_ttl: u32,
+}
+
+/// Converts the domain `BlockResponseMode` to its snake_case API string.
+pub fn block_mode_to_string(mode: ferrous_dns_domain::BlockResponseMode) -> String {
+    mode.as_str().to_string()
+}
+
+/// Parses an API block-mode string; unknown values fall back to the default
+/// (`NullIp`) rather than erroring, so a bad UI value can't break saving.
+pub fn block_mode_from_str(value: &str) -> ferrous_dns_domain::BlockResponseMode {
+    use ferrous_dns_domain::BlockResponseMode;
+    match value {
+        "nxdomain" => BlockResponseMode::NxDomain,
+        "nodata" => BlockResponseMode::NoData,
+        "refused" => BlockResponseMode::Refused,
+        _ => BlockResponseMode::NullIp,
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -201,6 +220,18 @@ pub struct BlockingConfigUpdate {
     pub enabled: Option<bool>,
     pub custom_blocked: Option<Vec<String>>,
     pub whitelist: Option<Vec<String>>,
+    pub block_mode: Option<String>,
+    pub block_ttl: Option<u32>,
+}
+
+fn default_block_mode() -> String {
+    ferrous_dns_domain::BlockResponseMode::default()
+        .as_str()
+        .to_string()
+}
+
+fn default_block_ttl() -> u32 {
+    ferrous_dns_domain::DEFAULT_BLOCK_TTL
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -214,6 +245,12 @@ pub struct SettingsDto {
 
     #[serde(default)]
     pub local_dns_server: String,
+
+    #[serde(default = "default_block_mode")]
+    pub block_mode: String,
+
+    #[serde(default = "default_block_ttl")]
+    pub block_ttl: u32,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -230,6 +267,8 @@ impl From<ConfigResponse> for SettingsDto {
             never_forward_reverse_lookups: config.dns.block_private_ptr,
             local_domain: config.dns.local_domain.unwrap_or_default(),
             local_dns_server: config.dns.local_dns_server.unwrap_or_default(),
+            block_mode: config.blocking.block_mode,
+            block_ttl: config.blocking.block_ttl,
         }
     }
 }

--- a/crates/api/src/handlers/config/get.rs
+++ b/crates/api/src/handlers/config/get.rs
@@ -105,6 +105,8 @@ pub async fn get_config(State(state): State<AppState>) -> Json<ConfigResponse> {
             enabled: config.blocking.enabled,
             custom_blocked: config.blocking.custom_blocked.clone(),
             whitelist: config.blocking.whitelist.clone(),
+            block_mode: crate::dto::config::block_mode_to_string(config.blocking.block_mode),
+            block_ttl: config.blocking.block_ttl,
         },
         logging: LoggingConfigResponse {
             level: config.logging.level.clone(),

--- a/crates/api/src/handlers/config/update.rs
+++ b/crates/api/src/handlers/config/update.rs
@@ -210,6 +210,12 @@ pub async fn update_config(
         if let Some(whitelist) = blocking_update.whitelist {
             new_config.blocking.whitelist = whitelist;
         }
+        if let Some(block_mode) = blocking_update.block_mode {
+            new_config.blocking.block_mode = crate::dto::config::block_mode_from_str(&block_mode);
+        }
+        if let Some(block_ttl) = blocking_update.block_ttl {
+            new_config.blocking.block_ttl = block_ttl;
+        }
     }
 
     if let Some(auth_update) = request.auth {
@@ -292,6 +298,8 @@ pub async fn update_settings(
     } else {
         Some(request.local_dns_server)
     };
+    new_config.blocking.block_mode = crate::dto::config::block_mode_from_str(&request.block_mode);
+    new_config.blocking.block_ttl = request.block_ttl;
 
     match state
         .config_file_persistence

--- a/crates/api/tests/block_mode_dto_test.rs
+++ b/crates/api/tests/block_mode_dto_test.rs
@@ -1,0 +1,20 @@
+use ferrous_dns_api::dto::config::{block_mode_from_str, block_mode_to_string};
+use ferrous_dns_domain::BlockResponseMode;
+
+#[test]
+fn block_mode_string_round_trips() {
+    for mode in [
+        BlockResponseMode::NullIp,
+        BlockResponseMode::NxDomain,
+        BlockResponseMode::NoData,
+        BlockResponseMode::Refused,
+    ] {
+        assert_eq!(block_mode_from_str(&block_mode_to_string(mode)), mode);
+    }
+}
+
+#[test]
+fn unknown_block_mode_falls_back_to_null_ip() {
+    assert_eq!(block_mode_from_str("bogus"), BlockResponseMode::NullIp);
+    assert_eq!(block_mode_from_str(""), BlockResponseMode::NullIp);
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,7 +6,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 use anyhow::Context;
 use clap::Parser;
 use ferrous_dns_domain::CliOverrides;
-use ferrous_dns_infrastructure::dns::server::DnsServerHandler;
+use ferrous_dns_infrastructure::dns::server::{BlockPolicy, DnsServerHandler};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -142,7 +142,11 @@ async fn async_main() -> anyhow::Result<()> {
     let handler_use_case = dns_services.handler_use_case;
     let tcp_conn_limiter = dns_services.tcp_conn_limiter;
     let dot_conn_limiter = dns_services.dot_conn_limiter;
-    let dns_handler = DnsServerHandler::new(handler_use_case.clone());
+    let block_policy = BlockPolicy {
+        mode: config.blocking.block_mode,
+        ttl: config.blocking.block_ttl,
+    };
+    let dns_handler = DnsServerHandler::new(handler_use_case.clone(), block_policy);
     let core_ids_for_dns = core_affinity::get_core_ids().unwrap_or_default();
     let num_dns_workers = core_ids_for_dns.len().max(1);
 
@@ -179,7 +183,10 @@ async fn async_main() -> anyhow::Result<()> {
                 "{}:{}",
                 config.server.bind_address, config.server.encrypted_dns.dot_port
             );
-            let dot_handler = Arc::new(DnsServerHandler::new(handler_use_case.clone()));
+            let dot_handler = Arc::new(DnsServerHandler::new(
+                handler_use_case.clone(),
+                block_policy,
+            ));
             tokio::spawn(async move {
                 if let Err(e) = server::start_dot_server(
                     dot_addr,
@@ -203,8 +210,10 @@ async fn async_main() -> anyhow::Result<()> {
                 let doh_addr: SocketAddr = format!("{}:{}", config.server.bind_address, doh_port)
                     .parse()
                     .context("Invalid DoH bind address")?;
-                let dedicated_doh_handler =
-                    Arc::new(DnsServerHandler::new(handler_use_case.clone()));
+                let dedicated_doh_handler = Arc::new(DnsServerHandler::new(
+                    handler_use_case.clone(),
+                    block_policy,
+                ));
                 tokio::spawn(async move {
                     if let Err(e) = server::start_doh_server(doh_addr, dedicated_doh_handler).await
                     {
@@ -214,7 +223,7 @@ async fn async_main() -> anyhow::Result<()> {
             }
             None
         } else {
-            tls_config.map(|_| Arc::new(DnsServerHandler::new(handler_use_case)))
+            tls_config.map(|_| Arc::new(DnsServerHandler::new(handler_use_case, block_policy)))
         }
     } else {
         None

--- a/crates/domain/src/config/blocking.rs
+++ b/crates/domain/src/config/blocking.rs
@@ -1,5 +1,47 @@
 use serde::{Deserialize, Serialize};
 
+/// How a blocked (or security-flagged) domain is answered on the wire.
+///
+/// The default, `NullIp`, returns a cacheable `NOERROR` answer pointing at the
+/// null address (`0.0.0.0` / `::`) so clients stop re-querying. `Refused` is the
+/// legacy behaviour and is non-cacheable (RFC 2308 §7), which causes clients to
+/// retry aggressively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockResponseMode {
+    /// `NOERROR` + `0.0.0.0` (A) / `::` (AAAA); NODATA for other record types.
+    #[default]
+    NullIp,
+    /// `NXDOMAIN`.
+    #[serde(rename = "nxdomain")]
+    NxDomain,
+    /// `NOERROR` with an empty answer section.
+    #[serde(rename = "nodata")]
+    NoData,
+    /// `REFUSED` (legacy, non-cacheable).
+    Refused,
+}
+
+impl BlockResponseMode {
+    /// The snake_case wire/config string for this mode (matches the serde rename).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BlockResponseMode::NullIp => "null_ip",
+            BlockResponseMode::NxDomain => "nxdomain",
+            BlockResponseMode::NoData => "nodata",
+            BlockResponseMode::Refused => "refused",
+        }
+    }
+}
+
+/// Default TTL (seconds) for blocked answers; shared as the single source of
+/// truth for the config default and the API DTO default.
+pub const DEFAULT_BLOCK_TTL: u32 = 60;
+
+fn default_block_ttl() -> u32 {
+    DEFAULT_BLOCK_TTL
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BlockingConfig {
     pub enabled: bool,
@@ -9,6 +51,12 @@ pub struct BlockingConfig {
 
     #[serde(default)]
     pub whitelist: Vec<String>,
+
+    #[serde(default)]
+    pub block_mode: BlockResponseMode,
+
+    #[serde(default = "default_block_ttl")]
+    pub block_ttl: u32,
 }
 
 impl Default for BlockingConfig {
@@ -17,6 +65,67 @@ impl Default for BlockingConfig {
             enabled: true,
             custom_blocked: vec![],
             whitelist: vec![],
+            block_mode: BlockResponseMode::default(),
+            block_ttl: default_block_ttl(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_mode_serializes_to_snake_case() {
+        for (mode, expected) in [
+            (BlockResponseMode::NullIp, "null_ip"),
+            (BlockResponseMode::NxDomain, "nxdomain"),
+            (BlockResponseMode::NoData, "nodata"),
+            (BlockResponseMode::Refused, "refused"),
+        ] {
+            let value = toml::Value::try_from(mode).unwrap();
+            assert_eq!(value.as_str(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn block_mode_deserializes_from_snake_case() {
+        for (text, expected) in [
+            ("null_ip", BlockResponseMode::NullIp),
+            ("nxdomain", BlockResponseMode::NxDomain),
+            ("nodata", BlockResponseMode::NoData),
+            ("refused", BlockResponseMode::Refused),
+        ] {
+            let config: BlockingConfig =
+                toml::from_str(&format!("enabled = true\nblock_mode = \"{text}\"")).unwrap();
+            assert_eq!(config.block_mode, expected);
+        }
+    }
+
+    #[test]
+    fn unknown_block_mode_errors() {
+        assert!(
+            toml::from_str::<BlockingConfig>("enabled = true\nblock_mode = \"bogus\"").is_err()
+        );
+    }
+
+    #[test]
+    fn defaults_are_null_ip_and_ttl_60() {
+        let config = BlockingConfig::default();
+        assert_eq!(config.block_mode, BlockResponseMode::NullIp);
+        assert_eq!(config.block_ttl, 60);
+    }
+
+    #[test]
+    fn missing_block_fields_fall_back_to_defaults() {
+        let config: BlockingConfig = toml::from_str("enabled = true").unwrap();
+        assert_eq!(config.block_mode, BlockResponseMode::NullIp);
+        assert_eq!(config.block_ttl, 60);
+    }
+
+    #[test]
+    fn custom_block_ttl_is_honoured() {
+        let config: BlockingConfig = toml::from_str("enabled = true\nblock_ttl = 300").unwrap();
+        assert_eq!(config.block_ttl, 300);
     }
 }

--- a/crates/domain/src/config/mod.rs
+++ b/crates/domain/src/config/mod.rs
@@ -19,7 +19,7 @@ pub mod upstream;
 pub mod web_tls;
 
 pub use auth::{AdminConfig, AuthConfig};
-pub use blocking::BlockingConfig;
+pub use blocking::{BlockResponseMode, BlockingConfig, DEFAULT_BLOCK_TTL};
 pub use database::DatabaseConfig;
 pub use dga_detection::{DgaDetectionAction, DgaDetectionConfig};
 pub use dns::DnsConfig;

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -11,11 +11,11 @@ pub use entities::schedule;
 pub use entities::whitelist;
 
 pub use config::{
-    AdminConfig, AuthConfig, CliOverrides, Config, ConfigError, DgaDetectionAction,
-    DgaDetectionConfig, DnsConfig, DnsCookiesConfig, EncryptedDnsConfig, HealthCheckConfig,
-    LocalDnsRecord, NxdomainHijackAction, NxdomainHijackConfig, RateLimitConfig,
+    AdminConfig, AuthConfig, BlockResponseMode, CliOverrides, Config, ConfigError,
+    DgaDetectionAction, DgaDetectionConfig, DnsConfig, DnsCookiesConfig, EncryptedDnsConfig,
+    HealthCheckConfig, LocalDnsRecord, NxdomainHijackAction, NxdomainHijackConfig, RateLimitConfig,
     ResponseIpFilterAction, ResponseIpFilterConfig, TunnelingAction, TunnelingDetectionConfig,
-    UpstreamPool, UpstreamStrategy,
+    UpstreamPool, UpstreamStrategy, DEFAULT_BLOCK_TTL,
 };
 pub use dns_record::{DnsRecord, RecordCategory, RecordType};
 pub use entities::api_token::ApiToken;

--- a/crates/infrastructure/src/dns/server.rs
+++ b/crates/infrastructure/src/dns/server.rs
@@ -2,7 +2,7 @@ use crate::dns::ede::{self, ExtendedDnsError};
 use crate::dns::forwarding::RecordTypeMapper;
 use bytes::Bytes;
 use ferrous_dns_application::use_cases::HandleDnsQueryUseCase;
-use ferrous_dns_domain::{DomainError, RecordType};
+use ferrous_dns_domain::{BlockResponseMode, DomainError, RecordType};
 use hickory_proto::op::{Edns, Message, MessageType, OpCode, ResponseCode};
 use hickory_proto::rr::rdata::opt::EdnsOption;
 use hickory_proto::rr::{RData, Record};
@@ -10,20 +10,35 @@ use hickory_proto::serialize::binary::{BinEncodable, BinEncoder};
 use hickory_server::authority::MessageResponseBuilder;
 use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
 use std::borrow::Cow;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use tracing::{debug, error, warn};
 
 const DEFAULT_TTL: u32 = 60;
 
+/// How domain-verdict blocks (blocklist, DGA, tunneling, C2 filter) are answered.
+///
+/// Snapshotted from `[blocking]` config at boot; applied to the wire response so
+/// blocked answers become cacheable (default `NullIp`) instead of the legacy,
+/// non-cacheable `REFUSED` that caused clients to retry aggressively.
+#[derive(Debug, Clone, Copy)]
+pub struct BlockPolicy {
+    pub mode: BlockResponseMode,
+    pub ttl: u32,
+}
+
 #[derive(Clone)]
 pub struct DnsServerHandler {
     use_case: Arc<HandleDnsQueryUseCase>,
+    block_policy: BlockPolicy,
 }
 
 impl DnsServerHandler {
-    pub fn new(use_case: Arc<HandleDnsQueryUseCase>) -> Self {
-        Self { use_case }
+    pub fn new(use_case: Arc<HandleDnsQueryUseCase>, block_policy: BlockPolicy) -> Self {
+        Self {
+            use_case,
+            block_policy,
+        }
     }
 
     /// Normalizes a domain received from Hickory for downstream use: strips the
@@ -98,8 +113,17 @@ impl DnsServerHandler {
             Err(ref e @ DomainError::Blocked)
             | Err(ref e @ DomainError::DgaDomainDetected)
             | Err(ref e @ DomainError::DnsTunnelingDetected)
-            | Err(ref e @ DomainError::DnsRateLimited)
             | Err(ref e @ DomainError::FilteredQuery(_)) => {
+                return build_blocked_wire(
+                    query_id,
+                    rd,
+                    &queries,
+                    self.block_policy,
+                    has_edns,
+                    ede::from_domain_error(e),
+                )
+            }
+            Err(ref e @ DomainError::DnsRateLimited) => {
                 return build_error_wire(
                     query_id,
                     rd,
@@ -296,20 +320,24 @@ impl RequestHandler for DnsServerHandler {
             Ok(res) => res,
             Err(ref e @ DomainError::Blocked) => {
                 warn!(domain = %domain_ref, "Domain blocked");
-                return send_error_response(
+                return send_blocked_response(
                     request,
                     &mut response_handle,
-                    ResponseCode::Refused,
+                    query.name().clone().into(),
+                    hickory_record_type,
+                    self.block_policy,
                     ede::from_domain_error(e),
                 )
                 .await;
             }
             Err(ref e @ DomainError::DnsTunnelingDetected) => {
                 debug!(domain = %domain_ref, client = %client_ip, "DNS tunneling detected");
-                return send_error_response(
+                return send_blocked_response(
                     request,
                     &mut response_handle,
-                    ResponseCode::Refused,
+                    query.name().clone().into(),
+                    hickory_record_type,
+                    self.block_policy,
                     ede::from_domain_error(e),
                 )
                 .await;
@@ -326,20 +354,24 @@ impl RequestHandler for DnsServerHandler {
             }
             Err(ref e @ DomainError::DgaDomainDetected) => {
                 debug!(domain = %domain_ref, client = %client_ip, "DGA domain detected");
-                return send_error_response(
+                return send_blocked_response(
                     request,
                     &mut response_handle,
-                    ResponseCode::Refused,
+                    query.name().clone().into(),
+                    hickory_record_type,
+                    self.block_policy,
                     ede::from_domain_error(e),
                 )
                 .await;
             }
             Err(ref e @ DomainError::FilteredQuery(ref reason)) => {
                 debug!(domain = %domain_ref, reason = %reason, "Query filtered by policy");
-                return send_error_response(
+                return send_blocked_response(
                     request,
                     &mut response_handle,
-                    ResponseCode::Refused,
+                    query.name().clone().into(),
+                    hickory_record_type,
+                    self.block_policy,
                     ede::from_domain_error(e),
                 )
                 .await;
@@ -504,6 +536,114 @@ fn build_error_wire(
     encode_message(&resp)
 }
 
+/// Synthesizes a minimal SOA record for the authority section of a negative
+/// block answer (NXDOMAIN / NODATA), so resolvers can negatively cache it per
+/// RFC 2308. The record TTL and the SOA `minimum` field are both set to the
+/// block TTL, which bounds how long the negative answer is cached. `owner` is
+/// the queried name; resolvers key the negative cache off the SOA `minimum`, so
+/// an exact zone apex is not required for the synthetic answer.
+fn synthetic_block_soa(owner: hickory_proto::rr::Name, ttl: u32) -> Record {
+    use hickory_proto::rr::rdata::SOA;
+    let rname = hickory_proto::rr::Name::from_ascii("hostmaster.ferrous-dns.invalid.")
+        .unwrap_or_else(|_| hickory_proto::rr::Name::root());
+    let soa = SOA::new(
+        owner.clone(), // mname
+        rname,         // rname
+        1,             // serial
+        3600,          // refresh
+        600,           // retry
+        604800,        // expire
+        ttl,           // minimum — bounds the negative-cache TTL (RFC 2308)
+    );
+    Record::from_rdata(owner, ttl, RData::SOA(soa))
+}
+
+/// Builds the wire response for a domain-verdict block (raw UDP fast path),
+/// honouring the configured [`BlockPolicy`]. `NullIp` synthesizes a cacheable
+/// `0.0.0.0`/`::` answer (NODATA for non-A/AAAA queries); other modes set the
+/// matching response code with an empty answer section. Negative answers
+/// (NXDOMAIN / NODATA) carry a synthetic SOA so they can be negatively cached.
+/// `Refused` delegates to [`build_error_wire`] for the legacy behaviour.
+pub fn build_blocked_wire(
+    id: u16,
+    rd: bool,
+    queries: &[hickory_proto::op::Query],
+    policy: BlockPolicy,
+    has_edns: bool,
+    ede: Option<ExtendedDnsError>,
+) -> Option<Vec<u8>> {
+    use hickory_proto::rr::RecordType;
+
+    if let BlockResponseMode::Refused = policy.mode {
+        return build_error_wire(id, rd, queries, ResponseCode::Refused, has_edns, ede);
+    }
+
+    let mut resp = Message::new(id, MessageType::Response, OpCode::Query);
+    resp.set_recursion_desired(rd);
+    resp.set_recursion_available(true);
+    for q in queries {
+        resp.add_query(q.clone());
+    }
+
+    // True once we've emitted a positive answer; otherwise the response is a
+    // negative answer (NXDOMAIN / NODATA) that should carry a synthetic SOA.
+    let mut answered = false;
+
+    match policy.mode {
+        BlockResponseMode::NxDomain => {
+            resp.set_response_code(ResponseCode::NXDomain);
+        }
+        BlockResponseMode::NoData => {
+            resp.set_response_code(ResponseCode::NoError);
+        }
+        BlockResponseMode::NullIp => {
+            resp.set_response_code(ResponseCode::NoError);
+            if let Some(q) = queries.first() {
+                let rdata = match q.query_type() {
+                    RecordType::A => {
+                        Some(RData::A(hickory_proto::rr::rdata::A(Ipv4Addr::UNSPECIFIED)))
+                    }
+                    RecordType::AAAA => Some(RData::AAAA(hickory_proto::rr::rdata::AAAA(
+                        Ipv6Addr::UNSPECIFIED,
+                    ))),
+                    // Other record types: NODATA (NOERROR, empty answer).
+                    _ => None,
+                };
+                if let Some(rdata) = rdata {
+                    resp.add_answer(Record::from_rdata(q.name().clone(), policy.ttl, rdata));
+                    answered = true;
+                }
+            }
+        }
+        // Handled above.
+        BlockResponseMode::Refused => unreachable!(),
+    }
+
+    if !answered {
+        if let Some(q) = queries.first() {
+            resp.add_name_server(synthetic_block_soa(q.name().clone(), policy.ttl));
+        }
+    }
+
+    if has_edns {
+        let mut edns = Edns::new();
+        edns.set_max_payload(4096);
+        edns.set_version(0);
+        if let Some(ede) = ede {
+            let mut data = Vec::with_capacity(2);
+            data.extend_from_slice(&ede.info_code.to_be_bytes());
+            if let Some(text) = ede.extra_text {
+                data.extend_from_slice(text.as_bytes());
+            }
+            edns.options_mut()
+                .insert(EdnsOption::Unknown(ede::OPTION_CODE, data));
+        }
+        resp.set_edns(edns);
+    }
+
+    encode_message(&resp)
+}
+
 fn build_truncated_wire(
     id: u16,
     rd: bool,
@@ -518,6 +658,87 @@ fn build_truncated_wire(
         resp.add_query(q.clone());
     }
     encode_message(&resp)
+}
+
+/// Sends the response for a domain-verdict block (hickory `RequestHandler`
+/// path), honouring the configured [`BlockPolicy`]. Mirrors [`build_blocked_wire`]:
+/// `NullIp` emits a cacheable `0.0.0.0`/`::` answer (NODATA for non-A/AAAA),
+/// other modes set the response code with an empty answer; negative answers
+/// (NXDOMAIN / NODATA) carry a synthetic SOA for negative caching. `Refused`
+/// delegates to [`send_error_response`].
+pub async fn send_blocked_response<R: ResponseHandler>(
+    request: &Request,
+    response_handle: &mut R,
+    record_name: hickory_proto::rr::Name,
+    query_type: hickory_proto::rr::RecordType,
+    policy: BlockPolicy,
+    ede: Option<ExtendedDnsError>,
+) -> ResponseInfo {
+    use hickory_proto::rr::RecordType;
+
+    let (code, answers): (ResponseCode, Vec<Record>) = match policy.mode {
+        BlockResponseMode::Refused => {
+            return send_error_response(request, response_handle, ResponseCode::Refused, ede).await;
+        }
+        BlockResponseMode::NxDomain => (ResponseCode::NXDomain, Vec::new()),
+        BlockResponseMode::NoData => (ResponseCode::NoError, Vec::new()),
+        BlockResponseMode::NullIp => {
+            let rdata = match query_type {
+                RecordType::A => Some(RData::A(hickory_proto::rr::rdata::A(Ipv4Addr::UNSPECIFIED))),
+                RecordType::AAAA => Some(RData::AAAA(hickory_proto::rr::rdata::AAAA(
+                    Ipv6Addr::UNSPECIFIED,
+                ))),
+                // Other record types: NODATA (NOERROR, empty answer).
+                _ => None,
+            };
+            let answers = rdata
+                .map(|rdata| vec![Record::from_rdata(record_name.clone(), policy.ttl, rdata)])
+                .unwrap_or_default();
+            (ResponseCode::NoError, answers)
+        }
+    };
+
+    // Negative answer (no positive record) carries a synthetic SOA so the
+    // verdict can be negatively cached (RFC 2308).
+    let authority: Vec<Record> = if answers.is_empty() {
+        vec![synthetic_block_soa(record_name, policy.ttl)]
+    } else {
+        Vec::new()
+    };
+
+    debug!(code = ?code, answers = answers.len(), "Sending blocked response");
+    let mut builder = MessageResponseBuilder::from_message_request(request);
+    let mut header = *request.header();
+    header.set_message_type(MessageType::Response);
+    header.set_response_code(code);
+    header.set_recursion_available(true);
+
+    // Echo an EDNS OPT whenever the query carried one (matches build_blocked_wire),
+    // attaching the EDE option when present.
+    if request.edns().is_some() {
+        let mut edns = Edns::new();
+        edns.set_max_payload(4096);
+        edns.set_version(0);
+        if let Some(ede) = ede {
+            let mut data = Vec::with_capacity(2);
+            data.extend_from_slice(&ede.info_code.to_be_bytes());
+            if let Some(text) = ede.extra_text {
+                data.extend_from_slice(text.as_bytes());
+            }
+            edns.options_mut()
+                .insert(EdnsOption::Unknown(ede::OPTION_CODE, data));
+        }
+        builder.edns(edns);
+    }
+
+    let response = builder.build(header, answers.iter(), &[], authority.iter(), &[]);
+    match response_handle.send_response(response).await {
+        Ok(info) => info,
+        Err(e) => {
+            error!(error = %e, "Failed to send blocked response");
+            ResponseInfo::from(*request.header())
+        }
+    }
 }
 
 async fn send_truncated_response<R: ResponseHandler>(

--- a/crates/infrastructure/src/repositories/config_persistence.rs
+++ b/crates/infrastructure/src/repositories/config_persistence.rs
@@ -374,6 +374,16 @@ pub fn save_config_to_file(config: &Config, path: &str) -> Result<(), ConfigErro
             str_array(&config.blocking.custom_blocked),
         );
         set_val(t, "whitelist", str_array(&config.blocking.whitelist));
+        set_val(
+            t,
+            "block_mode",
+            toml_edit::Value::from(config.blocking.block_mode.as_str()),
+        );
+        set_val(
+            t,
+            "block_ttl",
+            toml_edit::Value::from(config.blocking.block_ttl as i64),
+        );
     }
 
     // ── [logging] ───────────────────────────────────────────────────────

--- a/crates/infrastructure/tests/block_response_test.rs
+++ b/crates/infrastructure/tests/block_response_test.rs
@@ -1,0 +1,279 @@
+//! Integration tests for the domain-verdict block responders. Exercises both
+//! the raw UDP fast path (`build_blocked_wire`) and the hickory `RequestHandler`
+//! path (`send_blocked_response`) for every `BlockResponseMode`.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use ferrous_dns_domain::{BlockResponseMode, DomainError};
+use ferrous_dns_infrastructure::dns::ede;
+use ferrous_dns_infrastructure::dns::server::{
+    build_blocked_wire, send_blocked_response, BlockPolicy,
+};
+use hickory_proto::op::{Edns, Message, MessageType, OpCode, Query, ResponseCode};
+use hickory_proto::rr::{Name, RData, Record, RecordType};
+use hickory_proto::serialize::binary::{BinDecodable, BinEncoder};
+use hickory_proto::xfer::Protocol;
+use hickory_server::authority::{MessageRequest, MessageResponse};
+use hickory_server::server::{Request, ResponseHandler, ResponseInfo};
+use std::io;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+
+const TTL: u32 = 120;
+
+fn name() -> Name {
+    Name::from_str("ads.example.com.").unwrap()
+}
+
+fn query(record_type: RecordType) -> Query {
+    Query::query(name(), record_type)
+}
+
+fn policy(mode: BlockResponseMode) -> BlockPolicy {
+    BlockPolicy { mode, ttl: TTL }
+}
+
+/// Asserts the authority section carries exactly one synthetic SOA with the
+/// block TTL (so the negative answer is negatively cacheable, RFC 2308).
+fn assert_soa(msg: &Message) {
+    assert_eq!(msg.name_servers().len(), 1, "expected one SOA in authority");
+    let soa = &msg.name_servers()[0];
+    assert_eq!(soa.ttl(), TTL);
+    match soa.data() {
+        RData::SOA(record) => assert_eq!(record.minimum(), TTL),
+        other => panic!("expected SOA in authority, got {other:?}"),
+    }
+}
+
+// ── UDP fast path: build_blocked_wire ────────────────────────────────────
+
+fn decode(mode: BlockResponseMode, record_type: RecordType) -> Message {
+    let wire = build_blocked_wire(
+        0x1234,
+        true,
+        &[query(record_type)],
+        policy(mode),
+        false,
+        None,
+    )
+    .expect("wire bytes");
+    Message::from_vec(&wire).expect("valid DNS message")
+}
+
+#[test]
+fn null_ip_a_query_returns_unspecified_v4_with_ttl() {
+    let msg = decode(BlockResponseMode::NullIp, RecordType::A);
+    assert_eq!(msg.response_code(), ResponseCode::NoError);
+    assert_eq!(msg.answers().len(), 1);
+    // Positive answer ⇒ no synthetic SOA.
+    assert_eq!(msg.name_servers().len(), 0);
+    let answer = &msg.answers()[0];
+    assert_eq!(answer.ttl(), TTL);
+    match answer.data() {
+        RData::A(a) => assert_eq!(a.0, Ipv4Addr::UNSPECIFIED),
+        other => panic!("expected A 0.0.0.0, got {other:?}"),
+    }
+}
+
+#[test]
+fn null_ip_aaaa_query_returns_unspecified_v6_with_ttl() {
+    let msg = decode(BlockResponseMode::NullIp, RecordType::AAAA);
+    assert_eq!(msg.response_code(), ResponseCode::NoError);
+    assert_eq!(msg.answers().len(), 1);
+    assert_eq!(msg.name_servers().len(), 0);
+    let answer = &msg.answers()[0];
+    assert_eq!(answer.ttl(), TTL);
+    match answer.data() {
+        RData::AAAA(aaaa) => assert_eq!(aaaa.0, Ipv6Addr::UNSPECIFIED),
+        other => panic!("expected AAAA ::, got {other:?}"),
+    }
+}
+
+#[test]
+fn null_ip_non_address_query_is_nodata_with_soa() {
+    let msg = decode(BlockResponseMode::NullIp, RecordType::MX);
+    assert_eq!(msg.response_code(), ResponseCode::NoError);
+    assert_eq!(msg.answers().len(), 0);
+    assert_soa(&msg);
+}
+
+#[test]
+fn nxdomain_mode_sets_nxdomain_with_soa_and_no_answer() {
+    let msg = decode(BlockResponseMode::NxDomain, RecordType::A);
+    assert_eq!(msg.response_code(), ResponseCode::NXDomain);
+    assert_eq!(msg.answers().len(), 0);
+    assert_soa(&msg);
+}
+
+#[test]
+fn nodata_mode_sets_noerror_with_soa_and_no_answer() {
+    let msg = decode(BlockResponseMode::NoData, RecordType::A);
+    assert_eq!(msg.response_code(), ResponseCode::NoError);
+    assert_eq!(msg.answers().len(), 0);
+    assert_soa(&msg);
+}
+
+#[test]
+fn refused_mode_sets_refused_with_no_answer() {
+    let msg = decode(BlockResponseMode::Refused, RecordType::A);
+    assert_eq!(msg.response_code(), ResponseCode::Refused);
+    assert_eq!(msg.answers().len(), 0);
+    assert_eq!(msg.name_servers().len(), 0);
+}
+
+#[test]
+fn edns_request_gets_edns_response_with_ede() {
+    let ede = ede::from_domain_error(&DomainError::Blocked);
+    let wire = build_blocked_wire(
+        0x1234,
+        true,
+        &[query(RecordType::A)],
+        policy(BlockResponseMode::NullIp),
+        true,
+        ede,
+    )
+    .expect("wire bytes");
+    let msg = Message::from_vec(&wire).expect("valid DNS message");
+    assert!(
+        msg.extensions().is_some(),
+        "EDNS OPT (carrying the EDE) should be present"
+    );
+}
+
+// ── RequestHandler path: send_blocked_response ───────────────────────────
+
+/// A `ResponseHandler` that captures the serialized wire response so the
+/// hickory `RequestHandler` block path can be inspected in-process.
+#[derive(Clone, Default)]
+struct CapturingHandler {
+    captured: Arc<Mutex<Option<Vec<u8>>>>,
+}
+
+impl CapturingHandler {
+    fn decoded(&self) -> Message {
+        let guard = self.captured.lock().unwrap();
+        let bytes = guard.as_ref().expect("a response was sent");
+        Message::from_vec(bytes).expect("valid DNS message")
+    }
+}
+
+#[async_trait]
+impl ResponseHandler for CapturingHandler {
+    async fn send_response<'a>(
+        &mut self,
+        response: MessageResponse<
+            '_,
+            'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+            impl Iterator<Item = &'a Record> + Send + 'a,
+        >,
+    ) -> io::Result<ResponseInfo> {
+        let mut buf = Vec::new();
+        let info = {
+            let mut encoder = BinEncoder::new(&mut buf);
+            response
+                .destructive_emit(&mut encoder)
+                .map_err(io::Error::other)?
+        };
+        *self.captured.lock().unwrap() = Some(buf);
+        Ok(info)
+    }
+}
+
+fn make_request(query_type: RecordType, with_edns: bool) -> Request {
+    let mut msg = Message::new(0xBEEF, MessageType::Query, OpCode::Query);
+    msg.add_query(query(query_type));
+    msg.set_recursion_desired(true);
+    if with_edns {
+        let mut edns = Edns::new();
+        edns.set_version(0);
+        edns.set_max_payload(4096);
+        msg.set_edns(edns);
+    }
+    let bytes = msg.to_vec().expect("encoded query");
+    let raw = Bytes::from(bytes.clone());
+    let req_msg = MessageRequest::from_bytes(&bytes).expect("valid message request");
+    let src = "127.0.0.1:5353".parse().unwrap();
+    Request::new(req_msg, raw, src, Protocol::Udp)
+}
+
+async fn send(mode: BlockResponseMode, query_type: RecordType, with_edns: bool) -> Message {
+    let request = make_request(query_type, with_edns);
+    let mut handler = CapturingHandler::default();
+    let ede = ede::from_domain_error(&DomainError::Blocked);
+    let _ = send_blocked_response(
+        &request,
+        &mut handler,
+        name(),
+        query_type,
+        policy(mode),
+        ede,
+    )
+    .await;
+    handler.decoded()
+}
+
+#[tokio::test]
+async fn send_null_ip_a_returns_unspecified_v4() {
+    let msg = send(BlockResponseMode::NullIp, RecordType::A, false).await;
+    assert_eq!(msg.response_code(), ResponseCode::NoError);
+    assert_eq!(msg.answers().len(), 1);
+    assert_eq!(msg.name_servers().len(), 0);
+    match msg.answers()[0].data() {
+        RData::A(a) => assert_eq!(a.0, Ipv4Addr::UNSPECIFIED),
+        other => panic!("expected A 0.0.0.0, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn send_null_ip_non_address_is_nodata_with_soa() {
+    let msg = send(BlockResponseMode::NullIp, RecordType::MX, false).await;
+    assert_eq!(msg.response_code(), ResponseCode::NoError);
+    assert_eq!(msg.answers().len(), 0);
+    assert_soa(&msg);
+}
+
+#[tokio::test]
+async fn send_nxdomain_has_soa_and_no_answer() {
+    let msg = send(BlockResponseMode::NxDomain, RecordType::A, false).await;
+    assert_eq!(msg.response_code(), ResponseCode::NXDomain);
+    assert_eq!(msg.answers().len(), 0);
+    assert_soa(&msg);
+}
+
+#[tokio::test]
+async fn send_nodata_has_soa_and_no_answer() {
+    let msg = send(BlockResponseMode::NoData, RecordType::A, false).await;
+    assert_eq!(msg.response_code(), ResponseCode::NoError);
+    assert_eq!(msg.answers().len(), 0);
+    assert_soa(&msg);
+}
+
+#[tokio::test]
+async fn send_refused_delegates_to_error_response() {
+    let msg = send(BlockResponseMode::Refused, RecordType::A, false).await;
+    assert_eq!(msg.response_code(), ResponseCode::Refused);
+    assert_eq!(msg.answers().len(), 0);
+    assert_eq!(msg.name_servers().len(), 0);
+}
+
+#[tokio::test]
+async fn send_edns_request_gets_edns_response() {
+    let msg = send(BlockResponseMode::NullIp, RecordType::A, true).await;
+    assert!(
+        msg.extensions().is_some(),
+        "EDNS OPT should be echoed when the query carried one"
+    );
+}
+
+#[tokio::test]
+async fn send_non_edns_request_gets_no_edns() {
+    let msg = send(BlockResponseMode::NullIp, RecordType::A, false).await;
+    assert!(
+        msg.extensions().is_none(),
+        "no EDNS OPT should be added when the query lacked one"
+    );
+}

--- a/crates/infrastructure/tests/config_persistence_tests.rs
+++ b/crates/infrastructure/tests/config_persistence_tests.rs
@@ -440,6 +440,35 @@ fn test_save_preserves_inline_comments() {
     );
 }
 
+// ── Block response mode roundtrip ────────────────────────────────────────
+
+#[test]
+fn test_save_and_reload_preserves_block_mode_and_ttl() {
+    use ferrous_dns_domain::BlockResponseMode;
+
+    // Original file has no block_mode/block_ttl keys at all — they must be
+    // written on save and survive a reload.
+    let mut config = load_config(default_config_toml());
+    config.blocking.block_mode = BlockResponseMode::NxDomain;
+    config.blocking.block_ttl = 300;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("block_mode_roundtrip.toml");
+    std::fs::write(&path, default_config_toml()).unwrap();
+
+    save_config_to_file(&config, path.to_str().unwrap()).unwrap();
+
+    let written = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        written.contains("block_mode = \"nxdomain\""),
+        "block_mode should be written to the TOML, got:\n{written}"
+    );
+
+    let reloaded = Config::load(Some(path.to_str().unwrap()), Default::default()).unwrap();
+    assert_eq!(reloaded.blocking.block_mode, BlockResponseMode::NxDomain);
+    assert_eq!(reloaded.blocking.block_ttl, 300);
+}
+
 // ── Error handling ───────────────────────────────────────────────────────
 
 #[test]

--- a/docs/configuration/blocking.md
+++ b/docs/configuration/blocking.md
@@ -11,6 +11,8 @@ The `[blocking]` section controls the base blocking settings. Blocklists, client
 enabled = true
 custom_blocked = []
 whitelist = []
+block_mode = "null_ip"
+block_ttl = 60
 ```
 
 | Option | Default | Description |
@@ -18,6 +20,8 @@ whitelist = []
 | `enabled` | `true` | Enable DNS-based blocking globally |
 | `custom_blocked` | `[]` | Additional domains to block beyond downloaded blocklists |
 | `whitelist` | `[]` | Domains to always allow, even if present in a blocklist |
+| `block_mode` | `"null_ip"` | How blocked domains are answered on the wire — see [Block Response Mode](#block-response-mode) |
+| `block_ttl` | `60` | TTL (seconds) clients cache a blocked answer; also bounds the negative-cache lifetime for `nxdomain`/`nodata` |
 
 ### Example
 
@@ -33,6 +37,33 @@ whitelist = [
     "cdn.trusted.net",
 ]
 ```
+
+---
+
+## Block Response Mode
+
+`block_mode` controls **how** a blocked domain is answered — this applies to every domain-verdict block (blocklist match, DGA detection, DNS tunneling, and the C2/threat filter). The choice affects how clients behave after a block: a cacheable answer makes them stop re-querying, while a non-cacheable rejection makes them retry aggressively.
+
+| Mode | Response | Cacheable | Notes |
+|:-----|:---------|:----------|:------|
+| `null_ip` | `NOERROR` + `0.0.0.0` (A) / `::` (AAAA); `NODATA` for other types | Yes | **Default, recommended.** Clients connect to the null address and fail fast. |
+| `nxdomain` | `NXDOMAIN` with a synthetic SOA | Yes | The domain appears not to exist. Some clients log noisy errors. |
+| `nodata` | `NOERROR`, empty answer, with a synthetic SOA | Yes | The name exists but has no records of the requested type. |
+| `refused` | `REFUSED` | No | Legacy behaviour. Clients retry aggressively — avoid unless required. |
+
+For the negative modes (`nxdomain`, `nodata`, and `null_ip` answering a non-address query), Ferrous DNS attaches a synthetic `SOA` record to the authority section. Its `minimum` field is set to `block_ttl`, which lets downstream resolvers negatively cache the block per [RFC 2308](https://www.rfc-editor.org/rfc/rfc2308).
+
+```toml
+[blocking]
+block_mode = "null_ip"   # null_ip | nxdomain | nodata | refused
+block_ttl  = 60          # seconds clients/resolvers cache the blocked answer
+```
+
+!!! tip "Why `null_ip` is the default"
+    A cacheable `0.0.0.0` answer is the gentlest on both the client and the resolver: the client gets an immediate connection failure and caches it for `block_ttl`, so it stops hammering the resolver. `refused` is non-cacheable (RFC 2308 §7), so clients re-query on every attempt.
+
+!!! warning "Requires a restart"
+    `block_mode` and `block_ttl` are read once at startup. Changing them in the config file or via the dashboard takes effect only after the server is restarted. Blocklist contents (the domains themselves) still update live without a restart.
 
 ---
 

--- a/docs/configuration/ferrous-dns-toml.md
+++ b/docs/configuration/ferrous-dns-toml.md
@@ -562,6 +562,8 @@ DNS-based ad and malware blocking using downloaded blocklists. Blocklists are ma
 enabled        = true
 custom_blocked = []
 whitelist      = []
+block_mode     = "null_ip"
+block_ttl      = 60
 ```
 
 | Option | Type | Default | Description |
@@ -569,6 +571,11 @@ whitelist      = []
 | `enabled` | `bool` | `true` | Enable DNS blocking globally |
 | `custom_blocked` | `list` | `[]` | Additional domains to block beyond any active blocklists |
 | `whitelist` | `list` | `[]` | Domains that are always allowed, even if present in a blocklist |
+| `block_mode` | `string` | `"null_ip"` | How blocked domains are answered: `null_ip` (cacheable `0.0.0.0`/`::`, recommended), `nxdomain`, `nodata`, or `refused` (legacy, non-cacheable) |
+| `block_ttl` | `int` | `60` | TTL in seconds clients/resolvers cache a blocked answer; also drives the synthetic SOA `minimum` for `nxdomain`/`nodata` |
+
+!!! note "Restart required"
+    `block_mode` and `block_ttl` are applied at startup; changing them needs a server restart. See [Block Response Mode](blocking.md#block-response-mode) for what each mode returns.
 
 See [Blocking & Filtering](../features/blocking-filtering.md).
 

--- a/docs/features/blocking-filtering.md
+++ b/docs/features/blocking-filtering.md
@@ -18,7 +18,7 @@ Query: ads.doubleclick.net
   2. Quick pre-check ──────► definitely not blocked? → skip lookup
          │ possible match
          ▼
-  3. Exact domain match ─► in blocklist? → BLOCK (NXDOMAIN)
+  3. Exact domain match ─► in blocklist? → BLOCK
          │ no
          ▼
   4. Wildcard match ────► matches *.ads.com? → BLOCK
@@ -197,8 +197,13 @@ Changes take effect immediately without a restart.
 
 ## Blocking Response
 
-When a query is blocked, Ferrous DNS returns:
+How a blocked query is answered is controlled by the `block_mode` setting (dashboard: **Settings > DNS > Blocked query response**, or the `[blocking]` config section). The default is **Null IP**, which returns a cacheable `0.0.0.0`/`::` answer so clients fail fast and stop re-querying.
 
-- `NXDOMAIN` — domain does not exist (standard behavior, compatible with all clients)
+| Mode | Response |
+|:-----|:---------|
+| `null_ip` *(default)* | `NOERROR` + `0.0.0.0` (A) / `::` (AAAA); `NODATA` for other types |
+| `nxdomain` | `NXDOMAIN` (domain appears not to exist) |
+| `nodata` | `NOERROR` with an empty answer |
+| `refused` | `REFUSED` (legacy, non-cacheable) |
 
-Some deployments prefer returning `0.0.0.0` (A record) to prevent connection timeouts. This can be configured in the dashboard under **Settings > Blocking Response**.
+Negative responses include a synthetic `SOA` so resolvers can negatively cache the block for `block_ttl` seconds. See [Block Response Mode](../configuration/blocking.md#block-response-mode) for the full reference and the restart caveat.

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -262,6 +262,9 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$9pNep2fexSNQtaie80I/Mg$T9qgw7GKO
 enabled = true                          # Enable DNS-based ad/malware blocking
 custom_blocked = []                     # Additional domains to block (beyond downloaded blocklists)
 whitelist = []                          # Domains to always allow, even if present in a blocklist
+block_mode = "null_ip"                  # How blocked domains are answered: "null_ip" (NOERROR + 0.0.0.0/::,
+                                        #   cacheable — recommended), "nxdomain", "nodata", or "refused" (legacy)
+block_ttl = 60                          # TTL (seconds) clients cache the null-IP block answer
 
 
 # ── Logging ───────────────────────────────────────────────────────────────────

--- a/web/static/settings.html
+++ b/web/static/settings.html
@@ -454,6 +454,31 @@
                     </div>
                 </div>
             </div>
+
+            <div style="padding:16px 0;border-top:1px solid var(--border-color)">
+                <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+                    <i data-lucide="shield-x" style="width:20px;height:20px;color:var(--color-primary)"></i>
+                    <h4 style="font-size:16px;font-weight:600;margin:0">Blocked query response</h4>
+                </div>
+                <p style="font-size:13px;color:var(--text-secondary);margin:0 0 16px">How blocked domains (blocklist, DGA, tunneling, C2) are answered. <b>Null IP</b> returns a cacheable <code style="padding:1px 4px;background:var(--bg-tertiary);border-radius:3px">0.0.0.0</code>/<code style="padding:1px 4px;background:var(--bg-tertiary);border-radius:3px">::</code> so clients stop re-querying — recommended. <code style="padding:1px 4px;background:var(--bg-tertiary);border-radius:3px">REFUSED</code> is the legacy mode and makes clients retry aggressively.</p>
+                <div style="display:flex;gap:24px;flex-wrap:wrap">
+                    <div class="form-group" style="margin-bottom:0">
+                        <label class="form-label">Response mode</label>
+                        <select x-model="settings.block_mode" style="width:360px;max-width:100%">
+                            <option value="null_ip">Null IP (0.0.0.0 / ::) — recommended</option>
+                            <option value="nxdomain">NXDOMAIN</option>
+                            <option value="nodata">NODATA</option>
+                            <option value="refused">REFUSED (legacy)</option>
+                        </select>
+                    </div>
+                    <div class="form-group" style="margin-bottom:0">
+                        <label class="form-label">Block TTL (seconds)</label>
+                        <input type="number" min="1" x-model.number="settings.block_ttl" placeholder="60"
+                               style="max-width:160px;font-family:monospace">
+                        <p style="font-size:11px;color:var(--text-tertiary);margin-top:4px">How long clients cache the Null IP answer.</p>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <button @click="saveDnsSettings()" class="btn btn-success">

--- a/web/static/settings.js
+++ b/web/static/settings.js
@@ -35,7 +35,9 @@
                 never_forward_non_fqdn: false,
                 never_forward_reverse_lookups: false,
                 local_domain: '',
-                local_dns_server: ''
+                local_dns_server: '',
+                block_mode: 'null_ip',
+                block_ttl: 60
             },
             cacheStats: {total_entries: 0, hit_rate: 0, total_hits: 0, total_misses: 0},
             healthStatus: {},


### PR DESCRIPTION
Add a `block_mode` setting that controls how domain-verdict blocks (blocklist, DGA, tunneling, C2 filter) are answered on the wire:

- null_ip (default): cacheable NOERROR + 0.0.0.0/:: (NODATA for other record types) so clients stop re-querying
- nxdomain / nodata: cacheable negative answers carrying a synthetic SOA whose minimum = block_ttl for RFC 2308 negative caching
- refused: legacy non-cacheable behaviour

Applied on both the raw UDP fast path (build_blocked_wire) and the hickory RequestHandler path (send_blocked_response), with EDNS/EDE echoed when the query carried EDNS. DnsRateLimited stays REFUSED. New `block_ttl` config (default 60s) drives both the answer TTL and the SOA minimum; BlockPolicy is snapshotted at boot (restart required to change).

Wired through the domain config, REST API DTOs, config persistence, the settings UI, and the sample ferrous-dns.toml. Tests live in the crate tests/ folders; docs updated under docs/configuration and docs/features.