### PR TITLE
feat - show server version above logout in sidebar

### DIFF
--- a/crates/cli/src/server/web.rs
+++ b/crates/cli/src/server/web.rs
@@ -218,7 +218,8 @@ fn create_app(
     app
 }
 
-/// Returns a small JS snippet that sets `window.FERROUS_API_BASE` at runtime.
+/// Returns a small JS snippet that sets `window.FERROUS_API_BASE` and
+/// `window.FERROUS_VERSION` at runtime.
 ///
 /// The HTMLs are compiled into the binary via `include_str!` and cannot be
 /// patched at runtime, so the frontend discovers the correct API prefix here.
@@ -231,7 +232,9 @@ async fn ferrous_config_js_handler(State(pihole_compat): State<bool>) -> impl In
     } else {
         "/api"
     };
-    let body = format!(r#"window.FERROUS_API_BASE = "{api_base}";"#);
+    let version = env!("CARGO_PKG_VERSION");
+    let body =
+        format!(r#"window.FERROUS_API_BASE = "{api_base}";window.FERROUS_VERSION = "{version}";"#);
     (
         [(
             header::CONTENT_TYPE,

--- a/web/static/block-services.html
+++ b/web/static/block-services.html
@@ -55,6 +55,7 @@
         </div>
     </nav>
     <div style="padding:12px 16px;border-top:1px solid var(--border-color)">
+        <div id="server-version" style="font-size:11px;color:var(--text-tertiary);padding:0 8px 8px"></div>
         <a href="#" onclick="logout();return false" class="nav-item" style="color:var(--text-secondary)">
             <i data-lucide="log-out" class="nav-icon"></i><span>Logout</span>
         </a>

--- a/web/static/clients.html
+++ b/web/static/clients.html
@@ -96,6 +96,7 @@
         </div>
     </nav>
     <div style="padding:12px 16px;border-top:1px solid var(--border-color)">
+        <div id="server-version" style="font-size:11px;color:var(--text-tertiary);padding:0 8px 8px"></div>
         <a href="#" onclick="logout();return false" class="nav-item" style="color:var(--text-secondary)">
             <i data-lucide="log-out" class="nav-icon"></i><span>Logout</span>
         </a>

--- a/web/static/dashboard.html
+++ b/web/static/dashboard.html
@@ -79,6 +79,7 @@
         </div>
     </nav>
     <div style="padding:12px 16px;border-top:1px solid var(--border-color)">
+        <div id="server-version" style="font-size:11px;color:var(--text-tertiary);padding:0 8px 8px"></div>
         <a href="#" onclick="logout();return false" class="nav-item" style="color:var(--text-secondary)">
             <i data-lucide="log-out" class="nav-icon"></i><span>Logout</span>
         </a>

--- a/web/static/dns-filter.html
+++ b/web/static/dns-filter.html
@@ -78,6 +78,7 @@
         </div>
     </nav>
     <div style="padding:12px 16px;border-top:1px solid var(--border-color)">
+        <div id="server-version" style="font-size:11px;color:var(--text-tertiary);padding:0 8px 8px"></div>
         <a href="#" onclick="logout();return false" class="nav-item" style="color:var(--text-secondary)">
             <i data-lucide="log-out" class="nav-icon"></i><span>Logout</span>
         </a>

--- a/web/static/groups.html
+++ b/web/static/groups.html
@@ -79,6 +79,7 @@
         </div>
     </nav>
     <div style="padding:12px 16px;border-top:1px solid var(--border-color)">
+        <div id="server-version" style="font-size:11px;color:var(--text-tertiary);padding:0 8px 8px"></div>
         <a href="#" onclick="logout();return false" class="nav-item" style="color:var(--text-secondary)">
             <i data-lucide="log-out" class="nav-icon"></i><span>Logout</span>
         </a>

--- a/web/static/local-dns-settings.html
+++ b/web/static/local-dns-settings.html
@@ -80,6 +80,7 @@
         </div>
     </nav>
     <div style="padding:12px 16px;border-top:1px solid var(--border-color)">
+        <div id="server-version" style="font-size:11px;color:var(--text-tertiary);padding:0 8px 8px"></div>
         <a href="#" onclick="logout();return false" class="nav-item" style="color:var(--text-secondary)">
             <i data-lucide="log-out" class="nav-icon"></i><span>Logout</span>
         </a>

--- a/web/static/queries.html
+++ b/web/static/queries.html
@@ -73,6 +73,7 @@
         </div>
     </nav>
     <div style="padding:12px 16px;border-top:1px solid var(--border-color)">
+        <div id="server-version" style="font-size:11px;color:var(--text-tertiary);padding:0 8px 8px"></div>
         <a href="#" onclick="logout();return false" class="nav-item" style="color:var(--text-secondary)">
             <i data-lucide="log-out" class="nav-icon"></i><span>Logout</span>
         </a>

--- a/web/static/settings.html
+++ b/web/static/settings.html
@@ -74,6 +74,7 @@
         </div>
     </nav>
     <div style="padding:12px 16px;border-top:1px solid var(--border-color)">
+        <div id="server-version" style="font-size:11px;color:var(--text-tertiary);padding:0 8px 8px"></div>
         <a href="#" onclick="logout();return false" class="nav-item" style="color:var(--text-secondary)">
             <i data-lucide="log-out" class="nav-icon"></i><span>Logout</span>
         </a>

--- a/web/static/shared.js
+++ b/web/static/shared.js
@@ -158,7 +158,15 @@ function hideRestartBanner() {
     if (banner) banner.remove();
 }
 
+// --- Server version label (sidebar footer) ---
+
+function showServerVersion() {
+    const el = document.getElementById('server-version');
+    if (el && window.FERROUS_VERSION) el.textContent = 'v' + window.FERROUS_VERSION;
+}
+
 document.addEventListener('DOMContentLoaded', function() {
+    showServerVersion();
     if (document.body.dataset.page === 'settings') return;
     if (isRestartRequired()) showRestartBanner();
 });


### PR DESCRIPTION
## Summary
- Inject `window.FERROUS_VERSION` (from `CARGO_PKG_VERSION`) in the runtime `/ferrous-config.js` snippet, alongside the existing `FERROUS_API_BASE`.
- Add `showServerVersion()` in `shared.js`, called on `DOMContentLoaded`, which renders the version into a `#server-version` label.
- Add the `#server-version` element just above the Logout link on all 8 sidebar pages (small, muted label). `index.html`/`login.html` have no sidebar and are untouched.

## Test plan
- [x] Build and run the binary, open the Web UI, confirm `v<version>` shows above Logout on every sidebar page (dashboard, queries, clients, groups, local-dns, settings, dns-filter, block-services).
- [x] Confirm it also renders on the settings page (the label runs before the settings early-return).
- [x] Confirm Pi-hole compat mode still works (`FERROUS_API_BASE = /ferrous/api` and version both set).

🤖 Generated with Claudin