### PR TITLE
fix - correctly detect private IPv6 ranges in DNS rebinding protection

### DIFF
--- a/crates/application/tests/dns_rebinding_test.rs
+++ b/crates/application/tests/dns_rebinding_test.rs
@@ -196,6 +196,76 @@ async fn test_public_domain_resolves_to_ipv6_loopback_is_blocked() {
 }
 
 #[tokio::test]
+async fn test_public_domain_resolves_to_ipv4_mapped_private_is_blocked() {
+    let resolver = MockDnsResolver::new();
+    // `::ffff:192.168.1.1` — a private IPv4 delivered as an IPv4-mapped AAAA.
+    resolver
+        .set_response(
+            "evil.com",
+            resolution_with_ip(IpAddr::V6(Ipv4Addr::new(192, 168, 1, 1).to_ipv6_mapped())),
+        )
+        .await;
+
+    let use_case = make_use_case(resolver, None, &[]);
+    let result = use_case.execute(&dns_request("evil.com")).await;
+
+    assert!(matches!(result, Err(DomainError::Blocked)));
+}
+
+#[tokio::test]
+async fn test_public_domain_resolves_to_ipv6_unique_local_is_blocked() {
+    let resolver = MockDnsResolver::new();
+    // `fd12:3456::1` — a typical RFC 4193 ULA with a non-zero global ID.
+    resolver
+        .set_response(
+            "evil.com",
+            resolution_with_ip(IpAddr::V6(Ipv6Addr::new(0xfd12, 0x3456, 0, 0, 0, 0, 0, 1))),
+        )
+        .await;
+
+    let use_case = make_use_case(resolver, None, &[]);
+    let result = use_case.execute(&dns_request("evil.com")).await;
+
+    assert!(matches!(result, Err(DomainError::Blocked)));
+}
+
+#[tokio::test]
+async fn test_public_domain_resolves_to_ipv6_link_local_is_blocked() {
+    let resolver = MockDnsResolver::new();
+    // `fea0::1` — link-local outside the literal `fe80:` prefix.
+    resolver
+        .set_response(
+            "evil.com",
+            resolution_with_ip(IpAddr::V6(Ipv6Addr::new(0xfea0, 0, 0, 0, 0, 0, 0, 1))),
+        )
+        .await;
+
+    let use_case = make_use_case(resolver, None, &[]);
+    let result = use_case.execute(&dns_request("evil.com")).await;
+
+    assert!(matches!(result, Err(DomainError::Blocked)));
+}
+
+#[tokio::test]
+async fn test_public_domain_resolves_to_ipv6_public_is_allowed() {
+    let resolver = MockDnsResolver::new();
+    // `2606:4700:4700::1111` — Cloudflare public resolver.
+    resolver
+        .set_response(
+            "cloudflare.com",
+            resolution_with_ip(IpAddr::V6(Ipv6Addr::new(
+                0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111,
+            ))),
+        )
+        .await;
+
+    let use_case = make_use_case(resolver, None, &[]);
+    let result = use_case.execute(&dns_request("cloudflare.com")).await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
 async fn test_local_domain_suffix_match_is_case_insensitive() {
     let resolver = MockDnsResolver::new();
     resolver

--- a/crates/domain/src/value_objects/query_filters.rs
+++ b/crates/domain/src/value_objects/query_filters.rs
@@ -8,8 +8,6 @@ const PRIVATE_IPV4_RANGES: &[(u8, u8, u8, u8, u8)] = &[
     (127, 0, 0, 0, 8),
 ];
 
-const PRIVATE_IPV6_PREFIXES: &[&str] = &["fc00:", "fd00:", "fe80:", "::1"];
-
 pub struct PrivateIpFilter;
 
 impl PrivateIpFilter {
@@ -28,10 +26,20 @@ impl PrivateIpFilter {
     }
 
     fn is_private_ipv6(ip: &Ipv6Addr) -> bool {
-        let addr_str = ip.to_string();
-        PRIVATE_IPV6_PREFIXES
-            .iter()
-            .any(|prefix| addr_str.starts_with(prefix))
+        // IPv4-mapped addresses (`::ffff:a.b.c.d`) carry an IPv4 payload — unmap
+        // and apply the IPv4 ranges so a private IPv4 delivered as an AAAA record
+        // can't bypass the rebinding check.
+        if let Some(ipv4) = ip.to_ipv4_mapped() {
+            return Self::is_private_ipv4(&ipv4);
+        }
+
+        let segments = ip.segments();
+        // `::1` loopback.
+        ip.is_loopback()
+            // Unique local addresses: fc00::/7 (RFC 4193).
+            || (segments[0] & 0xfe00) == 0xfc00
+            // Link-local unicast: fe80::/10 (RFC 4291).
+            || (segments[0] & 0xffc0) == 0xfe80
     }
 
     fn matches_ipv4_range(ip: [u8; 4], network: (u8, u8, u8, u8), mask: u8) -> bool {

--- a/docs/features/malware-detection.md
+++ b/docs/features/malware-detection.md
@@ -176,7 +176,7 @@ client_whitelist           = []         # Client CIDRs exempt from detection
 | Option | Default | Description |
 |:-------|:--------|:------------|
 | `enabled` | `true` | Master switch for tunneling detection |
-| `action` | `block` | Action when tunneling is detected: `block` (REFUSED), `alert` (log only), or `throttle` (planned) |
+| `action` | `block` | Action when tunneling is detected: `block` (answer with the configured block response), `alert` (log only), or `throttle` (planned) |
 | `max_fqdn_length` | `120` | Maximum FQDN length in bytes before triggering |
 | `max_label_length` | `50` | Maximum single label length in bytes before triggering |
 | `block_null_queries` | `true` | Block NULL record type queries (used by iodine, dnscat2) |
@@ -194,7 +194,7 @@ client_whitelist           = []         # Client CIDRs exempt from detection
 
 | Action | Behavior |
 |:-------|:---------|
-| `block` | Query is refused (`REFUSED` response code) and logged with `block_source = dns_tunneling` |
+| `block` | Query is answered with the configured block response — by default `0.0.0.0`/`::` (`NOERROR`), governed by the global `[blocking] block_mode` setting — and logged with `block_source = dns_tunneling` |
 | `alert` | Query is resolved normally but the detection event is logged for review |
 | `throttle` | Planned for a future release — will add a delay to suspicious responses |
 
@@ -300,7 +300,7 @@ DNS Query arrives (A/AAAA for apex domain)
 │  ◆ N-gram bigram scoring (character     │
 │    pair frequency vs. English corpus)   │
 │  ◆ Per-client DGA rate tracking         │
-│    (NXDOMAIN ratio per client subnet)   │
+│    (DGA-like domains/min per subnet)    │
 │                                         │
 │  Confidence score > 0.65?               │
 │  → Flag SLD in hot-path DashMap         │
@@ -309,7 +309,7 @@ DNS Query arrives (A/AAAA for apex domain)
 
 **Phase 1** runs inline on every A/AAAA query with no heap allocations. It evaluates four O(1) signals on the SLD and accumulates their weights into a **mini-score**. A single suspicious signal alone is not enough to trigger — the combined mini-score must exceed `hot_path_confidence_threshold` (default 0.40), which typically requires two or more signals to fire simultaneously. This prevents false positives on legitimate domains that appear suspicious in only one dimension (e.g., CDN domains with high entropy but normal consonant ratios). Phase 1 also performs a DashMap lookup to check whether Phase 2 has previously flagged this SLD.
 
-**Phase 2** runs in a background async task, consuming events from the hot path via a bounded channel. It evaluates n-gram bigram scoring against a compiled English character-pair frequency table and tracks per-client NXDOMAIN rates over a sliding window. When the combined confidence score exceeds the threshold, the SLD is inserted into the hot-path DashMap so Phase 1 can block it immediately on the next query.
+**Phase 2** runs in a background async task, consuming events from the hot path via a bounded channel. It evaluates n-gram bigram scoring against a compiled English character-pair frequency table and tracks the rate of DGA-like domains per client subnet over a sliding window. When the combined confidence score exceeds the threshold, the SLD is inserted into the hot-path DashMap so Phase 1 can block it immediately on the next query.
 
 ### Confidence Scoring
 
@@ -389,7 +389,7 @@ client_whitelist              = []         # Client CIDRs exempt from DGA detect
 | Option | Default | Description |
 |:-------|:--------|:------------|
 | `enabled` | `true` | Master switch for DGA detection |
-| `action` | `block` | Action when a DGA domain is detected: `block` (REFUSED) or `alert` (log only) |
+| `action` | `block` | Action when a DGA domain is detected: `block` (answer with the configured block response) or `alert` (log only) |
 | `hot_path_confidence_threshold` | `0.40` | Minimum weighted mini-score for Phase 1 to trigger (0.0–1.0). With default weights, 0.40 typically requires two or more signals to fire simultaneously, preventing false positives on legitimate domains with a single suspicious characteristic |
 | `sld_entropy_threshold` | `3.5` | Shannon entropy of the SLD in bits/char. Values above this indicate random-looking names |
 | `sld_max_length` | `24` | Maximum SLD length — longer names trigger the length signal |
@@ -406,7 +406,7 @@ client_whitelist              = []         # Client CIDRs exempt from DGA detect
 
 | Action | Behavior |
 |:-------|:---------|
-| `block` | Query is refused (`REFUSED` response code) and logged with `block_source = dga_detection` |
+| `block` | Query is answered with the configured block response — by default `0.0.0.0`/`::` (`NOERROR`), governed by the global `[blocking] block_mode` setting — and logged with `block_source = dga_detection` |
 | `alert` | Query is resolved normally but the detection event is logged for review |
 
 !!! tip "Start with alert mode"
@@ -473,9 +473,33 @@ Ferrous DNS inspects every DNS response before delivering it to clients. If a pu
 | `192.168.0.0/16` | Private network (Class C) |
 | `169.254.0.0/16` | Link-local |
 | `127.0.0.0/8` | Loopback |
+| `::1/128` | IPv6 loopback |
+| `fc00::/7` | IPv6 unique local addresses (ULA) |
+| `fe80::/10` | IPv6 link-local unicast |
 
-!!! info "No configuration required"
-    DNS rebinding protection is built-in and always active when blocking is enabled. There is no TOML option to configure — it engages automatically.
+IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) are unmapped and checked against the IPv4 ranges above, so a private IPv4 delivered as an `AAAA` record cannot bypass the check.
+
+### Configuration
+
+DNS rebinding protection is **enabled by default**. It has its own enable flag (independent of whether blocklist-based blocking is enabled) plus an allowlist for split-horizon DNS.
+
+```toml title="ferrous-dns.toml"
+[dns]
+rebinding_protection_enabled = true   # Master switch (default: true)
+
+# Domains exempt from rebinding protection regardless of resolved IP.
+# Useful for split-horizon DNS where an external name intentionally
+# resolves to a private address (VPN endpoints, router admin panels).
+rebinding_allowlist = ["router.example.com", "nas.example.com"]
+```
+
+| Option | Default | Description |
+|:-------|:--------|:------------|
+| `rebinding_protection_enabled` | `true` | Master switch for DNS rebinding protection |
+| `rebinding_allowlist` | `[]` | Exact domain names that are always exempt, regardless of resolved IP |
+
+!!! tip "Local domain suffix is also exempt"
+    Domains under the configured `[dns] local_domain` suffix (e.g. `*.local`) are automatically exempt from rebinding protection, since they are expected to resolve to private addresses. The same applies to resolutions served by your local DNS server / local records.
 
 ---
 
@@ -547,7 +571,7 @@ Some corporate networks use DNS interception for security monitoring, brand prot
 
 ### How Detection Works
 
-Ferrous DNS uses a background probe mechanism that tests each upstream DNS server with domains that **must** return NXDOMAIN per RFC 6761. If an upstream returns A/AAAA records instead, the returned IPs are recorded as "hijack IPs" and all future responses containing those IPs are converted back to proper NXDOMAIN.
+Ferrous DNS uses a background probe mechanism that tests each upstream DNS server with domains that **must** return NXDOMAIN per RFC 6761. Each probe sends an `A` query; if an upstream returns address records instead of NXDOMAIN, the returned IPs are recorded as "hijack IPs" and all future responses containing those IPs are converted back to proper NXDOMAIN.
 
 ```text
 Background Probe Loop (every 5 min)
@@ -556,14 +580,14 @@ Background Probe Loop (every 5 min)
 ┌─────────────────────────────────────────────┐
 │  For each upstream DNS server:              │
 │                                             │
-│  Send 3 queries for random .invalid domains │
-│  e.g. a1b2c3d4e5f67890.probe.invalid       │
+│  Send 3 A queries for random .invalid       │
+│  domains, e.g. a1b2c3d4e5f67890.probe.invalid│
 │                                             │
 │  RFC 6761: .invalid MUST return NXDOMAIN    │
 │                                             │
 │  ┌─ Response is NXDOMAIN?  → Upstream OK    │
 │  │                                          │
-│  └─ Response has A/AAAA?   → HIJACKING!     │
+│  └─ Response has addresses? → HIJACKING!    │
 │     Record IPs in DashSet (O(1) lookups)    │
 │     Log warning with upstream + IP details  │
 └─────────────────────────────────────────────┘
@@ -591,7 +615,7 @@ Hot Path (every DNS query)
 - **Multiple probes per round** — 3 random domains per cycle to confirm hijacking (not a transient error). Random hex ensures no caching effects.
 - **DashSet for O(1) hot-path lookups** — the hijack IP set is lock-free and typically contains 0-5 IPs, adding negligible overhead to the DNS hot path.
 - **TTL-based eviction** — hijack IPs expire after `hijack_ip_ttl_secs` (default 1 hour) and must be re-confirmed by the next probe cycle. This handles ISPs that rotate their redirect IPs.
-- **Per-upstream tracking** — each upstream is probed independently. If only one of your upstreams is hijacking, only responses from that upstream's IPs are affected.
+- **Per-upstream probing, global IP set** — each upstream is probed independently, so only genuinely hijacking upstreams contribute IPs. The recorded hijack-IP set is global (keyed by IP, not by upstream), so once an IP is flagged, any response containing it is converted to NXDOMAIN regardless of which upstream returned it. In practice ISP redirect IPs do not host legitimate sites, so this does not affect normal traffic.
 
 ### Configuration
 
@@ -727,7 +751,7 @@ Hot Path (every DNS query)
 │  ┌─ No match?  → Deliver response normally  │
 │  │                                          │
 │  └─ Match!     → C2 IP detected             │
-│     Block: return REFUSED to client         │
+│     Block: return configured block response │
 │     Alert: log and deliver original response│
 └─────────────────────────────────────────────┘
 ```
@@ -770,7 +794,7 @@ ip_ttl_secs           = 604800
 | Option | Default | Description |
 |:-------|:--------|:------------|
 | `enabled` | `false` | Master switch — requires user to configure feed URLs |
-| `action` | `block` | Action when a C2 IP is detected: `block` (REFUSED) or `alert` (log only) |
+| `action` | `block` | Action when a C2 IP is detected: `block` (answer with the configured block response) or `alert` (log only) |
 | `ip_list_urls` | `[]` | URLs of IP threat feeds (one IP per line, `#` comments) |
 | `refresh_interval_secs` | `86400` | Seconds between feed re-downloads (24 hours) |
 | `ip_ttl_secs` | `604800` | Seconds before an IP not re-confirmed by a feed is evicted (7 days) |
@@ -779,7 +803,7 @@ ip_ttl_secs           = 604800
 
 | Action | Behavior |
 |:-------|:---------|
-| `block` | Response is refused (`REFUSED` response code) and logged with `block_source = response_ip_filter` |
+| `block` | Response is replaced with the configured block response — by default `0.0.0.0`/`::` (`NOERROR`), governed by the global `[blocking] block_mode` setting — and logged with `block_source = response_ip_filter` |
 | `alert` | Response is delivered as-is but the detection event is logged for review |
 
 !!! tip "Start with alert mode"


### PR DESCRIPTION
## Summary
- Rewrite `is_private_ipv6` in `crates/domain/src/value_objects/query_filters.rs` to unmap IPv4-mapped addresses via `to_ipv4_mapped()` and match ULA (`fc00::/7`), link-local (`fe80::/10`), and loopback with bitwise checks, replacing the incomplete prefix table that let rebinding responses pointing at private IPv6 space through.
- Add integration tests in `crates/application/tests/dns_rebinding_test.rs` covering the IPv6 cases (ULA, link-local, IPv6 loopback, IPv4-mapped private, public IPv6 allowed).
- Update `docs/features/malware-detection.md` to match the implementation: block policy is the configurable block response mode (not REFUSED), document the rebinding config and the covered IPv6 ranges.

## Test plan
- [x] `cargo test -p ferrous-dns-application --test dns_rebinding_test` (20/20 pass)
- [x] `cargo clippy -p ferrous-dns-domain -p ferrous-dns-application --all-features -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

🤖 Generated with Claudin