### PR TITLE
feat - add client/hostname substring filter to query log

### DIFF
--- a/crates/api-pihole/src/handlers/queries.rs
+++ b/crates/api-pihole/src/handlers/queries.rs
@@ -91,7 +91,7 @@ pub async fn get_queries(
         cursor: params.cursor,
         domain: params.domain.as_deref(),
         category,
-        client_ip: params.client.as_deref(),
+        client: params.client.as_deref(),
         ..Default::default()
     };
 

--- a/crates/api/src/handlers/queries.rs
+++ b/crates/api/src/handlers/queries.rs
@@ -51,7 +51,7 @@ pub async fn get_queries(
         cursor: params.cursor,
         domain: params.domain.as_deref(),
         category: params.category.as_deref(),
-        client_ip: params.client.as_deref(),
+        client: params.client.as_deref(),
         record_type: params.record_type.as_deref(),
         upstream: params.upstream.as_deref(),
     };

--- a/crates/application/src/use_cases/queries/get_recent.rs
+++ b/crates/application/src/use_cases/queries/get_recent.rs
@@ -17,7 +17,7 @@ pub struct PagedQueryInput<'a> {
     pub cursor: Option<i64>,
     pub domain: Option<&'a str>,
     pub category: Option<&'a str>,
-    pub client_ip: Option<&'a str>,
+    pub client: Option<&'a str>,
     pub record_type: Option<&'a str>,
     pub upstream: Option<&'a str>,
 }
@@ -45,7 +45,6 @@ impl GetRecentQueriesUseCase {
     ///
     /// String parameters are validated and parsed into typed filter values.
     /// Invalid `category` or `record_type` returns `DomainError::InvalidInput`.
-    /// Invalid `client_ip` format returns `DomainError::InvalidInput`.
     pub async fn execute_paged(
         &self,
         input: &PagedQueryInput<'_>,
@@ -64,19 +63,10 @@ impl GetRecentQueriesUseCase {
             .transpose()
             .map_err(DomainError::InvalidInput)?;
 
-        let parsed_client_ip = input
-            .client_ip
-            .filter(|c| !c.is_empty())
-            .map(|ip| {
-                ip.parse::<std::net::IpAddr>()
-                    .map_err(|e| DomainError::InvalidInput(e.to_string()))
-            })
-            .transpose()?;
-
         let filter = QueryLogFilter {
             domain: input.domain.filter(|d| !d.is_empty()).map(String::from),
             category: parsed_category,
-            client_ip: parsed_client_ip,
+            client: input.client.filter(|c| !c.is_empty()).map(String::from),
             record_type: parsed_record_type,
             upstream: input.upstream.filter(|u| !u.is_empty()).map(String::from),
         };

--- a/crates/application/tests/get_recent_limit_test.rs
+++ b/crates/application/tests/get_recent_limit_test.rs
@@ -152,26 +152,6 @@ async fn test_invalid_record_type_returns_error() {
 }
 
 #[tokio::test]
-async fn test_invalid_client_ip_returns_error() {
-    let captured = Arc::new(Mutex::new(0u32));
-    let repo = Arc::new(CaptureLimitRepository {
-        last_limit: captured.clone(),
-    });
-    let use_case = GetRecentQueriesUseCase::new(repo);
-
-    let input = PagedQueryInput {
-        limit: 100,
-        period_hours: 24.0,
-        client_ip: Some("not-an-ip"),
-        ..Default::default()
-    };
-    let result = use_case.execute_paged(&input).await;
-
-    assert!(result.is_err());
-    assert!(matches!(result.unwrap_err(), DomainError::InvalidInput(_)));
-}
-
-#[tokio::test]
 async fn test_invalid_category_returns_error() {
     let captured = Arc::new(Mutex::new(0u32));
     let repo = Arc::new(CaptureLimitRepository {

--- a/crates/domain/src/entities/query_log.rs
+++ b/crates/domain/src/entities/query_log.rs
@@ -15,8 +15,8 @@ pub struct QueryLogFilter {
     pub domain: Option<String>,
     /// Query category (allowed, blocked, cache, upstream, etc.).
     pub category: Option<QueryCategory>,
-    /// Exact match on client IP (canonical `IpAddr` form).
-    pub client_ip: Option<IpAddr>,
+    /// Substring match on client IP or hostname (SQL `LIKE`).
+    pub client: Option<String>,
     /// Exact match on DNS record type.
     pub record_type: Option<RecordType>,
     /// Exact match on upstream server address.

--- a/crates/infrastructure/src/repositories/query_log_repository/reader.rs
+++ b/crates/infrastructure/src/repositories/query_log_repository/reader.rs
@@ -71,6 +71,11 @@ pub(super) async fn get_recent_paged(
         .as_deref()
         .filter(|d| !d.is_empty())
         .map(|d| format!("%{d}%"));
+    let client_pattern = filter
+        .client
+        .as_deref()
+        .filter(|c| !c.is_empty())
+        .map(|c| format!("%{c}%"));
 
     // Each arm is a static SQL fragment — no user input is interpolated.
     let category_clause = match filter.category {
@@ -88,8 +93,8 @@ pub(super) async fn get_recent_paged(
     } else {
         ""
     };
-    let client_clause = if filter.client_ip.is_some() {
-        " AND q.client_ip = ?"
+    let client_clause = if client_pattern.is_some() {
+        " AND (q.client_ip LIKE ? OR c.hostname LIKE ?)"
     } else {
         ""
     };
@@ -111,8 +116,8 @@ pub(super) async fn get_recent_paged(
             if let Some(ref pat) = domain_pattern {
                 q = q.bind(pat);
             }
-            if let Some(ref ip) = $filter.client_ip {
-                q = q.bind(ip.to_string());
+            if let Some(ref pat) = client_pattern {
+                q = q.bind(pat).bind(pat);
             }
             if let Some(ref rt) = $filter.record_type {
                 q = q.bind(rt.as_str());
@@ -169,6 +174,7 @@ pub(super) async fn get_recent_paged(
         async {
             let count_sql = format!(
                 "SELECT COUNT(*) as cnt FROM query_log q
+                 LEFT JOIN clients c ON q.client_ip = c.ip_address
                  WHERE q.query_source = 'client' AND q.created_at >= ?{domain_clause}{category_clause}{client_clause}{type_clause}{upstream_clause}"
             );
             let q = sqlx::query(&count_sql).bind(&cutoff);

--- a/crates/infrastructure/tests/query_log_repository_tests.rs
+++ b/crates/infrastructure/tests/query_log_repository_tests.rs
@@ -822,7 +822,7 @@ async fn test_client_ip_filter() {
     );
 
     let filter = QueryLogFilter {
-        client_ip: Some("10.0.0.1".parse().unwrap()),
+        client: Some("10.0.0.1".to_string()),
         ..Default::default()
     };
     let result = repo
@@ -836,6 +836,119 @@ async fn test_client_ip_filter() {
         .queries
         .iter()
         .all(|q| q.client_ip.to_string() == "10.0.0.1"));
+}
+
+#[tokio::test]
+async fn test_client_filter_partial_ip() {
+    let pool = create_test_db().await;
+
+    insert_query_full(
+        &pool, "a.com", "10.0.0.1", "A", false, false, None, None, None,
+    )
+    .await;
+    insert_query_full(
+        &pool, "b.com", "10.0.0.2", "A", false, false, None, None, None,
+    )
+    .await;
+    insert_query_full(
+        &pool,
+        "c.com",
+        "10.0.10.5",
+        "A",
+        false,
+        false,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    let repo = SqliteQueryLogRepository::new(
+        pool.clone(),
+        pool.clone(),
+        pool.clone(),
+        &DatabaseConfig::default(),
+    );
+
+    // Substring "10.0.0." matches the two 10.0.0.x clients but not 10.0.10.5.
+    let filter = QueryLogFilter {
+        client: Some("10.0.0.".to_string()),
+        ..Default::default()
+    };
+    let result = repo
+        .get_recent_paged(100, 0, 24.0, None, &filter)
+        .await
+        .unwrap();
+
+    assert_eq!(result.records_filtered, 2);
+    assert_eq!(result.queries.len(), 2);
+    assert!(result
+        .queries
+        .iter()
+        .all(|q| q.client_ip.to_string().starts_with("10.0.0.")));
+}
+
+#[tokio::test]
+async fn test_client_filter_hostname() {
+    let pool = create_test_db().await;
+
+    insert_query_full(
+        &pool,
+        "a.com",
+        "10.0.10.1",
+        "A",
+        false,
+        false,
+        None,
+        None,
+        None,
+    )
+    .await;
+    insert_query_full(
+        &pool,
+        "b.com",
+        "10.0.10.2",
+        "A",
+        false,
+        false,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    // Map 10.0.10.1 to a hostname; 10.0.10.2 has no clients row.
+    sqlx::query("INSERT INTO clients (ip_address, hostname) VALUES (?, ?)")
+        .bind("10.0.10.1")
+        .bind("Win_viudes.lan.")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let repo = SqliteQueryLogRepository::new(
+        pool.clone(),
+        pool.clone(),
+        pool.clone(),
+        &DatabaseConfig::default(),
+    );
+
+    // Case-insensitive substring match on the joined hostname.
+    let filter = QueryLogFilter {
+        client: Some("win_viudes".to_string()),
+        ..Default::default()
+    };
+    let result = repo
+        .get_recent_paged(100, 0, 24.0, None, &filter)
+        .await
+        .unwrap();
+
+    assert_eq!(result.records_filtered, 1);
+    assert_eq!(result.queries.len(), 1);
+    assert_eq!(result.queries[0].client_ip.to_string(), "10.0.10.1");
+    assert_eq!(
+        result.queries[0].client_hostname.as_deref(),
+        Some("Win_viudes.lan.")
+    );
 }
 
 #[tokio::test]
@@ -1008,7 +1121,7 @@ async fn test_combined_client_and_category() {
 
     let filter = QueryLogFilter {
         category: Some(QueryCategory::Blocked),
-        client_ip: Some("10.0.0.1".parse().unwrap()),
+        client: Some("10.0.0.1".to_string()),
         ..Default::default()
     };
     let result = repo
@@ -1101,7 +1214,7 @@ async fn test_combined_all_filters() {
     let filter = QueryLogFilter {
         domain: Some("example".to_string()),
         category: Some(QueryCategory::Blocked),
-        client_ip: Some("10.0.0.1".parse().unwrap()),
+        client: Some("10.0.0.1".to_string()),
         record_type: Some(ferrous_dns_domain::RecordType::AAAA),
         upstream: Some("8.8.8.8".to_string()),
     };
@@ -1157,7 +1270,7 @@ async fn test_cursor_pagination_with_client_filter() {
     );
 
     let filter = QueryLogFilter {
-        client_ip: Some("10.0.0.1".parse().unwrap()),
+        client: Some("10.0.0.1".to_string()),
         ..Default::default()
     };
 

--- a/web/static/queries.html
+++ b/web/static/queries.html
@@ -105,6 +105,12 @@
                        style="padding:8px 12px;border:1px solid var(--border-color);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px;width:200px">
             </div>
             <div style="display:flex;align-items:center;gap:8px">
+                <label style="font-size:14px;font-weight:500;color:var(--text-secondary);white-space:nowrap">Client:</label>
+                <input type="text" x-model="searchClient" @input.debounce.400ms="currentPage=1;_cursors={};loadQueries()"
+                       placeholder="Search client..."
+                       style="padding:8px 12px;border:1px solid var(--border-color);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px;width:200px">
+            </div>
+            <div style="display:flex;align-items:center;gap:8px">
                 <label style="font-size:14px;font-weight:500;color:var(--text-secondary);white-space:nowrap">Category:</label>
                 <select x-model="category" @change="currentPage=1;_cursors={};loadQueries()"
                         style="padding:8px 12px;border:1px solid var(--border-color);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px">

--- a/web/static/queries.js
+++ b/web/static/queries.js
@@ -8,6 +8,7 @@
             currentPage: 1,
             category: '',
             searchDomain: '',
+            searchClient: '',
             autoRefresh: false,
             _hasMore: false,
             stats: {allowed: 0, blocked: 0, cacheHits: 0, upstream: 0, queries_total: 0},
@@ -48,11 +49,14 @@
                     const domainParam = this.searchDomain
                         ? `&domain=${encodeURIComponent(this.searchDomain)}`
                         : '';
+                    const clientParam = this.searchClient
+                        ? `&client=${encodeURIComponent(this.searchClient)}`
+                        : '';
                     const categoryParam = this.category
                         ? `&category=${encodeURIComponent(this.category)}`
                         : '';
                     const res = await fetch(
-                        `${API_BASE}/queries?limit=${this.pageSize}&${pageParam}&period=24h${domainParam}${categoryParam}`,
+                        `${API_BASE}/queries?limit=${this.pageSize}&${pageParam}&period=24h${domainParam}${clientParam}${categoryParam}`,
                         {signal: this._ctrl.queries.signal}
                     );
                     if (res.ok) {


### PR DESCRIPTION
## Summary

Adds a **Client** filter to the Query Log screen. The backend already accepted a `client` query param but did an *exact* match on a parsed `IpAddr`. This relaxes it to a case-insensitive **substring** match (`LIKE %x%`) against **both** the `query_log.client_ip` column **and** the joined `clients.hostname` column, and wires up the matching UI control. The public HTTP param name stays `client`.

So `10.0.10`, a full IP, or `Win_viudes` all work — mirroring the existing Domain filter.

## Changes

- **domain** (`crates/domain/.../query_log.rs`): `QueryLogFilter.client_ip: Option<IpAddr>` → `client: Option<String>`.
- **application** (`crates/application/.../queries/get_recent.rs`): rename `PagedQueryInput.client_ip` → `client`; drop the IpAddr parse/validation (any string is now a valid substring).
- **infrastructure** (`crates/infrastructure/.../query_log_repository/reader.rs`): new `client_pattern`; clause `AND (q.client_ip LIKE ? OR c.hostname LIKE ?)` bound twice; added `LEFT JOIN clients c` to the filtered-count query so `c.hostname` resolves (the two data queries already had the join).
- **api / api-pihole**: pass `client` through.
- **web** (`web/static/queries.{html,js}`): debounced **Client** search box + `&client=` param.

## Tests

- Added `test_client_filter_partial_ip` and `test_client_filter_hostname` (infrastructure).
- Removed the now-obsolete `test_invalid_client_ip_returns_error` (it asserted the rejection behavior that was intentionally removed).

## Verification

- `make ci` (fmt-check + clippy `-D warnings` + full test suite) passes.
- A correctness-focused review confirmed SQL bind order, the safe 1:1 `LEFT JOIN` (`clients.ip_address` is `UNIQUE`), and complete field rename — no blocking findings.

> Note: user-typed `%`/`_` in the Client box are treated as SQL `LIKE` wildcards (not escaped). This is pre-existing parity with the Domain filter, not introduced here.