### PR TITLE
feat - upstream anti-spoofing for Do53 responses (cookies + 0x20)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "smallvec",
  "socket2",
  "sqlx",
+ "subtle",
  "tempfile",
  "time",
  "tokio",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,13 +84,13 @@
 
 ### 🎯 v0.9.0 - Protocol Hardening & Privacy
 
-- [ ] EDNS Client Subnet (RFC 7871) — strip client ECS by default for privacy; optional configurable subnet injection upstream for CDN-correct results
-- [ ] Upstream anti-spoofing — DNS Cookies to upstream (RFC 7873) + 0x20 QNAME randomization (draft-vixie-dns-0x20) against cache poisoning on plain-UDP upstream
+- [x] Upstream anti-spoofing — off-path forgery validation on every plain-UDP (Do53) upstream response: transaction-ID + question name/type checks always on; DNS Cookies (RFC 7873) always sent and validated gracefully on A/AAAA; opt-in 0x20 QNAME case randomization (draft-vixie-dns-0x20) via `qname_case_randomization`. Encrypted transports (DoT/DoH/DoQ) skip cookie/0x20 *validation* (TLS already authenticates the upstream), tolerating upstreams that normalize QNAME case
 - [ ] EDNS UDP payload size negotiation + correct TC truncation (RFC 6891 §6.2.5 / RFC 7766) — honor client-advertised buffer, set TC=1 on oversized responses
 - [ ] DNSSEC validation enforcement (RFC 4035 / RFC 6840) — SERVFAIL on Bogus, AD bit set/clear from validation, honor client CD bit (upgrade from current advisory `dnssec_status` tagging)
 - [ ] DNS-over-QUIC (DoQ) server listener (RFC 9250) — serve encrypted DNS to clients over QUIC (upstream DoQ already supported)
 - [ ] DNS64 / NAT64 AAAA synthesis (RFC 6147) — `64:ff9b::/96` well-known prefix for IPv6-only clients
 - [ ] Custom sinkhole IP for blocked responses (configurable A/AAAA target beyond `0.0.0.0` / `::`)
+- [ ] EDNS Client Subnet (RFC 7871) — strip client ECS by default for privacy; optional configurable subnet injection upstream for CDN-correct results
 
 ### 🌟 v1.0.0 - Production Ready
 

--- a/crates/cli/src/wiring/dns/mod.rs
+++ b/crates/cli/src/wiring/dns/mod.rs
@@ -67,7 +67,8 @@ impl DnsServices {
                 health_checker,
                 QueryEventEmitter::new_disabled(),
             )
-            .await?,
+            .await?
+            .with_hardening(pool::hardening_opts(config)),
         );
         let dnssec_pool_manager_clone = Arc::clone(&pool_manager_for_dnssec);
 
@@ -358,7 +359,8 @@ impl DnsServices {
                 health_checker,
                 QueryEventEmitter::new_disabled(),
             )
-            .await?,
+            .await?
+            .with_hardening(pool::hardening_opts(config)),
         );
         // Keep a handle so hot upstream reloads also reach this resolver.
         let maintenance_pool_manager = Arc::clone(&pool_manager_for_maintenance);

--- a/crates/cli/src/wiring/dns/pool.rs
+++ b/crates/cli/src/wiring/dns/pool.rs
@@ -1,4 +1,5 @@
 use ferrous_dns_domain::Config;
+use ferrous_dns_infrastructure::dns::forwarding::HardeningOpts;
 use ferrous_dns_infrastructure::dns::{
     events::QueryEventEmitter, query_logger::QueryEventLogger, HealthChecker, PoolManager,
 };
@@ -33,13 +34,24 @@ pub(super) fn setup_health_checker(config: &Config) -> Option<Arc<HealthChecker>
     Some(checker)
 }
 
+/// Anti-spoofing hardening for upstream A/AAAA queries. DNS Cookies are always
+/// on (graceful); 0x20 case randomization follows the config flag.
+pub(super) fn hardening_opts(config: &Config) -> HardeningOpts {
+    HardeningOpts {
+        cookie: true,
+        qname_0x20: config.dns.qname_case_randomization,
+    }
+}
+
 pub(super) async fn setup_pool_manager(
     config: &Config,
     health_checker: Option<Arc<HealthChecker>>,
     emitter: QueryEventEmitter,
 ) -> anyhow::Result<Arc<PoolManager>> {
     Ok(Arc::new(
-        PoolManager::new(config.dns.pools.clone(), health_checker, emitter).await?,
+        PoolManager::new(config.dns.pools.clone(), health_checker, emitter)
+            .await?
+            .with_hardening(hardening_opts(config)),
     ))
 }
 

--- a/crates/domain/src/config/dns.rs
+++ b/crates/domain/src/config/dns.rs
@@ -128,6 +128,14 @@ pub struct DnsConfig {
     /// DNS Cookies anti-spoofing configuration (RFC 7873).
     #[serde(default)]
     pub dns_cookies: DnsCookiesConfig,
+
+    /// Randomize the case of QNAME letters on A/AAAA upstream queries
+    /// (draft-vixie-dns-0x20) for extra anti-spoofing entropy, validating the
+    /// echoed case on the response. Off by default: some upstreams/forwarders do
+    /// not preserve QNAME case and would fail validation. DNS Cookies on A/AAAA
+    /// upstream queries are always on and graceful, independent of this flag.
+    #[serde(default = "default_false")]
+    pub qname_case_randomization: bool,
 }
 
 impl Default for DnsConfig {
@@ -171,6 +179,7 @@ impl Default for DnsConfig {
             response_ip_filter: ResponseIpFilterConfig::default(),
             dga_detection: DgaDetectionConfig::default(),
             dns_cookies: DnsCookiesConfig::default(),
+            qname_case_randomization: false,
         }
     }
 }

--- a/crates/domain/src/errors/domain_error.rs
+++ b/crates/domain/src/errors/domain_error.rs
@@ -146,6 +146,9 @@ pub enum DomainError {
     #[error("All upstream servers are unreachable")]
     TransportAllServersUnreachable,
 
+    #[error("Spoofed or invalid upstream response from {server}: {reason}")]
+    SpoofedResponse { server: String, reason: String },
+
     #[error("Schedule profile not found: {0}")]
     ScheduleProfileNotFound(i64),
 

--- a/crates/domain/tests/dns_config_test.rs
+++ b/crates/domain/tests/dns_config_test.rs
@@ -27,6 +27,24 @@ fn test_config_default_values() {
     assert!(config.local_domain.is_none());
     assert!(config.local_dns_server.is_none());
     assert!(config.local_records.is_empty());
+    assert!(!config.qname_case_randomization);
+}
+
+#[test]
+fn test_qname_case_randomization_defaults_off_when_absent() {
+    // Existing configs without the field must still deserialize, defaulting off.
+    let config: DnsConfig = toml::from_str("query_timeout = 3").unwrap();
+    assert!(!config.qname_case_randomization);
+}
+
+#[test]
+fn test_qname_case_randomization_roundtrip() {
+    let config: DnsConfig = toml::from_str("qname_case_randomization = true").unwrap();
+    assert!(config.qname_case_randomization);
+
+    let serialized = toml::to_string(&config).unwrap();
+    let reparsed: DnsConfig = toml::from_str(&serialized).unwrap();
+    assert!(reparsed.qname_case_randomization);
 }
 
 #[test]

--- a/crates/domain/tests/domain_error_test.rs
+++ b/crates/domain/tests/domain_error_test.rs
@@ -1,0 +1,15 @@
+use ferrous_dns_domain::DomainError;
+
+#[test]
+fn spoofed_response_display_includes_server_and_reason() {
+    let err = DomainError::SpoofedResponse {
+        server: "8.8.8.8:53".into(),
+        reason: "client cookie echo mismatch".into(),
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("8.8.8.8:53"), "missing server: {msg}");
+    assert!(
+        msg.contains("client cookie echo mismatch"),
+        "missing reason: {msg}"
+    );
+}

--- a/crates/infrastructure/Cargo.toml
+++ b/crates/infrastructure/Cargo.toml
@@ -42,6 +42,7 @@ ring.workspace = true
 sha1.workspace = true
 sha2.workspace = true
 base64.workspace = true
+subtle = "2"
 
 # Transport layer
 rustls.workspace = true

--- a/crates/infrastructure/src/dns/forwarding/message_builder.rs
+++ b/crates/infrastructure/src/dns/forwarding/message_builder.rs
@@ -1,11 +1,29 @@
 use super::record_type_map::RecordTypeMapper;
+use super::response_validator::ResponseValidator;
 use ferrous_dns_domain::{DomainError, RecordType};
 use hickory_proto::op::{Edns, Message, MessageType, OpCode, Query};
+use hickory_proto::rr::rdata::opt::EdnsOption;
 use hickory_proto::rr::Name;
 use hickory_proto::serialize::binary::{BinEncodable, BinEncoder};
 use ring::rand::{SecureRandom, SystemRandom};
 use std::str::FromStr;
 use std::sync::LazyLock;
+
+const CLIENT_COOKIE_LEN: usize = 8;
+const COOKIE_OPTION_CODE: u16 = 10;
+
+/// Opt-in anti-spoofing measures for an upstream query. Only honored for A/AAAA
+/// queries (see [`MessageBuilder::build_query_hardened`]); ignored for other
+/// record types because their responses are cached/replayed as raw upstream wire
+/// and must not carry randomized case or our cookie.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HardeningOpts {
+    /// Inject a random client DNS Cookie (RFC 7873, EDNS option 10) and validate
+    /// its echo on the response.
+    pub cookie: bool,
+    /// Randomize QNAME letter case (draft-vixie-dns-0x20) and validate the echo.
+    pub qname_0x20: bool,
+}
 
 pub struct MessageBuilder;
 
@@ -27,32 +45,110 @@ impl MessageBuilder {
         let name = Name::from_str(domain).map_err(|e| {
             DomainError::InvalidDomainName(format!("Invalid domain '{}': {}", domain, e))
         })?;
+        let id = Self::secure_random_id();
+        let bytes = Self::assemble_query(
+            id,
+            name,
+            RecordTypeMapper::to_hickory(record_type),
+            Self::build_edns(dnssec_ok),
+        )?;
+        Ok((id, bytes))
+    }
+
+    /// Builds an upstream query with optional anti-spoofing hardening and returns
+    /// the wire bytes alongside a [`ResponseValidator`] capturing the per-query
+    /// expectations (txid, question name/type, client cookie).
+    ///
+    /// Cookie injection and 0x20 case randomization are applied **only** to A/AAAA
+    /// queries — for other record types the response is cached/replayed to clients
+    /// as raw upstream wire, so randomized case or our cookie must not appear in it.
+    /// Transaction-ID and question validation still apply to every query.
+    pub fn build_query_hardened(
+        domain: &str,
+        record_type: &RecordType,
+        dnssec_ok: bool,
+        opts: HardeningOpts,
+    ) -> Result<(Vec<u8>, ResponseValidator), DomainError> {
+        let is_address = matches!(record_type, RecordType::A | RecordType::AAAA);
+        let use_cookie = opts.cookie && is_address;
+        let use_0x20 = opts.qname_0x20 && is_address;
+
+        let name = if use_0x20 {
+            Self::randomized_case_name(domain)?
+        } else {
+            Name::from_str(domain).map_err(|e| {
+                DomainError::InvalidDomainName(format!("Invalid domain '{}': {}", domain, e))
+            })?
+        };
 
         let hickory_type = RecordTypeMapper::to_hickory(record_type);
         let id = Self::secure_random_id();
 
-        let mut query = Query::new();
-        query.set_name(name);
-        query.set_query_type(hickory_type);
-        query.set_query_class(hickory_proto::rr::DNSClass::IN);
+        let mut edns = Self::build_edns(dnssec_ok);
+        let client_cookie = if use_cookie {
+            let mut cookie = [0u8; CLIENT_COOKIE_LEN];
+            Self::fill_random(&mut cookie);
+            edns.options_mut()
+                .insert(EdnsOption::Unknown(COOKIE_OPTION_CODE, cookie.to_vec()));
+            Some(cookie)
+        } else {
+            None
+        };
 
-        let mut message = Message::new(id, MessageType::Query, OpCode::Query);
-        message.set_recursion_desired(true);
-        message.add_query(query);
-        message.set_edns(Self::build_edns(dnssec_ok));
+        let bytes = Self::assemble_query(id, name.clone(), hickory_type, edns)?;
 
-        let bytes = Self::serialize_message(&message)?;
-        Ok((id, bytes))
+        let expected_labels = name.iter().map(|label| label.to_vec()).collect();
+        let validator =
+            ResponseValidator::new(id, expected_labels, hickory_type, client_cookie, use_0x20);
+
+        Ok((bytes, validator))
+    }
+
+    /// Builds a `Name` whose ASCII letters have randomized case (0x20). Built from
+    /// raw label bytes via `Name::from_labels` because `Name::from_str` lowercases.
+    fn randomized_case_name(domain: &str) -> Result<Name, DomainError> {
+        let src = domain.trim_end_matches('.').as_bytes();
+        let mut rnd = vec![0u8; (src.len() / 8) + 1];
+        Self::fill_random(&mut rnd);
+
+        let mut bit = 0usize;
+        let mut labels: Vec<Vec<u8>> = Vec::new();
+        let mut current: Vec<u8> = Vec::new();
+        for &b in src {
+            if b == b'.' {
+                labels.push(std::mem::take(&mut current));
+            } else if b.is_ascii_alphabetic() {
+                let uppercase = (rnd[bit / 8] >> (bit % 8)) & 1 == 1;
+                bit += 1;
+                current.push(if uppercase {
+                    b.to_ascii_uppercase()
+                } else {
+                    b.to_ascii_lowercase()
+                });
+            } else {
+                current.push(b);
+            }
+        }
+        labels.push(current);
+
+        Name::from_labels(labels).map_err(|e| {
+            DomainError::InvalidDomainName(format!("Invalid domain '{}': {}", domain, e))
+        })
+    }
+
+    fn fill_random(buf: &mut [u8]) {
+        static SECURE_RNG: LazyLock<SystemRandom> = LazyLock::new(SystemRandom::new);
+        if SECURE_RNG.fill(buf).is_err() {
+            for b in buf.iter_mut() {
+                *b = fastrand::u8(..);
+            }
+        }
     }
 
     fn secure_random_id() -> u16 {
-        static SECURE_RNG: LazyLock<SystemRandom> = LazyLock::new(SystemRandom::new);
-
         let mut bytes = [0u8; 2];
-        SECURE_RNG
-            .fill(&mut bytes)
-            .map(|_| u16::from_be_bytes(bytes))
-            .unwrap_or_else(|_| fastrand::u16(..))
+        Self::fill_random(&mut bytes);
+        u16::from_be_bytes(bytes)
     }
 
     fn build_edns(dnssec_ok: bool) -> Edns {
@@ -61,6 +157,27 @@ impl MessageBuilder {
         edns.set_dnssec_ok(dnssec_ok);
         edns.set_version(0);
         edns
+    }
+
+    /// Assembles and serializes a recursion-desired query for `name`/`hickory_type`
+    /// with the given EDNS. Shared boilerplate between the plain and hardened builders.
+    fn assemble_query(
+        id: u16,
+        name: Name,
+        hickory_type: hickory_proto::rr::RecordType,
+        edns: Edns,
+    ) -> Result<Vec<u8>, DomainError> {
+        let mut query = Query::new();
+        query.set_name(name);
+        query.set_query_type(hickory_type);
+        query.set_query_class(hickory_proto::rr::DNSClass::IN);
+
+        let mut message = Message::new(id, MessageType::Query, OpCode::Query);
+        message.set_recursion_desired(true);
+        message.add_query(query);
+        message.set_edns(edns);
+
+        Self::serialize_message(&message)
     }
 
     fn serialize_message(message: &Message) -> Result<Vec<u8>, DomainError> {

--- a/crates/infrastructure/src/dns/forwarding/mod.rs
+++ b/crates/infrastructure/src/dns/forwarding/mod.rs
@@ -2,8 +2,10 @@ pub mod forwarder;
 pub mod message_builder;
 pub mod record_type_map;
 pub mod response_parser;
+pub mod response_validator;
 
 pub use forwarder::DnsForwarder;
-pub use message_builder::MessageBuilder;
+pub use message_builder::{HardeningOpts, MessageBuilder};
 pub use record_type_map::RecordTypeMapper;
 pub use response_parser::{DnsResponse, ResponseParser};
+pub use response_validator::ResponseValidator;

--- a/crates/infrastructure/src/dns/forwarding/response_parser.rs
+++ b/crates/infrastructure/src/dns/forwarding/response_parser.rs
@@ -127,6 +127,7 @@ impl ResponseParser {
                 | DomainError::TransportConnectionReset { .. }
                 | DomainError::TransportNoHealthyServers
                 | DomainError::TransportAllServersUnreachable
+                | DomainError::SpoofedResponse { .. }
                 | DomainError::IoError(_)
         )
     }

--- a/crates/infrastructure/src/dns/forwarding/response_validator.rs
+++ b/crates/infrastructure/src/dns/forwarding/response_validator.rs
@@ -1,0 +1,171 @@
+use super::response_parser::DnsResponse;
+use ferrous_dns_domain::{DnsProtocol, DomainError};
+use hickory_proto::op::Message;
+use hickory_proto::rr::rdata::opt::{EdnsCode, EdnsOption};
+use hickory_proto::rr::{Name, RecordType as HickoryRecordType};
+
+const CLIENT_COOKIE_LEN: usize = 8;
+const COOKIE_OPTION_CODE: u16 = 10;
+
+/// Per-query expectations used to reject spoofed/off-path upstream responses on
+/// the plain-UDP/TCP (Do53) path. Produced by
+/// [`MessageBuilder::build_query_hardened`](super::message_builder::MessageBuilder::build_query_hardened)
+/// and checked at the single upstream choke point after the response is parsed.
+///
+/// Cookie and case-sensitive (0x20) checks only apply when the builder injected
+/// them (i.e. for A/AAAA queries) AND the response arrived over plain-UDP/TCP
+/// (Do53). Encrypted transports (DoT/DoH/DoQ) are authenticated by TLS, so their
+/// echo is accepted case-insensitively even when 0x20 was applied to the wire.
+/// Transaction-ID and question (name/type) matching always apply, across every
+/// transport.
+pub struct ResponseValidator {
+    id: u16,
+    /// Case-preserving label bytes of the question name we sent.
+    expected_labels: Vec<Vec<u8>>,
+    expected_qtype: HickoryRecordType,
+    /// `Some` only when a client cookie (EDNS option 10) was sent.
+    client_cookie: Option<[u8; CLIENT_COOKIE_LEN]>,
+    /// `true` when 0x20 case randomization was applied — compare labels case-sensitively.
+    case_sensitive: bool,
+}
+
+impl ResponseValidator {
+    pub fn new(
+        id: u16,
+        expected_labels: Vec<Vec<u8>>,
+        expected_qtype: HickoryRecordType,
+        client_cookie: Option<[u8; CLIENT_COOKIE_LEN]>,
+        case_sensitive: bool,
+    ) -> Self {
+        Self {
+            id,
+            expected_labels,
+            expected_qtype,
+            client_cookie,
+            case_sensitive,
+        }
+    }
+
+    /// Validates a parsed upstream response against this query's expectations.
+    /// Returns [`DomainError::SpoofedResponse`] (transport-class, so strategies
+    /// fail over to the next server) on any mismatch.
+    pub fn validate(&self, resp: &DnsResponse, protocol: &DnsProtocol) -> Result<(), DomainError> {
+        let msg = &resp.message;
+
+        if msg.id() != self.id {
+            return Err(self.spoof(
+                protocol,
+                format!(
+                    "transaction ID mismatch: expected {:#06x}, got {:#06x}",
+                    self.id,
+                    msg.id()
+                ),
+            ));
+        }
+
+        let query = msg
+            .queries()
+            .first()
+            .ok_or_else(|| self.spoof(protocol, "response has no question section".to_string()))?;
+
+        if query.query_type() != self.expected_qtype {
+            return Err(self.spoof(
+                protocol,
+                format!(
+                    "question type mismatch: expected {:?}, got {:?}",
+                    self.expected_qtype,
+                    query.query_type()
+                ),
+            ));
+        }
+
+        if !self.qname_matches(query.name(), protocol) {
+            return Err(self.spoof(protocol, "question name mismatch".to_string()));
+        }
+
+        // Cookie echo only protects plain-UDP/TCP upstreams; encrypted transports
+        // are already authenticated by TLS.
+        if let Some(ref expected) = self.client_cookie {
+            if is_do53(protocol) {
+                self.validate_cookie(msg, protocol, expected)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Compares the response question labels to what we sent. hickory `Name`
+    /// equality is case-INSENSITIVE, so we compare label bytes ourselves —
+    /// case-sensitively only when 0x20 was applied AND the response is Do53
+    /// (encrypted transports are TLS-authenticated, so we tolerate upstreams that
+    /// normalize QNAME case); otherwise ASCII-case-insensitively.
+    fn qname_matches(&self, name: &Name, protocol: &DnsProtocol) -> bool {
+        let mut got = name.iter();
+        let mut want = self.expected_labels.iter();
+        loop {
+            match (got.next(), want.next()) {
+                (Some(g), Some(w)) => {
+                    let eq = if self.case_sensitive && is_do53(protocol) {
+                        g == w.as_slice()
+                    } else {
+                        g.eq_ignore_ascii_case(w)
+                    };
+                    if !eq {
+                        return false;
+                    }
+                }
+                (None, None) => return true,
+                _ => return false,
+            }
+        }
+    }
+
+    fn validate_cookie(
+        &self,
+        msg: &Message,
+        protocol: &DnsProtocol,
+        expected: &[u8; CLIENT_COOKIE_LEN],
+    ) -> Result<(), DomainError> {
+        let echoed = msg
+            .extensions()
+            .as_ref()
+            .and_then(|edns| extract_cookie(edns.options().as_ref().iter()));
+
+        match echoed {
+            // Graceful: upstream did not echo a cookie (no DNS Cookies support).
+            None => Ok(()),
+            Some(data) if data.len() < CLIENT_COOKIE_LEN => Err(self.spoof(
+                protocol,
+                format!("malformed cookie option ({} bytes)", data.len()),
+            )),
+            Some(data) => {
+                use subtle::ConstantTimeEq;
+                if bool::from(data[..CLIENT_COOKIE_LEN].ct_eq(&expected[..])) {
+                    Ok(())
+                } else {
+                    Err(self.spoof(protocol, "client cookie echo mismatch".to_string()))
+                }
+            }
+        }
+    }
+
+    fn spoof(&self, protocol: &DnsProtocol, reason: String) -> DomainError {
+        DomainError::SpoofedResponse {
+            server: protocol.to_string(),
+            reason,
+        }
+    }
+}
+
+fn is_do53(protocol: &DnsProtocol) -> bool {
+    matches!(protocol, DnsProtocol::Udp { .. } | DnsProtocol::Tcp { .. })
+}
+
+fn extract_cookie<'a>(
+    mut options: impl Iterator<Item = &'a (EdnsCode, EdnsOption)>,
+) -> Option<Vec<u8>> {
+    options.find_map(|(_, opt)| match opt {
+        EdnsOption::Unknown(COOKIE_OPTION_CODE, data) => Some(data.clone()),
+        _ => None,
+    })
+}

--- a/crates/infrastructure/src/dns/load_balancer/balanced.rs
+++ b/crates/infrastructure/src/dns/load_balancer/balanced.rs
@@ -31,6 +31,7 @@ impl BalancedStrategy {
                 ctx.domain,
                 ctx.record_type,
                 ctx.timeout_ms,
+                ctx.validator,
                 ctx.emitter,
                 ctx.pool_name,
                 ctx.server_displays,

--- a/crates/infrastructure/src/dns/load_balancer/failover.rs
+++ b/crates/infrastructure/src/dns/load_balancer/failover.rs
@@ -24,6 +24,7 @@ impl FailoverStrategy {
                 ctx.domain,
                 ctx.record_type,
                 ctx.timeout_ms,
+                ctx.validator,
                 ctx.emitter,
                 ctx.pool_name,
                 ctx.server_displays,

--- a/crates/infrastructure/src/dns/load_balancer/parallel.rs
+++ b/crates/infrastructure/src/dns/load_balancer/parallel.rs
@@ -32,6 +32,7 @@ impl ParallelStrategy {
                     &domain,
                     &record_type,
                     ctx.timeout_ms,
+                    ctx.validator,
                     &emitter,
                     &pool_name,
                     &sd,
@@ -46,7 +47,10 @@ impl ParallelStrategy {
                 })
             }
             2 => {
-                // tokio::select! races both upstreams on the stack — zero heap alloc vs FuturesUnordered.
+                // Race both upstreams on the stack (zero heap alloc vs FuturesUnordered),
+                // preferring the first *successful* answer: if whichever finishes first
+                // is an error (e.g. a rejected off-path forgery), fall back to the other
+                // instead of failing the whole attempt.
                 let s0 = Arc::clone(ctx.servers[0]);
                 let s1 = Arc::clone(ctx.servers[1]);
                 let domain = Arc::clone(ctx.domain);
@@ -56,29 +60,53 @@ impl ParallelStrategy {
                 let pool_name = Arc::clone(ctx.pool_name);
                 let sd = Arc::clone(ctx.server_displays);
                 let qb = Arc::clone(&ctx.query_bytes);
+                let validator = Arc::clone(ctx.validator);
                 let timeout_ms = ctx.timeout_ms;
 
                 let result = timeout(Duration::from_millis(timeout_ms), async move {
-                    tokio::select! {
-                        r = query_server(&s0, &qb, &domain, &record_type, timeout_ms, &emitter0, &pool_name, &sd) => {
-                            r.map(|r| UpstreamResult {
-                                response: r.response,
-                                server: r.server_addr,
-                                latency_ms: r.latency_ms,
-                                pool_name: Arc::clone(&pool_name),
-                                server_display: r.server_display,
-                            })
-                        }
-                        r = query_server(&s1, &qb, &domain, &record_type, timeout_ms, &emitter1, &pool_name, &sd) => {
-                            r.map(|r| UpstreamResult {
-                                response: r.response,
-                                server: r.server_addr,
-                                latency_ms: r.latency_ms,
-                                pool_name: Arc::clone(&pool_name),
-                                server_display: r.server_display,
-                            })
-                        }
-                    }
+                    let f0 = query_server(
+                        &s0,
+                        &qb,
+                        &domain,
+                        &record_type,
+                        timeout_ms,
+                        &validator,
+                        &emitter0,
+                        &pool_name,
+                        &sd,
+                    );
+                    let f1 = query_server(
+                        &s1,
+                        &qb,
+                        &domain,
+                        &record_type,
+                        timeout_ms,
+                        &validator,
+                        &emitter1,
+                        &pool_name,
+                        &sd,
+                    );
+                    tokio::pin!(f0, f1);
+
+                    // Track which future settled first so the fallback only re-awaits
+                    // the *other* one (re-polling a completed future would panic).
+                    let (first_idx, first) = tokio::select! {
+                        r = &mut f0 => (0u8, r),
+                        r = &mut f1 => (1u8, r),
+                    };
+                    let winner = match first {
+                        Ok(r) => Ok(r),
+                        Err(_) if first_idx == 0 => (&mut f1).await,
+                        Err(_) => (&mut f0).await,
+                    };
+
+                    winner.map(|r| UpstreamResult {
+                        response: r.response,
+                        server: r.server_addr,
+                        latency_ms: r.latency_ms,
+                        pool_name: Arc::clone(&pool_name),
+                        server_display: r.server_display,
+                    })
                 })
                 .await;
 
@@ -102,6 +130,7 @@ impl ParallelStrategy {
                     let pool_name = Arc::clone(ctx.pool_name);
                     let server_displays = Arc::clone(ctx.server_displays);
                     let query_bytes = Arc::clone(&ctx.query_bytes);
+                    let validator = Arc::clone(ctx.validator);
 
                     futs.push(async move {
                         query_server(
@@ -110,6 +139,7 @@ impl ParallelStrategy {
                             &domain,
                             &record_type,
                             per_server_timeout_ms,
+                            &validator,
                             &emitter,
                             &pool_name,
                             &server_displays,

--- a/crates/infrastructure/src/dns/load_balancer/pool.rs
+++ b/crates/infrastructure/src/dns/load_balancer/pool.rs
@@ -4,7 +4,7 @@ use super::health::HealthChecker;
 use super::parallel::ParallelStrategy;
 use super::strategy::{QueryContext, Strategy, UpstreamResult};
 use crate::dns::events::QueryEventEmitter;
-use crate::dns::forwarding::{MessageBuilder, ResponseParser};
+use crate::dns::forwarding::{HardeningOpts, MessageBuilder, ResponseParser};
 use crate::dns::transport::resolver;
 use arc_swap::ArcSwap;
 use ferrous_dns_domain::{
@@ -22,6 +22,8 @@ pub struct PoolManager {
     pools: ArcSwap<Vec<PoolWithStrategy>>,
     health_checker: Option<Arc<HealthChecker>>,
     emitter: QueryEventEmitter,
+    /// Anti-spoofing hardening applied to A/AAAA upstream queries (DNS Cookies + 0x20).
+    hardening: HardeningOpts,
 }
 
 /// Maps one original configured server string to its resolved protocol entries.
@@ -55,7 +57,20 @@ impl PoolManager {
             pools: ArcSwap::from_pointee(pools_with_strategy),
             health_checker,
             emitter,
+            // Cookie echo validation is always-on (safe + graceful); 0x20 case
+            // randomization is opt-in via `with_hardening`.
+            hardening: HardeningOpts {
+                cookie: true,
+                qname_0x20: false,
+            },
         })
+    }
+
+    /// Overrides the anti-spoofing hardening applied to A/AAAA upstream queries.
+    /// Used by wiring to honor the `qname_case_randomization` config flag.
+    pub fn with_hardening(mut self, hardening: HardeningOpts) -> Self {
+        self.hardening = hardening;
+        self
     }
 
     /// Rebuilds the pool set from `pools` and atomically swaps it into the live
@@ -290,8 +305,10 @@ impl PoolManager {
             %domain, "Starting load balancer query"
         );
 
-        let query_bytes: Arc<[u8]> =
-            Arc::from(MessageBuilder::build_query(domain, record_type, dnssec_ok)?);
+        let (bytes, validator) =
+            MessageBuilder::build_query_hardened(domain, record_type, dnssec_ok, self.hardening)?;
+        let query_bytes: Arc<[u8]> = Arc::from(bytes);
+        let validator = Arc::new(validator);
 
         for pool in pools.iter() {
             let healthy_refs: SmallVec<[&Arc<DnsProtocol>; 16]> =
@@ -315,6 +332,7 @@ impl PoolManager {
                 record_type,
                 timeout_ms,
                 query_bytes: Arc::clone(&query_bytes),
+                validator: &validator,
                 emitter: &self.emitter,
                 pool_name: &pool.name_arc,
                 server_displays: &pool.server_displays,

--- a/crates/infrastructure/src/dns/load_balancer/query.rs
+++ b/crates/infrastructure/src/dns/load_balancer/query.rs
@@ -1,5 +1,5 @@
 use crate::dns::events::{QueryEvent, QueryEventEmitter};
-use crate::dns::forwarding::{DnsResponse, ResponseParser};
+use crate::dns::forwarding::{DnsResponse, ResponseParser, ResponseValidator};
 use crate::dns::transport;
 use ferrous_dns_domain::{DnsProtocol, DomainError, RecordType};
 use std::collections::HashMap;
@@ -28,6 +28,7 @@ pub async fn query_server(
     domain: &Arc<str>,
     record_type: &RecordType,
     timeout_ms: u64,
+    validator: &ResponseValidator,
     emitter: &QueryEventEmitter,
     pool_name: &Arc<str>,
     server_displays: &Arc<HashMap<Arc<DnsProtocol>, Arc<str>>>,
@@ -40,6 +41,10 @@ pub async fn query_server(
     let transport_response = dns_transport.send(query_bytes, timeout_duration).await?;
 
     let dns_response = ResponseParser::parse_bytes(transport_response.bytes)?;
+
+    // Reject spoofed/off-path responses before acting on them (incl. before the
+    // TCP-on-truncation retry below), so a forged TC=1 packet can't waste a retry.
+    validator.validate(&dns_response, protocol)?;
 
     let response_time_us = start.elapsed().as_micros() as u64;
     let server_arc = get_display(protocol, server_displays);
@@ -66,6 +71,7 @@ pub async fn query_server(
             let tcp_start = Instant::now();
             let tcp_response = tcp_transport.send(query_bytes, remaining).await?;
             let tcp_dns_response = ResponseParser::parse_bytes(tcp_response.bytes)?;
+            validator.validate(&tcp_dns_response, &tcp_protocol)?;
 
             let tcp_response_time_us = tcp_start.elapsed().as_micros() as u64;
             let tcp_server_arc = get_display(&tcp_protocol, server_displays);

--- a/crates/infrastructure/src/dns/load_balancer/strategy.rs
+++ b/crates/infrastructure/src/dns/load_balancer/strategy.rs
@@ -2,7 +2,7 @@ use super::balanced::BalancedStrategy;
 use super::failover::FailoverStrategy;
 use super::parallel::ParallelStrategy;
 use crate::dns::events::QueryEventEmitter;
-use crate::dns::forwarding::DnsResponse;
+use crate::dns::forwarding::{DnsResponse, ResponseValidator};
 use ferrous_dns_domain::{DnsProtocol, DomainError, RecordType};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -22,6 +22,7 @@ pub struct QueryContext<'a> {
     pub record_type: &'a RecordType,
     pub timeout_ms: u64,
     pub query_bytes: Arc<[u8]>,
+    pub validator: &'a Arc<ResponseValidator>,
     pub emitter: &'a QueryEventEmitter,
     pub pool_name: &'a Arc<str>,
     pub server_displays: &'a Arc<std::collections::HashMap<Arc<DnsProtocol>, Arc<str>>>,

--- a/crates/infrastructure/src/dns/server.rs
+++ b/crates/infrastructure/src/dns/server.rs
@@ -178,33 +178,53 @@ impl DnsServerHandler {
             resp.add_query(q.clone());
         }
 
+        // Copies a record, lowercasing its owner name when `canonicalize` is set,
+        // so any 0x20-randomized case the upstream echoed is stripped before serving.
+        fn copy_record(record: &Record, canonicalize: bool) -> Record {
+            if !canonicalize {
+                return record.clone();
+            }
+            let mut copy = record.clone();
+            let lower = copy.name().to_lowercase();
+            copy.set_name(lower);
+            copy
+        }
+
         if addresses.is_empty() {
             if let Some(ref wire_data) = resolution.upstream_wire_data {
+                // A/AAAA queries may have been 0x20 case-randomized, so the upstream
+                // echoes mixed-case names. Rebuild the reply from the client's
+                // question (already on `resp`) and canonicalize copied record owner
+                // names, so our randomization never reaches the client. Non-address
+                // types are never randomized, so they keep the raw-bytes fast path
+                // (unless a cookie must be injected, which already rebuilds from the
+                // client question).
+                let is_address_type = matches!(our_rt, RecordType::A | RecordType::AAAA);
                 let has_cookie_to_inject = dns_request
                     .edns_cookie
                     .as_ref()
                     .is_some_and(|c| c.len() >= 8);
 
-                if has_cookie_to_inject {
+                if is_address_type || has_cookie_to_inject {
                     match Message::from_vec(wire_data) {
                         Ok(upstream_msg) => {
                             resp.set_response_code(upstream_msg.response_code());
                             for record in upstream_msg.answers() {
-                                resp.add_answer(record.clone());
+                                resp.add_answer(copy_record(record, is_address_type));
                             }
                             for record in upstream_msg.name_servers() {
-                                resp.add_name_server(record.clone());
+                                resp.add_name_server(copy_record(record, is_address_type));
                             }
                             for record in upstream_msg.additionals() {
-                                // skip existing OPT — we'll add our own with the server cookie
+                                // skip existing OPT — we add our own below
                                 if record.record_type() != hickory_proto::rr::RecordType::OPT {
-                                    resp.add_additional(record.clone());
+                                    resp.add_additional(copy_record(record, is_address_type));
                                 }
                             }
-                            // fall through to cookie injection below
+                            // fall through to EDNS/cookie handling + encode resp below
                         }
                         Err(_) => {
-                            // parse failed — fallback to raw bytes (no cookie)
+                            // parse failed — fall back to raw bytes (id-patched)
                             let mut response = wire_data.to_vec();
                             if response.len() >= 2 {
                                 response[0] = (query_id >> 8) as u8;
@@ -214,7 +234,7 @@ impl DnsServerHandler {
                         }
                     }
                 } else {
-                    // no cookie to inject — return raw bytes (fast path unchanged)
+                    // Non-address type with no cookie — raw bytes fast path unchanged.
                     let mut response = wire_data.to_vec();
                     if response.len() >= 2 {
                         response[0] = (query_id >> 8) as u8;

--- a/crates/infrastructure/tests/dns_transport_test.rs
+++ b/crates/infrastructure/tests/dns_transport_test.rs
@@ -363,6 +363,12 @@ fn test_transport_error_classification_typed_variants() {
     assert!(ResponseParser::is_transport_error(
         &DomainError::TransportAllServersUnreachable
     ));
+    assert!(ResponseParser::is_transport_error(
+        &DomainError::SpoofedResponse {
+            server: "8.8.8.8:53".into(),
+            reason: "cookie mismatch".into()
+        }
+    ));
 
     assert!(!ResponseParser::is_transport_error(&DomainError::NxDomain));
     assert!(!ResponseParser::is_transport_error(&DomainError::Blocked));

--- a/crates/infrastructure/tests/live_upstream_test.rs
+++ b/crates/infrastructure/tests/live_upstream_test.rs
@@ -1,0 +1,85 @@
+//! Live (network) smoke test for upstream anti-spoofing against REAL public
+//! resolvers. `#[ignore]`d so it never runs in normal CI; run explicitly with:
+//!
+//!   cargo test -p ferrous-dns-infrastructure --test live_upstream_test -- --ignored --nocapture
+//!
+//! These confirm that real-world Do53 resolvers behave as the `ResponseValidator`
+//! assumes: the transaction ID + question match, the cookie echo (when supported)
+//! validates, and — for the 0x20 cases — the resolver preserves the randomized
+//! QNAME case so the case-sensitive question check still passes.
+
+use ferrous_dns_domain::{RecordType, UpstreamPool, UpstreamStrategy};
+use ferrous_dns_infrastructure::dns::events::QueryEventEmitter;
+use ferrous_dns_infrastructure::dns::forwarding::HardeningOpts;
+use ferrous_dns_infrastructure::dns::load_balancer::PoolManager;
+use std::sync::Arc;
+use std::time::Duration;
+
+async fn hardened_pm(server: &str, qname_0x20: bool) -> Arc<PoolManager> {
+    let pool = UpstreamPool {
+        name: "live".into(),
+        strategy: UpstreamStrategy::Parallel,
+        priority: 1,
+        servers: vec![server.to_string()],
+        weight: None,
+    };
+    Arc::new(
+        PoolManager::new(vec![pool], None, QueryEventEmitter::new_disabled())
+            .await
+            .unwrap()
+            .with_hardening(HardeningOpts {
+                cookie: true,
+                qname_0x20,
+            }),
+    )
+}
+
+async fn resolve_live(server: &str, domain: &str, qname_0x20: bool) {
+    let pm = hardened_pm(server, qname_0x20).await;
+    let domain: Arc<str> = Arc::from(domain);
+
+    // Real Do53 over the open internet drops packets and rate-limits bursts;
+    // retry with backoff so the smoke test only fails on a deterministic
+    // validation rejection, not a blip. (Each test targets a distinct resolver
+    // IP to avoid one process hammering the same server twice.)
+    let mut last_err = None;
+    for attempt in 0..4 {
+        if attempt > 0 {
+            tokio::time::sleep(Duration::from_millis(750)).await;
+        }
+        match pm.query(&domain, &RecordType::A, 5000, false).await {
+            Ok(result) => {
+                assert!(
+                    !result.response.addresses.is_empty(),
+                    "{server} returned no A records for {domain}"
+                );
+                println!(
+                    "{server} {domain} (cookie=on, 0x20={qname_0x20}) -> {:?}",
+                    result.response.addresses
+                );
+                return;
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    panic!("{server} response for {domain} failed anti-spoofing validation after 4 tries: {last_err:?}");
+}
+
+#[tokio::test]
+#[ignore = "live network: hits 9.9.9.9; run with --ignored"]
+async fn live_cookie_only() {
+    // Most lenient mode (cookie graceful, case-insensitive question) against Quad9.
+    resolve_live("udp://9.9.9.9:53", "example.com", false).await;
+}
+
+#[tokio::test]
+#[ignore = "live network: hits 1.1.1.1; run with --ignored"]
+async fn live_cloudflare_cookie_and_0x20() {
+    resolve_live("udp://1.1.1.1:53", "example.com", true).await;
+}
+
+#[tokio::test]
+#[ignore = "live network: hits 8.8.8.8; run with --ignored"]
+async fn live_google_cookie_and_0x20() {
+    resolve_live("udp://8.8.8.8:53", "cloudflare.com", true).await;
+}

--- a/crates/infrastructure/tests/message_builder_hardened_test.rs
+++ b/crates/infrastructure/tests/message_builder_hardened_test.rs
@@ -1,0 +1,165 @@
+use ferrous_dns_domain::{DnsProtocol, RecordType, UpstreamAddr};
+use ferrous_dns_infrastructure::dns::forwarding::{
+    DnsResponse, HardeningOpts, MessageBuilder, ResponseParser,
+};
+use hickory_proto::op::{Edns, Message, MessageType, OpCode, Query, ResponseCode};
+use hickory_proto::rr::rdata::opt::EdnsOption;
+use hickory_proto::rr::{DNSClass, Name, RecordType as HRecordType};
+use hickory_proto::serialize::binary::BinEncodable;
+
+fn hardened() -> HardeningOpts {
+    HardeningOpts {
+        cookie: true,
+        qname_0x20: true,
+    }
+}
+
+fn udp() -> DnsProtocol {
+    DnsProtocol::Udp {
+        addr: UpstreamAddr::Resolved("8.8.8.8:53".parse().unwrap()),
+    }
+}
+
+fn cookie_of(msg: &Message) -> Option<Vec<u8>> {
+    msg.extensions().as_ref().and_then(|edns| {
+        edns.options()
+            .as_ref()
+            .iter()
+            .find_map(|(_, opt)| match opt {
+                EdnsOption::Unknown(10, data) => Some(data.clone()),
+                _ => None,
+            })
+    })
+}
+
+fn labels(msg: &Message) -> Vec<Vec<u8>> {
+    msg.queries()[0].name().iter().map(|l| l.to_vec()).collect()
+}
+
+fn has_upper(labels: &[Vec<u8>]) -> bool {
+    labels.iter().any(|l| l.iter().any(u8::is_ascii_uppercase))
+}
+
+fn build_response(id: u16, name: &Name, qtype: HRecordType, cookie: Option<&[u8]>) -> DnsResponse {
+    let mut query = Query::new();
+    query.set_name(name.clone());
+    query.set_query_type(qtype);
+    query.set_query_class(DNSClass::IN);
+
+    let mut msg = Message::new(id, MessageType::Response, OpCode::Query);
+    msg.set_response_code(ResponseCode::NoError);
+    msg.add_query(query);
+    if let Some(c) = cookie {
+        let mut edns = Edns::new();
+        edns.set_max_payload(4096);
+        edns.options_mut()
+            .insert(EdnsOption::Unknown(10, c.to_vec()));
+        msg.set_edns(edns);
+    }
+    ResponseParser::parse_bytes(msg.to_bytes().unwrap().into()).unwrap()
+}
+
+#[test]
+fn a_query_carries_cookie() {
+    let (bytes, _) =
+        MessageBuilder::build_query_hardened("example.com", &RecordType::A, false, hardened())
+            .unwrap();
+    let msg = Message::from_vec(&bytes).unwrap();
+    assert_eq!(
+        cookie_of(&msg).map(|c| c.len()),
+        Some(8),
+        "A query must carry an 8-byte client cookie"
+    );
+}
+
+#[test]
+fn a_query_randomizes_qname_case() {
+    // 0x20 is random per build; across many builds at least one must show an
+    // uppercase letter (all-lowercase odds per build are ~2^-10).
+    let saw_upper = (0..16).any(|_| {
+        let (bytes, _) =
+            MessageBuilder::build_query_hardened("example.com", &RecordType::A, false, hardened())
+                .unwrap();
+        has_upper(&labels(&Message::from_vec(&bytes).unwrap()))
+    });
+    assert!(saw_upper, "A query qname must be 0x20 case-randomized");
+}
+
+#[test]
+fn aaaa_query_carries_cookie_and_randomizes_qname_case() {
+    // AAAA is the other address type the gate hardens alongside A: every build
+    // must carry a cookie, and across many builds at least one must show 0x20 case.
+    let saw_upper = (0..16).any(|_| {
+        let (bytes, _) = MessageBuilder::build_query_hardened(
+            "example.com",
+            &RecordType::AAAA,
+            false,
+            hardened(),
+        )
+        .unwrap();
+        let msg = Message::from_vec(&bytes).unwrap();
+        assert_eq!(
+            cookie_of(&msg).map(|c| c.len()),
+            Some(8),
+            "AAAA query must carry an 8-byte client cookie"
+        );
+        has_upper(&labels(&msg))
+    });
+    assert!(saw_upper, "AAAA query qname must be 0x20 case-randomized");
+}
+
+#[test]
+fn non_address_query_is_plain() {
+    for rt in [RecordType::MX, RecordType::TXT] {
+        for _ in 0..16 {
+            let (bytes, _) =
+                MessageBuilder::build_query_hardened("example.com", &rt, false, hardened())
+                    .unwrap();
+            let msg = Message::from_vec(&bytes).unwrap();
+            assert!(cookie_of(&msg).is_none(), "{rt:?} must not carry a cookie");
+            assert!(
+                !has_upper(&labels(&msg)),
+                "{rt:?} must not be case-randomized"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_query_is_plain_when_opts_disabled() {
+    let (bytes, _) = MessageBuilder::build_query_hardened(
+        "example.com",
+        &RecordType::A,
+        false,
+        HardeningOpts::default(),
+    )
+    .unwrap();
+    let msg = Message::from_vec(&bytes).unwrap();
+    assert!(cookie_of(&msg).is_none());
+    assert!(!has_upper(&labels(&msg)));
+}
+
+#[test]
+fn returned_validator_accepts_faithful_echo_and_rejects_tampered_cookie() {
+    let (bytes, validator) =
+        MessageBuilder::build_query_hardened("example.org", &RecordType::A, false, hardened())
+            .unwrap();
+    let query = Message::from_vec(&bytes).unwrap();
+    let id = query.id();
+    let name = query.queries()[0].name().clone();
+    let cookie = cookie_of(&query).unwrap();
+
+    let faithful = build_response(id, &name, HRecordType::A, Some(&cookie));
+    assert!(
+        validator.validate(&faithful, &udp()).is_ok(),
+        "a faithful echo must validate"
+    );
+
+    let mut tampered = cookie.clone();
+    tampered[0] ^= 0xFF;
+    let bad = build_response(id, &name, HRecordType::A, Some(&tampered));
+    assert!(
+        validator.validate(&bad, &udp()).is_err(),
+        "a tampered cookie must be rejected"
+    );
+}

--- a/crates/infrastructure/tests/qname_0x20_test.rs
+++ b/crates/infrastructure/tests/qname_0x20_test.rs
@@ -1,0 +1,106 @@
+//! T0 spike: does hickory preserve mixed-case QNAME label bytes through an
+//! emit -> parse wire round-trip? This is the precondition for implementing
+//! 0x20 QNAME randomization via `hickory_proto::rr::Name`. If these assertions
+//! hold, `build_query_hardened` can randomize case on the `Name`; if they ever
+//! regress, fall back to stamping case directly on the serialized QNAME bytes.
+
+use hickory_proto::op::{Message, MessageType, OpCode, Query};
+use hickory_proto::rr::{DNSClass, Name, RecordType};
+use hickory_proto::serialize::binary::{BinEncodable, BinEncoder};
+use std::str::FromStr;
+
+fn labels(name: &Name) -> Vec<Vec<u8>> {
+    name.iter().map(|label| label.to_vec()).collect()
+}
+
+#[test]
+fn name_from_str_lowercases_labels() {
+    // FINDING: hickory `Name::from_str` lowercases labels, so 0x20 randomization
+    // cannot go through `from_str` — it must build the Name from raw label bytes
+    // (see `name_from_labels_preserves_case_through_roundtrip`).
+    let name = Name::from_str("ExAmPlE.cOm").unwrap();
+    let has_upper = name
+        .iter()
+        .any(|label| label.iter().any(u8::is_ascii_uppercase));
+    assert!(!has_upper, "Name::from_str unexpectedly preserved case");
+}
+
+#[test]
+fn name_from_labels_preserves_case_through_roundtrip() {
+    // The viable 0x20 path: construct the Name from raw mixed-case label bytes,
+    // which must survive both construction and the emit -> parse wire round-trip.
+    let raw: [&[u8]; 2] = [b"eXaMpLe", b"NeT"];
+    let original = Name::from_labels(raw.iter().map(|l| l.to_vec())).unwrap();
+
+    let has_upper = original
+        .iter()
+        .any(|label| label.iter().any(u8::is_ascii_uppercase));
+    assert!(
+        has_upper,
+        "Name::from_labels must keep label case; got {:?}",
+        labels(&original)
+    );
+
+    let mut query = Query::new();
+    query.set_name(original.clone());
+    query.set_query_type(RecordType::A);
+    query.set_query_class(DNSClass::IN);
+
+    let mut message = Message::new(0x1234, MessageType::Query, OpCode::Query);
+    message.add_query(query);
+
+    let mut buf = Vec::new();
+    {
+        let mut encoder = BinEncoder::new(&mut buf);
+        message.emit(&mut encoder).unwrap();
+    }
+
+    let parsed = Message::from_vec(&buf).unwrap();
+    let parsed_labels = labels(parsed.queries()[0].name());
+
+    assert_eq!(
+        labels(&original),
+        parsed_labels,
+        "from_labels mixed case must survive emit -> parse for 0x20 to work"
+    );
+}
+
+#[test]
+fn name_equality_is_case_insensitive() {
+    // Documents the gotcha that drives the byte-wise 0x20 echo check: hickory's
+    // `Name` PartialEq ignores case, so `==` cannot detect a 0x20 mismatch.
+    let lower = Name::from_str("example.com").unwrap();
+    let upper = Name::from_str("EXAMPLE.COM").unwrap();
+    assert_eq!(
+        lower, upper,
+        "hickory Name equality should be case-insensitive"
+    );
+}
+
+#[test]
+fn mixed_case_qname_survives_wire_roundtrip() {
+    let original = Name::from_str("eXaMpLe.NeT").unwrap();
+    let original_labels = labels(&original);
+
+    let mut query = Query::new();
+    query.set_name(original.clone());
+    query.set_query_type(RecordType::A);
+    query.set_query_class(DNSClass::IN);
+
+    let mut message = Message::new(0x1234, MessageType::Query, OpCode::Query);
+    message.add_query(query);
+
+    let mut buf = Vec::new();
+    {
+        let mut encoder = BinEncoder::new(&mut buf);
+        message.emit(&mut encoder).unwrap();
+    }
+
+    let parsed = Message::from_vec(&buf).unwrap();
+    let parsed_labels = labels(parsed.queries()[0].name());
+
+    assert_eq!(
+        original_labels, parsed_labels,
+        "hickory must preserve mixed-case label bytes through emit -> parse for 0x20 to work"
+    );
+}

--- a/crates/infrastructure/tests/response_validator_test.rs
+++ b/crates/infrastructure/tests/response_validator_test.rs
@@ -1,0 +1,149 @@
+use ferrous_dns_domain::{DnsProtocol, DomainError, UpstreamAddr};
+use ferrous_dns_infrastructure::dns::forwarding::{DnsResponse, ResponseParser, ResponseValidator};
+use hickory_proto::op::{Edns, Message, MessageType, OpCode, Query, ResponseCode};
+use hickory_proto::rr::rdata::opt::EdnsOption;
+use hickory_proto::rr::{DNSClass, Name, RecordType};
+use hickory_proto::serialize::binary::BinEncodable;
+use std::sync::Arc;
+
+const ID: u16 = 0x1234;
+const COOKIE: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+
+fn udp() -> DnsProtocol {
+    DnsProtocol::Udp {
+        addr: UpstreamAddr::Resolved("8.8.8.8:53".parse().unwrap()),
+    }
+}
+
+fn https() -> DnsProtocol {
+    DnsProtocol::Https {
+        url: Arc::from("https://dns.google/dns-query"),
+        hostname: Arc::from("dns.google"),
+        resolved_addrs: vec![],
+    }
+}
+
+fn validator(cookie: Option<[u8; 8]>, case_sensitive: bool, labels: &[&[u8]]) -> ResponseValidator {
+    ResponseValidator::new(
+        ID,
+        labels.iter().map(|l| l.to_vec()).collect(),
+        RecordType::A,
+        cookie,
+        case_sensitive,
+    )
+}
+
+fn response(id: u16, labels: &[&[u8]], qtype: RecordType, cookie: Option<&[u8]>) -> DnsResponse {
+    let name = Name::from_labels(labels.iter().map(|l| l.to_vec())).unwrap();
+    let mut query = Query::new();
+    query.set_name(name);
+    query.set_query_type(qtype);
+    query.set_query_class(DNSClass::IN);
+
+    let mut msg = Message::new(id, MessageType::Response, OpCode::Query);
+    msg.set_response_code(ResponseCode::NoError);
+    msg.add_query(query);
+    if let Some(c) = cookie {
+        let mut edns = Edns::new();
+        edns.set_max_payload(4096);
+        edns.set_version(0);
+        edns.options_mut()
+            .insert(EdnsOption::Unknown(10, c.to_vec()));
+        msg.set_edns(edns);
+    }
+    ResponseParser::parse_bytes(msg.to_bytes().unwrap().into()).unwrap()
+}
+
+fn is_spoof(result: Result<(), DomainError>) -> bool {
+    matches!(result, Err(DomainError::SpoofedResponse { .. }))
+}
+
+#[test]
+fn accepts_matching_response_with_cookie_and_0x20() {
+    let v = validator(Some(COOKIE), true, &[b"eXaMpLe", b"CoM"]);
+    let resp = response(ID, &[b"eXaMpLe", b"CoM"], RecordType::A, Some(&COOKIE));
+    assert!(v.validate(&resp, &udp()).is_ok());
+}
+
+#[test]
+fn rejects_wrong_txid() {
+    let v = validator(Some(COOKIE), false, &[b"example", b"com"]);
+    let resp = response(0x9999, &[b"example", b"com"], RecordType::A, Some(&COOKIE));
+    assert!(is_spoof(v.validate(&resp, &udp())));
+}
+
+#[test]
+fn rejects_qname_case_mismatch_when_0x20() {
+    let v = validator(Some(COOKIE), true, &[b"eXaMpLe", b"com"]);
+    let resp = response(ID, &[b"example", b"com"], RecordType::A, Some(&COOKIE));
+    assert!(is_spoof(v.validate(&resp, &udp())));
+}
+
+#[test]
+fn accepts_qname_case_difference_when_not_0x20() {
+    let v = validator(None, false, &[b"example", b"com"]);
+    let resp = response(ID, &[b"ExAmPlE", b"CoM"], RecordType::A, None);
+    assert!(v.validate(&resp, &udp()).is_ok());
+}
+
+#[test]
+fn rejects_qtype_mismatch() {
+    let v = validator(None, false, &[b"example", b"com"]);
+    let resp = response(ID, &[b"example", b"com"], RecordType::AAAA, None);
+    assert!(is_spoof(v.validate(&resp, &udp())));
+}
+
+#[test]
+fn rejects_wrong_cookie() {
+    let v = validator(Some(COOKIE), false, &[b"example", b"com"]);
+    let resp = response(
+        ID,
+        &[b"example", b"com"],
+        RecordType::A,
+        Some(&[9, 9, 9, 9, 9, 9, 9, 9]),
+    );
+    assert!(is_spoof(v.validate(&resp, &udp())));
+}
+
+#[test]
+fn accepts_missing_cookie_gracefully() {
+    let v = validator(Some(COOKIE), false, &[b"example", b"com"]);
+    let resp = response(ID, &[b"example", b"com"], RecordType::A, None);
+    assert!(v.validate(&resp, &udp()).is_ok());
+}
+
+#[test]
+fn rejects_malformed_short_cookie() {
+    let v = validator(Some(COOKIE), false, &[b"example", b"com"]);
+    let resp = response(ID, &[b"example", b"com"], RecordType::A, Some(&[1, 2, 3]));
+    assert!(is_spoof(v.validate(&resp, &udp())));
+}
+
+#[test]
+fn skips_cookie_check_on_encrypted_transport() {
+    // Wrong cookie, but HTTPS is TLS-authenticated -> cookie echo not enforced.
+    let v = validator(Some(COOKIE), false, &[b"example", b"com"]);
+    let resp = response(
+        ID,
+        &[b"example", b"com"],
+        RecordType::A,
+        Some(&[9, 9, 9, 9, 9, 9, 9, 9]),
+    );
+    assert!(v.validate(&resp, &https()).is_ok());
+}
+
+#[test]
+fn skips_0x20_case_check_on_encrypted_transport() {
+    // 0x20 was applied (case_sensitive), so the same response over Do53 would be
+    // rejected (see `rejects_qname_case_mismatch_when_0x20`). Over HTTPS the
+    // upstream may normalize QNAME case; TLS already authenticates it, so a
+    // case-only difference must NOT be treated as a spoof.
+    let v = validator(Some(COOKIE), true, &[b"eXaMpLe", b"CoM"]);
+    let resp = response(ID, &[b"example", b"com"], RecordType::A, Some(&COOKIE));
+    assert!(
+        v.validate(&resp, &https()).is_ok(),
+        "encrypted transport must accept a case-normalized QNAME echo"
+    );
+    // Sanity: the very same mismatch is still rejected on Do53.
+    assert!(is_spoof(v.validate(&resp, &udp())));
+}

--- a/crates/infrastructure/tests/spoof_rejection_test.rs
+++ b/crates/infrastructure/tests/spoof_rejection_test.rs
@@ -1,0 +1,260 @@
+//! End-to-end anti-spoofing: drive `PoolManager::query` against a local UDP
+//! responder and assert that off-path forgeries (wrong transaction ID, wrong DNS
+//! Cookie) are rejected while a faithful echo is accepted.
+
+use ferrous_dns_domain::{RecordType, UpstreamPool, UpstreamStrategy};
+use ferrous_dns_infrastructure::dns::events::QueryEventEmitter;
+use ferrous_dns_infrastructure::dns::forwarding::HardeningOpts;
+use ferrous_dns_infrastructure::dns::load_balancer::PoolManager;
+use hickory_proto::op::{Edns, Message, MessageType, OpCode, Query, ResponseCode};
+use hickory_proto::rr::rdata::opt::EdnsOption;
+use hickory_proto::rr::Name;
+use hickory_proto::serialize::binary::BinEncodable;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, UdpSocket};
+
+#[derive(Clone, Copy)]
+enum Mode {
+    /// Echo the question with the correct transaction ID and no cookie.
+    Faithful,
+    /// Reply with a deliberately wrong transaction ID.
+    WrongTxid,
+    /// Echo the correct ID/question but attach a bogus cookie the client never sent.
+    WrongCookie,
+    /// Echo the correct ID but flip the case of one QNAME byte — an off-path forger
+    /// guessing the 0x20-randomized case wrong.
+    FlipQnameCase,
+}
+
+/// Spawns a UDP DNS responder on an ephemeral port and returns its address.
+async fn spawn_responder(mode: Mode) -> SocketAddr {
+    let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = socket.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 1500];
+        while let Ok((len, peer)) = socket.recv_from(&mut buf).await {
+            let Ok(req) = Message::from_vec(&buf[..len]) else {
+                continue;
+            };
+
+            let id = match mode {
+                Mode::WrongTxid => req.id() ^ 0xFFFF,
+                _ => req.id(),
+            };
+            let mut resp = Message::new(id, MessageType::Response, OpCode::Query);
+            resp.set_recursion_desired(true);
+            resp.set_recursion_available(true);
+            resp.set_response_code(ResponseCode::NoError);
+            for q in req.queries() {
+                if let Mode::FlipQnameCase = mode {
+                    // Flip the 0x20 bit of the first label's first byte: since that
+                    // byte is always an ASCII letter, this is a guaranteed (non-flaky)
+                    // case mismatch versus the randomized QNAME the client sent.
+                    let mut labels: Vec<Vec<u8>> = q.name().iter().map(|l| l.to_vec()).collect();
+                    if let Some(b) = labels.first_mut().and_then(|l| l.first_mut()) {
+                        *b ^= 0x20;
+                    }
+                    let mut flipped = Query::new();
+                    flipped.set_name(Name::from_labels(labels).unwrap());
+                    flipped.set_query_type(q.query_type());
+                    flipped.set_query_class(q.query_class());
+                    resp.add_query(flipped);
+                } else {
+                    resp.add_query(q.clone());
+                }
+            }
+            if let Mode::WrongCookie = mode {
+                let mut edns = Edns::new();
+                edns.set_max_payload(4096);
+                edns.set_version(0);
+                edns.options_mut()
+                    .insert(EdnsOption::Unknown(10, vec![9; 8]));
+                resp.set_edns(edns);
+            }
+
+            let _ = socket.send_to(&resp.to_bytes().unwrap(), peer).await;
+        }
+    });
+
+    addr
+}
+
+async fn manager(addr: SocketAddr) -> Arc<PoolManager> {
+    let pool = UpstreamPool {
+        name: "test".into(),
+        strategy: UpstreamStrategy::Parallel,
+        priority: 1,
+        servers: vec![format!("udp://{addr}")],
+        weight: None,
+    };
+    Arc::new(
+        PoolManager::new(vec![pool], None, QueryEventEmitter::new_disabled())
+            .await
+            .unwrap(),
+    )
+}
+
+/// Like [`manager`], but with 0x20 QNAME case randomization enabled so the
+/// validator enforces case-sensitive QNAME matching on Do53 responses.
+async fn manager_hardened(addr: SocketAddr) -> Arc<PoolManager> {
+    let pool = UpstreamPool {
+        name: "test".into(),
+        strategy: UpstreamStrategy::Parallel,
+        priority: 1,
+        servers: vec![format!("udp://{addr}")],
+        weight: None,
+    };
+    Arc::new(
+        PoolManager::new(vec![pool], None, QueryEventEmitter::new_disabled())
+            .await
+            .unwrap()
+            .with_hardening(HardeningOpts {
+                cookie: true,
+                qname_0x20: true,
+            }),
+    )
+}
+
+async fn resolve(mode: Mode) -> Result<SocketAddr, ferrous_dns_domain::DomainError> {
+    let addr = spawn_responder(mode).await;
+    let pm = manager(addr).await;
+    let domain: Arc<str> = Arc::from("example.com");
+    pm.query(&domain, &RecordType::A, 2000, false)
+        .await
+        .map(|r| r.server)
+}
+
+#[tokio::test]
+async fn faithful_upstream_response_is_accepted() {
+    let result = resolve(Mode::Faithful).await;
+    assert!(
+        result.is_ok(),
+        "faithful response must be accepted: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn spoofed_transaction_id_is_rejected() {
+    let result = resolve(Mode::WrongTxid).await;
+    assert!(
+        result.is_err(),
+        "a response with the wrong transaction ID must be rejected, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn forged_cookie_is_rejected() {
+    let result = resolve(Mode::WrongCookie).await;
+    assert!(
+        result.is_err(),
+        "a response echoing a cookie the client never sent must be rejected, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn case_forged_qname_is_rejected_with_0x20() {
+    // With 0x20 on, a faithful upstream echoes the randomized QNAME case verbatim.
+    // A response that gets the case wrong (an off-path forger) must be rejected.
+    let addr = spawn_responder(Mode::FlipQnameCase).await;
+    let pm = manager_hardened(addr).await;
+    let domain: Arc<str> = Arc::from("example.com");
+    let result = pm.query(&domain, &RecordType::A, 2000, false).await;
+    assert!(
+        result.is_err(),
+        "a case-flipped QNAME echo must be rejected under 0x20, got {result:?}"
+    );
+}
+
+/// Spawns a UDP responder that always answers with TC=1 (truncated), paired with
+/// a TCP responder on the same port. The UDP TC=1 forces the truncation retry;
+/// the TCP side replies per `tcp_mode`, letting us assert the validator also runs
+/// on the post-truncation TCP path (`query_server`'s second validate site).
+async fn spawn_truncating_pair(tcp_mode: Mode) -> SocketAddr {
+    let udp = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = udp.local_addr().unwrap();
+    let listener = TcpListener::bind(addr).await.unwrap();
+
+    // UDP side: faithful echo but TC=1, so the response passes the first validate
+    // and then triggers the TCP retry.
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 1500];
+        while let Ok((len, peer)) = udp.recv_from(&mut buf).await {
+            let Ok(req) = Message::from_vec(&buf[..len]) else {
+                continue;
+            };
+            let mut resp = Message::new(req.id(), MessageType::Response, OpCode::Query);
+            resp.set_recursion_desired(true);
+            resp.set_recursion_available(true);
+            resp.set_response_code(ResponseCode::NoError);
+            resp.set_truncated(true);
+            for q in req.queries() {
+                resp.add_query(q.clone());
+            }
+            let _ = udp.send_to(&resp.to_bytes().unwrap(), peer).await;
+        }
+    });
+
+    // TCP side: length-prefixed DNS; the truncation retry lands here.
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut lenbuf = [0u8; 2];
+                if stream.read_exact(&mut lenbuf).await.is_err() {
+                    return;
+                }
+                let qlen = u16::from_be_bytes(lenbuf) as usize;
+                let mut qbuf = vec![0u8; qlen];
+                if stream.read_exact(&mut qbuf).await.is_err() {
+                    return;
+                }
+                let Ok(req) = Message::from_vec(&qbuf) else {
+                    return;
+                };
+                let id = match tcp_mode {
+                    Mode::WrongTxid => req.id() ^ 0xFFFF,
+                    _ => req.id(),
+                };
+                let mut resp = Message::new(id, MessageType::Response, OpCode::Query);
+                resp.set_recursion_desired(true);
+                resp.set_recursion_available(true);
+                resp.set_response_code(ResponseCode::NoError);
+                for q in req.queries() {
+                    resp.add_query(q.clone());
+                }
+                let bytes = resp.to_bytes().unwrap();
+                let mut framed = (bytes.len() as u16).to_be_bytes().to_vec();
+                framed.extend_from_slice(&bytes);
+                let _ = stream.write_all(&framed).await;
+            });
+        }
+    });
+
+    addr
+}
+
+#[tokio::test]
+async fn validator_runs_on_post_truncation_tcp_retry() {
+    let domain: Arc<str> = Arc::from("example.com");
+
+    // Faithful TCP reply after a TC=1 UDP answer must resolve.
+    let addr = spawn_truncating_pair(Mode::Faithful).await;
+    let pm = manager(addr).await;
+    let ok = pm.query(&domain, &RecordType::A, 2000, false).await;
+    assert!(
+        ok.is_ok(),
+        "a faithful post-truncation TCP retry must resolve: {ok:?}"
+    );
+
+    // A forged TCP retry (wrong transaction ID) must be rejected at the second
+    // validate site — not silently accepted because validation only ran on UDP.
+    let addr = spawn_truncating_pair(Mode::WrongTxid).await;
+    let pm = manager(addr).await;
+    let bad = pm.query(&domain, &RecordType::A, 2000, false).await;
+    assert!(
+        bad.is_err(),
+        "a wrong-txid TCP retry must be rejected, got {bad:?}"
+    );
+}

--- a/crates/infrastructure/tests/upstream_anti_spoofing_cache_test.rs
+++ b/crates/infrastructure/tests/upstream_anti_spoofing_cache_test.rs
@@ -1,0 +1,217 @@
+//! Regression: 0x20 QNAME case randomization is applied to the *upstream* wire
+//! only, and the anti-spoofing cookie path (validated vs. graceful) does not
+//! disturb caching. Addresses come from rdata IPs, never the (randomized-case)
+//! owner name, and the cache key is the client's lowercased domain.
+
+use ferrous_dns_application::ports::DnsResolver;
+use ferrous_dns_domain::{DnsQuery, RecordType, UpstreamPool, UpstreamStrategy};
+use ferrous_dns_infrastructure::dns::events::QueryEventEmitter;
+use ferrous_dns_infrastructure::dns::forwarding::HardeningOpts;
+use ferrous_dns_infrastructure::dns::load_balancer::PoolManager;
+use ferrous_dns_infrastructure::dns::resolver::{CachedResolver, CoreResolver};
+use ferrous_dns_infrastructure::dns::{
+    DnsCache, DnsCacheAccess, DnsCacheConfig, EvictionStrategy, NegativeQueryTracker,
+};
+use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
+use hickory_proto::rr::rdata::A;
+use hickory_proto::rr::{RData, Record};
+use hickory_proto::serialize::binary::BinEncodable;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use tokio::net::UdpSocket;
+
+const UPSTREAM_IP: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 7);
+
+/// Faithful A-record responder. Records the raw QNAME label bytes (preserving
+/// on-wire case) of every query, so tests can confirm 0x20 reached upstream and
+/// count how many times the upstream was actually hit. When `echo_cookie` is set
+/// it mirrors the client's EDNS OPT back (a cookie-supporting upstream); when
+/// not, it answers with no OPT (an upstream without DNS Cookies — graceful path).
+async fn spawn_responder(seen: Arc<Mutex<Vec<Vec<u8>>>>, echo_cookie: bool) -> SocketAddr {
+    let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = socket.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 1500];
+        while let Ok((len, peer)) = socket.recv_from(&mut buf).await {
+            let Ok(req) = Message::from_vec(&buf[..len]) else {
+                continue;
+            };
+            let Some(q) = req.queries().first().cloned() else {
+                continue;
+            };
+            seen.lock()
+                .unwrap()
+                .push(q.name().iter().flat_map(|l| l.to_vec()).collect());
+
+            let mut resp = Message::new(req.id(), MessageType::Response, OpCode::Query);
+            resp.set_recursion_desired(true);
+            resp.set_recursion_available(true);
+            resp.set_response_code(ResponseCode::NoError);
+            resp.add_query(q.clone());
+            // Owner name echoes the randomized query name; the parser must still
+            // extract the IP by rdata regardless of its case.
+            resp.add_answer(Record::from_rdata(
+                q.name().clone(),
+                300,
+                RData::A(A(UPSTREAM_IP)),
+            ));
+            // A cookie-supporting upstream echoes the client's COOKIE option back
+            // (validated path); copying the request OPT carries option 10 verbatim.
+            if echo_cookie {
+                if let Some(edns) = req.extensions().clone() {
+                    resp.set_edns(edns);
+                }
+            }
+
+            let _ = socket.send_to(&resp.to_bytes().unwrap(), peer).await;
+        }
+    });
+
+    addr
+}
+
+async fn manager(addr: SocketAddr, qname_0x20: bool) -> Arc<PoolManager> {
+    let pool = UpstreamPool {
+        name: "test".into(),
+        strategy: UpstreamStrategy::Parallel,
+        priority: 1,
+        servers: vec![format!("udp://{addr}")],
+        weight: None,
+    };
+    Arc::new(
+        PoolManager::new(vec![pool], None, QueryEventEmitter::new_disabled())
+            .await
+            .unwrap()
+            .with_hardening(HardeningOpts {
+                cookie: true,
+                qname_0x20,
+            }),
+    )
+}
+
+fn make_cache() -> Arc<dyn DnsCacheAccess> {
+    Arc::new(DnsCache::new(DnsCacheConfig {
+        max_entries: 1000,
+        eviction_strategy: EvictionStrategy::LRU,
+        min_threshold: 2.0,
+        refresh_threshold: 0.75,
+        batch_eviction_percentage: 0.2,
+        adaptive_thresholds: false,
+        min_frequency: 0,
+        min_lfuk_score: 0.0,
+        shard_amount: 4,
+        access_window_secs: 7200,
+        eviction_sample_size: 8,
+        lfuk_k_value: 0.5,
+        refresh_sample_rate: 1.0,
+        min_ttl: 0,
+        max_ttl: 86_400,
+    }))
+}
+
+#[tokio::test]
+async fn hardening_does_not_corrupt_address_extraction() {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let addr = spawn_responder(seen, false).await;
+    let pm = manager(addr, true).await;
+
+    let domain: Arc<str> = Arc::from("example.com");
+    let result = pm
+        .query(&domain, &RecordType::A, 2000, false)
+        .await
+        .expect("faithful A response must resolve");
+
+    // The served/cached value is exact: addresses come from rdata, not the
+    // randomized-case owner name.
+    assert_eq!(result.response.addresses, vec![IpAddr::V4(UPSTREAM_IP)]);
+}
+
+#[tokio::test]
+async fn zero_x20_randomizes_qname_on_the_wire_only() {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let addr = spawn_responder(seen.clone(), false).await;
+    let pm = manager(addr, true).await;
+
+    let domain: Arc<str> = Arc::from("example.com");
+    // 0x20 is random per query; over several queries at least one upstream QNAME
+    // must carry an uppercase letter (all-lowercase odds per query are ~2^-10).
+    for _ in 0..16 {
+        let _ = pm.query(&domain, &RecordType::A, 2000, false).await;
+    }
+
+    let observed = seen.lock().unwrap().clone();
+    assert!(!observed.is_empty(), "responder should have seen queries");
+    let saw_upper = observed
+        .iter()
+        .any(|bytes| bytes.iter().any(u8::is_ascii_uppercase));
+    assert!(
+        saw_upper,
+        "0x20 must randomize the upstream QNAME case; saw {observed:?}"
+    );
+
+    // Our side keyed on the client's domain, untouched by upstream randomization.
+    assert_eq!(&*domain, "example.com");
+}
+
+/// Drives queries through the full cache stack (`CachedResolver` ->
+/// `CoreResolver` -> `PoolManager`) against a live UDP upstream. We always send a
+/// cookie (hardening on); `echo_cookie` toggles whether the upstream supports
+/// cookies. Either way: first query is a miss that hits upstream once, the second
+/// identical query is a cache hit that does NOT touch the upstream.
+async fn assert_cache_hit_miss(echo_cookie: bool) {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let addr = spawn_responder(seen.clone(), echo_cookie).await;
+    let pm = manager(addr, false).await;
+
+    let core = Arc::new(CoreResolver::new(pm, 2000, false));
+    let resolver = Arc::new(CachedResolver::new(
+        core as Arc<dyn DnsResolver>,
+        make_cache(),
+        300,
+        Arc::new(NegativeQueryTracker::new()),
+        4,
+    ));
+
+    let query = DnsQuery {
+        domain: Arc::from("example.com"),
+        record_type: RecordType::A,
+    };
+
+    let first = resolver
+        .resolve(&query)
+        .await
+        .expect("first resolve must succeed");
+    assert!(!first.cache_hit, "first query is a cache miss");
+    assert_eq!(first.addresses.to_vec(), vec![IpAddr::V4(UPSTREAM_IP)]);
+    assert_eq!(
+        seen.lock().unwrap().len(),
+        1,
+        "upstream queried exactly once on the miss"
+    );
+
+    let second = resolver
+        .resolve(&query)
+        .await
+        .expect("second resolve must succeed");
+    assert!(
+        second.cache_hit,
+        "second identical query is served from cache"
+    );
+    assert_eq!(second.addresses.to_vec(), vec![IpAddr::V4(UPSTREAM_IP)]);
+    assert_eq!(
+        seen.lock().unwrap().len(),
+        1,
+        "cache hit must NOT re-query the upstream"
+    );
+}
+
+#[tokio::test]
+async fn cache_hit_miss_with_cookie_echoing_upstream() {
+    assert_cache_hit_miss(true).await;
+}
+
+#[tokio::test]
+async fn cache_hit_miss_with_non_cookie_upstream() {
+    assert_cache_hit_miss(false).await;
+}

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -66,6 +66,13 @@ block_non_fqdn = true                   # Block queries for names that are not f
 local_domain = "lan"                    # Local domain suffix appended to short hostnames
 local_dns_server = "10.0.0.1:53"        # Router/DHCP server — used for PTR lookups to resolve client hostnames
 
+# Anti-spoofing for plaintext (Do53) upstream A/AAAA queries. DNS Cookies (RFC 7873)
+# are always sent and validated gracefully. Setting this adds draft-vixie-dns-0x20
+# QNAME case randomization for extra off-path entropy, validating the echoed case.
+# Off by default: a few upstreams/forwarders normalize QNAME case and would fail
+# validation. Encrypted transports (DoT/DoH/DoQ) skip both — TLS already authenticates.
+qname_case_randomization = false
+
 
 # ── DNS Cache ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Off-path forgery validation on every plain-UDP/TCP (Do53) upstream response, before it is cached or served:

- **Always on:** transaction-ID and question name/type matching (both validate sites — the initial response and the TCP-on-truncation retry).
- **A/AAAA only:** a random **DNS Cookie** (RFC 7873, EDNS option 10) is sent and validated gracefully on the echo (a cookie-less or short-cookie reply is accepted; a *wrong* cookie is rejected). Cookie comparison is constant-time (`subtle`).
- **A/AAAA, opt-in:** **0x20 QNAME case randomization** (draft-vixie-dns-0x20) behind the `qname_case_randomization` config flag, with the echoed case validated byte-for-byte.
- **Encrypted transports (DoT/DoH/DoQ):** skip cookie/0x20 *validation* since TLS already authenticates the upstream — tolerating upstreams that normalize QNAME case so a mixed Do53+encrypted pool never false-positives a spoof.

Non-address record types are never hardened (their responses are cached/replayed as raw upstream wire), and our randomized 0x20 case never reaches the client: A/AAAA fast-path replies are rebuilt from the client's question and copied record owner names are canonicalized.

A new `SpoofedResponse` domain error carries the rejection reason; the N=2 parallel race now prefers the first *successful* answer instead of aborting when a rejected forgery happens to arrive first.

## Test plan

- [x] `make ci` green (fmt-check + clippy `-D warnings` + full test suite)
- [x] Unit: `ResponseValidator` accepts/rejects txid, qname (case-sensitive under 0x20, case-insensitive otherwise and on encrypted transport), qtype, and cookie (graceful/missing/short/wrong) cases
- [x] `MessageBuilder` gate: A **and** AAAA carry a cookie and randomize case; MX/TXT and disabled-opts stay plain
- [x] e2e (`spoof_rejection_test`): faithful accepted; wrong-txid, forged-cookie, case-forged-QNAME-under-0x20, and forged TCP-retry-after-TC=1 all rejected
- [x] Cache regression: hardening does not corrupt address extraction or cache hit/miss behavior (cookie-echoing and non-cookie upstreams)
- [x] Live smoke (manual, network): `cargo test -p ferrous-dns-infrastructure --test live_upstream_test -- --ignored` against 1.1.1.1 / 8.8.8.8 / 9.9.9.9

🤖 Generated with Claudin