### PR TITLE
fix - dashboard chart stability and mobile query log domain column

### DIFF
--- a/web/static/dashboard.css
+++ b/web/static/dashboard.css
@@ -21,3 +21,68 @@
                 height: 220px
             }
         }
+
+        /* Doughnut card: chart on the left, HTML legend on the right.
+           The legend is real DOM, so the card grows vertically to fit every
+           entry instead of clipping/stacking. Grid `align-items:stretch`
+           keeps the two cards the same height when one legend is taller. */
+        .chart-card {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .chart-row {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            gap: 20px;
+        }
+
+        .chart-canvas-wrap {
+            flex: 1 1 0;
+            min-width: 0;
+            max-width: 260px;
+        }
+
+        .chart-legend {
+            flex: 0 0 auto;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .chart-legend-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            cursor: pointer;
+        }
+
+        .chart-legend-swatch {
+            flex: 0 0 auto;
+            width: 28px;
+            height: 14px;
+            border-radius: 3px;
+        }
+
+        .chart-legend-label {
+            font-size: 13px;
+            color: var(--text-secondary);
+            white-space: nowrap;
+        }
+
+        @media (max-width: 560px) {
+            .chart-row {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .chart-canvas-wrap {
+                max-width: none;
+                align-self: center;
+                width: 220px;
+            }
+        }

--- a/web/static/dashboard.html
+++ b/web/static/dashboard.html
@@ -177,14 +177,20 @@
             <canvas id="timelineChart"></canvas>
         </div>
     </div>
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(min(450px,100%),1fr));gap:24px">
-        <div class="card" style="padding:24px"><h3
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(min(450px,100%),1fr));gap:24px;align-items:stretch">
+        <div class="card chart-card" style="padding:24px"><h3
                 style="font-size:16px;font-weight:700;margin-bottom:16px;color:var(--text-primary)">Query Types</h3>
-            <canvas id="queryTypesChart" style="max-height:300px"></canvas>
+            <div class="chart-row">
+                <div class="chart-canvas-wrap"><canvas id="queryTypesChart"></canvas></div>
+                <ul id="queryTypesChartLegend" class="chart-legend"></ul>
+            </div>
         </div>
-        <div class="card" style="padding:24px"><h3
+        <div class="card chart-card" style="padding:24px"><h3
                 style="font-size:16px;font-weight:700;margin-bottom:16px;color:var(--text-primary)">Query Source</h3>
-            <canvas id="cacheSourceChart" style="max-height:300px"></canvas>
+            <div class="chart-row">
+                <div class="chart-canvas-wrap"><canvas id="cacheSourceChart"></canvas></div>
+                <ul id="cacheSourceChartLegend" class="chart-legend"></ul>
+            </div>
         </div>
     </div>
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(min(450px,100%),1fr));gap:24px;margin-top:24px">

--- a/web/static/dashboard.js
+++ b/web/static/dashboard.js
@@ -13,6 +13,40 @@
         });
     }
 
+    // Renders the chart legend as flowing HTML next to the canvas (instead of
+    // inside it) so the card grows vertically to fit every entry rather than
+    // clipping. The target container id is `<canvasId>Legend`.
+    const htmlLegendPlugin = {
+        id: 'htmlLegend',
+        afterUpdate(chart) {
+            const ul = document.getElementById(chart.canvas.id + 'Legend');
+            if (!ul) return;
+            while (ul.firstChild) ul.firstChild.remove();
+            const colors = chart.data.datasets[0]?.backgroundColor || [];
+            chart.data.labels.forEach((label, i) => {
+                const hidden = !chart.getDataVisibility(i);
+                const li = document.createElement('li');
+                li.className = 'chart-legend-item';
+                li.onclick = () => {
+                    chart.toggleDataVisibility(i);
+                    chart.update();
+                };
+                const box = document.createElement('span');
+                box.className = 'chart-legend-swatch';
+                box.style.background = colors[i];
+                const text = document.createElement('span');
+                text.className = 'chart-legend-label';
+                text.textContent = label;
+                if (hidden) {
+                    text.style.textDecoration = 'line-through';
+                    li.style.opacity = '.4';
+                }
+                li.append(box, text);
+                ul.appendChild(li);
+            });
+        }
+    };
+
     function formatSourceKey(key) {
         if (key.includes(':')) {
             const parts = key.split(':');
@@ -177,12 +211,11 @@
                 }
 
                 try {
-                    const validTypes = {};
-                    Object.entries(this.queryTypes).forEach(([key, value]) => {
-                        if (key !== 'undefined' && key !== 'null' && value > 0) {
-                            validTypes[key] = value;
-                        }
-                    });
+                    const entries = Object.entries(this.queryTypes)
+                        .filter(([key, value]) => key !== 'undefined' && key !== 'null' && value > 0)
+                        .sort((a, b) => a[0].localeCompare(b[0]));
+                    const newLabels = entries.map(e => e[0]);
+                    const newData   = entries.map(e => e[1]);
 
                     const pctTooltip = {
                         callbacks: {
@@ -194,31 +227,30 @@
                             }
                         }
                     };
-                    if (!appCharts.queryTypes && Object.keys(validTypes).length > 0) {
+                    if (!appCharts.queryTypes && newLabels.length > 0) {
 
                         const ctx2 = document.getElementById('queryTypesChart');
                         if (ctx2) {
                             appCharts.queryTypes = new Chart(ctx2.getContext('2d'), {
                                 type: 'doughnut',
                                 data: {
-                                    labels: Object.keys(validTypes),
+                                    labels: newLabels,
                                     datasets: [{
-                                        data: Object.values(validTypes),
-                                        backgroundColor: generateChartColors(Object.keys(validTypes).length)
+                                        data: newData,
+                                        backgroundColor: generateChartColors(newLabels.length)
                                     }]
                                 },
                                 options: {
                                     responsive: true,
                                     maintainAspectRatio: true,
-                                    aspectRatio: 2,
-                                    plugins: {legend: {position: 'right'}, tooltip: pctTooltip}
-                                }
+                                    aspectRatio: 1,
+                                    plugins: {legend: {display: false}, tooltip: pctTooltip}
+                                },
+                                plugins: [htmlLegendPlugin]
                             });
                         }
-                    } else if (appCharts.queryTypes && appCharts.queryTypes.data && appCharts.queryTypes.canvas && Object.keys(validTypes).length > 0) {
+                    } else if (appCharts.queryTypes && appCharts.queryTypes.data && appCharts.queryTypes.canvas && newLabels.length > 0) {
 
-                        const newLabels = Object.keys(validTypes);
-                        const newData   = Object.values(validTypes);
                         const curLabels = appCharts.queryTypes.data.labels;
                         const curData   = appCharts.queryTypes.data.datasets[0].data;
                         const labelsChanged = newLabels.length !== curLabels.length ||
@@ -253,7 +285,8 @@
                 try {
                     const active = Object.entries(this.sourceStats)
                         .filter(([, v]) => v > 0)
-                        .map(([key, value]) => ({ label: formatSourceKey(key), value }));
+                        .map(([key, value]) => ({ label: formatSourceKey(key), value }))
+                        .sort((a, b) => a.label.localeCompare(b.label));
 
                     if (active.length === 0) return;
 
@@ -273,9 +306,10 @@
                                 options: {
                                     responsive: true,
                                     maintainAspectRatio: true,
-                                    aspectRatio: 2,
-                                    plugins: {legend: {position: 'right'}, tooltip: pctTooltip}
-                                }
+                                    aspectRatio: 1,
+                                    plugins: {legend: {display: false}, tooltip: pctTooltip}
+                                },
+                                plugins: [htmlLegendPlugin]
                             });
                         }
                     } else if (appCharts.cacheSource.data && appCharts.cacheSource.canvas) {

--- a/web/static/queries.css
+++ b/web/static/queries.css
@@ -19,12 +19,27 @@
             min-width: 480px
         }
 
+        .col-time { width: 120px }
+        .col-client { width: 130px }
+        .col-source { width: 240px }
+
         @media (max-width: 1100px) {
             .col-rt { display: none }
         }
 
         @media (max-width: 820px) {
             .col-type { display: none }
+        }
+
+        /* Phones: drop the table min-width and the CLIENT column, and shrink
+           TIME/SOURCE so the DOMAIN column keeps enough room to show the
+           queried name instead of collapsing to zero width. */
+        @media (max-width: 640px) {
+            table { min-width: 0 }
+            .col-client { display: none }
+            .col-time { width: 86px }
+            .col-source { width: 116px }
+            th, td { padding: 8px 6px }
         }
 
         th {

--- a/web/static/queries.html
+++ b/web/static/queries.html
@@ -130,11 +130,11 @@
         <table>
             <thead>
             <tr>
-                <th style="width:120px">TIME</th>
+                <th class="col-time">TIME</th>
                 <th>DOMAIN</th>
                 <th class="col-type" style="width:70px">TYPE</th>
-                <th style="width:130px">CLIENT</th>
-                <th style="width:240px">SOURCE</th>
+                <th class="col-client">CLIENT</th>
+                <th class="col-source">SOURCE</th>
                 <th class="col-rt" style="width:110px">RESPONSE TIME</th>
                 <th class="col-action" style="width:80px">ACTION</th>
             </tr>
@@ -165,7 +165,7 @@
                     </td>
                     <td class="col-type"><span class="badge" style="background:rgba(59,130,246,0.1);color:#3B82F6"
                               x-text="query.type"></span></td>
-                    <td style="font-size:13px"
+                    <td class="col-client" style="font-size:13px"
                         x-text="query.client_hostname ? query.client_hostname + ' (' + query.client + ')' : query.client"></td>
                     <td style="max-width:0;overflow:hidden">
                         <span class="badge" style="max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"


### PR DESCRIPTION
## Summary
- **Dashboard donuts**: sort Query Types / Query Source entries by label so slices and colors no longer get reshuffled on every refresh (the backend serializes a Rust `HashMap`, whose iteration order is non-deterministic). Colors are assigned by position, so a stable order keeps each label's color stable.
- **Dashboard legend**: render the chart legend as flowing HTML beside the donut instead of inside the canvas, so the card grows vertically to fit every entry rather than clipping/stacking. Grid `align-items:stretch` keeps both cards the same height.
- **Query log on mobile**: the DOMAIN column was collapsing to zero width (fixed TIME+CLIENT+SOURCE widths exceeded the table `min-width`), leaving the DOMAIN header overlapping CLIENT. Moved those widths to CSS classes and added a `<=640px` breakpoint that drops the table min-width, hides CLIENT, and shrinks TIME/SOURCE so the queried domain shows again.

## Notes
- Frontend-only (HTML/CSS/JS under `web/static/`). These files are embedded into the binary via `include_str!`, so the changes only take effect after a rebuild + restart.

## Test plan
- [x] `cargo build --release` and restart; open the dashboard — confirm Query Types/Query Source slices and colors stay fixed across refreshes and the legend no longer overflows.
- [x] Resize/open the Query Log on a narrow (<=640px) viewport — confirm the DOMAIN column shows the queried name and headers no longer overlap.

🤖 Generated with Claudin