### PR TITLE
feat - configurable custom sinkhole IP for null_ip block mode

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,7 +90,7 @@
 - [ ] DNSSEC validation enforcement (RFC 4035 / RFC 6840) — SERVFAIL on Bogus, AD bit set/clear from validation, honor client CD bit (upgrade from current advisory `dnssec_status` tagging)
 - [ ] DNS-over-QUIC (DoQ) server listener (RFC 9250) — serve encrypted DNS to clients over QUIC (upstream DoQ already supported)
 - [ ] DNS64 / NAT64 AAAA synthesis (RFC 6147) — `64:ff9b::/96` well-known prefix for IPv6-only clients
-- [ ] Custom sinkhole IP for blocked responses (configurable A/AAAA target beyond `0.0.0.0` / `::`)
+- [x] Custom sinkhole IP for blocked responses (configurable A/AAAA target beyond `0.0.0.0` / `::`) — `[blocking]` `sinkhole_ipv4` / `sinkhole_ipv6`, applied to `null_ip` blocked answers
 
 ### 🌟 v1.0.0 - Production Ready
 

--- a/crates/api/src/dto/config.rs
+++ b/crates/api/src/dto/config.rs
@@ -1,3 +1,5 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -108,6 +110,12 @@ pub struct BlockingConfigResponse {
     pub whitelist: Vec<String>,
     pub block_mode: String,
     pub block_ttl: u32,
+    /// Custom A target for `null_ip` blocks; empty string means the null
+    /// address `0.0.0.0`.
+    pub sinkhole_ipv4: String,
+    /// Custom AAAA target for `null_ip` blocks; empty string means the null
+    /// address `::`.
+    pub sinkhole_ipv6: String,
 }
 
 /// Converts the domain `BlockResponseMode` to its snake_case API string.
@@ -125,6 +133,38 @@ pub fn block_mode_from_str(value: &str) -> ferrous_dns_domain::BlockResponseMode
         "refused" => BlockResponseMode::Refused,
         _ => BlockResponseMode::NullIp,
     }
+}
+
+/// Formats an optional sinkhole address as an API string (empty when unset).
+pub fn sinkhole_to_string(addr: Option<impl ToString>) -> String {
+    addr.map(|a| a.to_string()).unwrap_or_default()
+}
+
+/// Parses an API sinkhole IPv4 string. Empty/whitespace clears it (`Ok(None)`);
+/// a non-empty value that isn't a valid IPv4 address is rejected so a typo can't
+/// silently revert the block target to `0.0.0.0`.
+pub fn parse_sinkhole_ipv4(value: &str) -> Result<Option<Ipv4Addr>, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    trimmed
+        .parse::<Ipv4Addr>()
+        .map(Some)
+        .map_err(|_| format!("Invalid IPv4 sinkhole address: {trimmed}"))
+}
+
+/// Parses an API sinkhole IPv6 string. Empty/whitespace clears it (`Ok(None)`);
+/// a non-empty non-IPv6 value is rejected.
+pub fn parse_sinkhole_ipv6(value: &str) -> Result<Option<Ipv6Addr>, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    trimmed
+        .parse::<Ipv6Addr>()
+        .map(Some)
+        .map_err(|_| format!("Invalid IPv6 sinkhole address: {trimmed}"))
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -228,6 +268,10 @@ pub struct BlockingConfigUpdate {
     pub whitelist: Option<Vec<String>>,
     pub block_mode: Option<String>,
     pub block_ttl: Option<u32>,
+    /// Custom A target for `null_ip` blocks; empty string clears it.
+    pub sinkhole_ipv4: Option<String>,
+    /// Custom AAAA target for `null_ip` blocks; empty string clears it.
+    pub sinkhole_ipv6: Option<String>,
 }
 
 fn default_block_mode() -> String {
@@ -257,6 +301,12 @@ pub struct SettingsDto {
 
     #[serde(default = "default_block_ttl")]
     pub block_ttl: u32,
+
+    #[serde(default)]
+    pub sinkhole_ipv4: String,
+
+    #[serde(default)]
+    pub sinkhole_ipv6: String,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -275,6 +325,8 @@ impl From<ConfigResponse> for SettingsDto {
             local_dns_server: config.dns.local_dns_server.unwrap_or_default(),
             block_mode: config.blocking.block_mode,
             block_ttl: config.blocking.block_ttl,
+            sinkhole_ipv4: config.blocking.sinkhole_ipv4,
+            sinkhole_ipv6: config.blocking.sinkhole_ipv6,
         }
     }
 }

--- a/crates/api/src/handlers/config/get.rs
+++ b/crates/api/src/handlers/config/get.rs
@@ -108,6 +108,8 @@ pub async fn get_config(State(state): State<AppState>) -> Json<ConfigResponse> {
             whitelist: config.blocking.whitelist.clone(),
             block_mode: crate::dto::config::block_mode_to_string(config.blocking.block_mode),
             block_ttl: config.blocking.block_ttl,
+            sinkhole_ipv4: crate::dto::config::sinkhole_to_string(config.blocking.sinkhole_ipv4),
+            sinkhole_ipv6: crate::dto::config::sinkhole_to_string(config.blocking.sinkhole_ipv6),
         },
         logging: LoggingConfigResponse {
             level: config.logging.level.clone(),

--- a/crates/api/src/handlers/config/update.rs
+++ b/crates/api/src/handlers/config/update.rs
@@ -248,6 +248,18 @@ pub async fn update_config(
         if let Some(block_ttl) = blocking_update.block_ttl {
             new_config.blocking.block_ttl = block_ttl;
         }
+        if let Some(sinkhole_ipv4) = blocking_update.sinkhole_ipv4 {
+            match crate::dto::config::parse_sinkhole_ipv4(&sinkhole_ipv4) {
+                Ok(addr) => new_config.blocking.sinkhole_ipv4 = addr,
+                Err(e) => return Json(serde_json::json!({ "success": false, "error": e })),
+            }
+        }
+        if let Some(sinkhole_ipv6) = blocking_update.sinkhole_ipv6 {
+            match crate::dto::config::parse_sinkhole_ipv6(&sinkhole_ipv6) {
+                Ok(addr) => new_config.blocking.sinkhole_ipv6 = addr,
+                Err(e) => return Json(serde_json::json!({ "success": false, "error": e })),
+            }
+        }
     }
 
     if let Some(auth_update) = request.auth {
@@ -379,6 +391,16 @@ pub async fn update_settings(
     };
     new_config.blocking.block_mode = crate::dto::config::block_mode_from_str(&request.block_mode);
     new_config.blocking.block_ttl = request.block_ttl;
+    new_config.blocking.sinkhole_ipv4 =
+        match crate::dto::config::parse_sinkhole_ipv4(&request.sinkhole_ipv4) {
+            Ok(addr) => addr,
+            Err(e) => return Json(serde_json::json!({ "success": false, "error": e })),
+        };
+    new_config.blocking.sinkhole_ipv6 =
+        match crate::dto::config::parse_sinkhole_ipv6(&request.sinkhole_ipv6) {
+            Ok(addr) => addr,
+            Err(e) => return Json(serde_json::json!({ "success": false, "error": e })),
+        };
 
     match state
         .config_file_persistence

--- a/crates/api/tests/backup_api_tests.rs
+++ b/crates/api/tests/backup_api_tests.rs
@@ -876,6 +876,24 @@ async fn test_export_includes_local_records_from_config() {
 }
 
 #[tokio::test]
+async fn test_export_includes_block_response_config() {
+    let (app, config, _pool) = create_test_app().await;
+
+    {
+        let mut cfg = config.write().await;
+        cfg.blocking.block_mode = ferrous_dns_domain::BlockResponseMode::NxDomain;
+        cfg.blocking.sinkhole_ipv4 = Some(std::net::Ipv4Addr::new(192, 168, 1, 2));
+        cfg.blocking.sinkhole_ipv6 = Some("fd00::2".parse().unwrap());
+    }
+
+    let (_, json) = do_export(app).await;
+    let blocking = &json["config"]["blocking"];
+    assert_eq!(blocking["block_mode"], "nxdomain");
+    assert_eq!(blocking["sinkhole_ipv4"], "192.168.1.2");
+    assert_eq!(blocking["sinkhole_ipv6"], "fd00::2");
+}
+
+#[tokio::test]
 async fn test_export_includes_groups_from_database() {
     let (app, _config, _pool) = create_test_app().await;
     let (_, json) = do_export(app).await;

--- a/crates/api/tests/config_update_api_tests.rs
+++ b/crates/api/tests/config_update_api_tests.rs
@@ -787,3 +787,83 @@ async fn test_update_config_non_pool_change_requires_restart() {
     // No pools were sent, so the live pool set is untouched.
     assert!(live_servers(&pm).iter().any(|s| s == "8.8.8.8:53"));
 }
+
+#[tokio::test]
+async fn test_update_config_rejects_invalid_sinkhole_ipv4() {
+    let pool = create_test_db().await;
+    let (app, _pm, _path) = create_test_app(pool).await;
+
+    let (status, json) = post_config(
+        app,
+        serde_json::json!({ "blocking": { "sinkhole_ipv4": "10.0.0.300" } }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], false);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid IPv4 sinkhole address"),
+        "error should name the bad sinkhole, got: {}",
+        json["error"]
+    );
+}
+
+#[tokio::test]
+async fn test_update_config_rejects_invalid_sinkhole_ipv6() {
+    let pool = create_test_db().await;
+    let (app, _pm, _path) = create_test_app(pool).await;
+
+    let (status, json) = post_config(
+        app,
+        serde_json::json!({ "blocking": { "sinkhole_ipv6": "fd00::zz" } }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], false);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid IPv6 sinkhole address"),
+        "error should name the bad sinkhole, got: {}",
+        json["error"]
+    );
+}
+
+#[tokio::test]
+async fn test_update_config_persists_then_clears_sinkhole() {
+    let pool = create_test_db().await;
+    let (app, _pm, path) = create_test_app(pool).await;
+
+    // A valid custom sinkhole is accepted and written to the config file.
+    let (status, json) = post_config(
+        app.clone(),
+        serde_json::json!({ "blocking": { "sinkhole_ipv4": "192.168.50.50" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+    let written = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        written.contains("192.168.50.50"),
+        "config file should carry the custom sinkhole, got:\n{written}"
+    );
+
+    // An empty string clears it: the key must disappear from the file.
+    let (status, json) = post_config(
+        app,
+        serde_json::json!({ "blocking": { "sinkhole_ipv4": "" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+    let cleared = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        !cleared.contains("sinkhole_ipv4") && !cleared.contains("192.168.50.50"),
+        "cleared sinkhole key must be removed from the file, got:\n{cleared}"
+    );
+}

--- a/crates/api/tests/sinkhole_dto_test.rs
+++ b/crates/api/tests/sinkhole_dto_test.rs
@@ -1,0 +1,41 @@
+use ferrous_dns_api::dto::config::{parse_sinkhole_ipv4, parse_sinkhole_ipv6, sinkhole_to_string};
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+#[test]
+fn empty_string_clears_sinkhole() {
+    assert_eq!(parse_sinkhole_ipv4("").unwrap(), None);
+    assert_eq!(parse_sinkhole_ipv4("   ").unwrap(), None);
+    assert_eq!(parse_sinkhole_ipv6("").unwrap(), None);
+}
+
+#[test]
+fn valid_addresses_parse() {
+    assert_eq!(
+        parse_sinkhole_ipv4("192.168.1.2").unwrap(),
+        Some(Ipv4Addr::new(192, 168, 1, 2))
+    );
+    assert_eq!(
+        parse_sinkhole_ipv6("fd00::2").unwrap(),
+        Some("fd00::2".parse::<Ipv6Addr>().unwrap())
+    );
+}
+
+#[test]
+fn invalid_addresses_are_rejected() {
+    assert!(parse_sinkhole_ipv4("10.0.0.300").is_err());
+    assert!(parse_sinkhole_ipv4("not-an-ip").is_err());
+    // Wrong family is rejected too.
+    assert!(parse_sinkhole_ipv4("fd00::2").is_err());
+    assert!(parse_sinkhole_ipv6("192.168.1.2").is_err());
+}
+
+#[test]
+fn formatting_round_trips() {
+    assert_eq!(sinkhole_to_string(None::<Ipv4Addr>), "");
+    assert_eq!(
+        sinkhole_to_string(Some(Ipv4Addr::new(192, 168, 1, 2))),
+        "192.168.1.2"
+    );
+    let v6 = "fd00::2".parse::<Ipv6Addr>().unwrap();
+    assert_eq!(sinkhole_to_string(Some(v6)), "fd00::2");
+}

--- a/crates/application/src/use_cases/backup/export.rs
+++ b/crates/application/src/use_cases/backup/export.rs
@@ -136,6 +136,10 @@ impl ExportConfigUseCase {
                 enabled: config.blocking.enabled,
                 custom_blocked: config.blocking.custom_blocked.clone(),
                 whitelist: config.blocking.whitelist.clone(),
+                block_mode: config.blocking.block_mode,
+                block_ttl: config.blocking.block_ttl,
+                sinkhole_ipv4: config.blocking.sinkhole_ipv4,
+                sinkhole_ipv6: config.blocking.sinkhole_ipv6,
             },
             logging: SnapshotLoggingConfig {
                 level: config.logging.level.clone(),

--- a/crates/application/src/use_cases/backup/import.rs
+++ b/crates/application/src/use_cases/backup/import.rs
@@ -150,6 +150,10 @@ impl ImportConfigUseCase {
         new_config.blocking.enabled = sc.blocking.enabled;
         new_config.blocking.custom_blocked = sc.blocking.custom_blocked.clone();
         new_config.blocking.whitelist = sc.blocking.whitelist.clone();
+        new_config.blocking.block_mode = sc.blocking.block_mode;
+        new_config.blocking.block_ttl = sc.blocking.block_ttl;
+        new_config.blocking.sinkhole_ipv4 = sc.blocking.sinkhole_ipv4;
+        new_config.blocking.sinkhole_ipv6 = sc.blocking.sinkhole_ipv6;
 
         new_config.logging.level = sc.logging.level.clone();
 

--- a/crates/application/src/use_cases/backup/snapshot.rs
+++ b/crates/application/src/use_cases/backup/snapshot.rs
@@ -66,6 +66,20 @@ pub struct SnapshotBlockingConfig {
     pub enabled: bool,
     pub custom_blocked: Vec<String>,
     pub whitelist: Vec<String>,
+    // The following are absent from pre-0.9 backups; serde defaults keep those
+    // older files importable (block_mode → null_ip, block_ttl → 60, sinkhole → none).
+    #[serde(default)]
+    pub block_mode: ferrous_dns_domain::BlockResponseMode,
+    #[serde(default = "default_block_ttl")]
+    pub block_ttl: u32,
+    #[serde(default)]
+    pub sinkhole_ipv4: Option<std::net::Ipv4Addr>,
+    #[serde(default)]
+    pub sinkhole_ipv6: Option<std::net::Ipv6Addr>,
+}
+
+fn default_block_ttl() -> u32 {
+    ferrous_dns_domain::DEFAULT_BLOCK_TTL
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/application/tests/backup_snapshot_blocking_test.rs
+++ b/crates/application/tests/backup_snapshot_blocking_test.rs
@@ -1,0 +1,49 @@
+//! Backward/forward compatibility of the backup [blocking] snapshot section:
+//! pre-0.9 backups omit block_mode/block_ttl/sinkhole and must still import via
+//! serde defaults; newer backups carry and restore the full block-response config.
+
+use ferrous_dns_application::use_cases::backup::snapshot::SnapshotBlockingConfig;
+use ferrous_dns_domain::BlockResponseMode;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+#[test]
+fn legacy_blocking_section_deserializes_with_defaults() {
+    // A pre-0.9 backup only carried these three keys.
+    let json = serde_json::json!({
+        "enabled": true,
+        "custom_blocked": [],
+        "whitelist": []
+    });
+    let parsed: SnapshotBlockingConfig = serde_json::from_value(json).unwrap();
+    assert_eq!(parsed.block_mode, BlockResponseMode::NullIp);
+    assert_eq!(parsed.block_ttl, 60);
+    assert_eq!(parsed.sinkhole_ipv4, None);
+    assert_eq!(parsed.sinkhole_ipv6, None);
+}
+
+#[test]
+fn full_blocking_section_round_trips() {
+    let json = serde_json::json!({
+        "enabled": true,
+        "custom_blocked": [],
+        "whitelist": [],
+        "block_mode": "nxdomain",
+        "block_ttl": 120,
+        "sinkhole_ipv4": "192.168.1.2",
+        "sinkhole_ipv6": "fd00::2"
+    });
+    let parsed: SnapshotBlockingConfig = serde_json::from_value(json).unwrap();
+    assert_eq!(parsed.block_mode, BlockResponseMode::NxDomain);
+    assert_eq!(parsed.block_ttl, 120);
+    assert_eq!(parsed.sinkhole_ipv4, Some(Ipv4Addr::new(192, 168, 1, 2)));
+    assert_eq!(
+        parsed.sinkhole_ipv6,
+        Some("fd00::2".parse::<Ipv6Addr>().unwrap())
+    );
+
+    // Re-serialize and confirm the custom targets survive a round-trip.
+    let reserialized = serde_json::to_value(&parsed).unwrap();
+    assert_eq!(reserialized["sinkhole_ipv4"], "192.168.1.2");
+    assert_eq!(reserialized["sinkhole_ipv6"], "fd00::2");
+    assert_eq!(reserialized["block_mode"], "nxdomain");
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -145,6 +145,8 @@ async fn async_main() -> anyhow::Result<()> {
     let block_policy = BlockPolicy {
         mode: config.blocking.block_mode,
         ttl: config.blocking.block_ttl,
+        sinkhole_ipv4: config.blocking.sinkhole_ipv4,
+        sinkhole_ipv6: config.blocking.sinkhole_ipv6,
     };
     let dns_handler = DnsServerHandler::new(handler_use_case.clone(), block_policy);
     let core_ids_for_dns = core_affinity::get_core_ids().unwrap_or_default();

--- a/crates/domain/src/config/blocking.rs
+++ b/crates/domain/src/config/blocking.rs
@@ -1,3 +1,5 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
 use serde::{Deserialize, Serialize};
 
 /// How a blocked (or security-flagged) domain is answered on the wire.
@@ -57,6 +59,17 @@ pub struct BlockingConfig {
 
     #[serde(default = "default_block_ttl")]
     pub block_ttl: u32,
+
+    /// Optional custom A target for `null_ip` blocked answers. When unset, the
+    /// null address `0.0.0.0` is used. Lets operators point blocked domains at a
+    /// local block-page server instead of a dead address.
+    #[serde(default)]
+    pub sinkhole_ipv4: Option<Ipv4Addr>,
+
+    /// Optional custom AAAA target for `null_ip` blocked answers. When unset, the
+    /// null address `::` is used.
+    #[serde(default)]
+    pub sinkhole_ipv6: Option<Ipv6Addr>,
 }
 
 impl Default for BlockingConfig {
@@ -67,6 +80,8 @@ impl Default for BlockingConfig {
             whitelist: vec![],
             block_mode: BlockResponseMode::default(),
             block_ttl: default_block_ttl(),
+            sinkhole_ipv4: None,
+            sinkhole_ipv6: None,
         }
     }
 }
@@ -127,5 +142,38 @@ mod tests {
     fn custom_block_ttl_is_honoured() {
         let config: BlockingConfig = toml::from_str("enabled = true\nblock_ttl = 300").unwrap();
         assert_eq!(config.block_ttl, 300);
+    }
+
+    #[test]
+    fn sinkhole_addresses_default_to_none() {
+        let config: BlockingConfig = toml::from_str("enabled = true").unwrap();
+        assert_eq!(config.sinkhole_ipv4, None);
+        assert_eq!(config.sinkhole_ipv6, None);
+    }
+
+    #[test]
+    fn sinkhole_addresses_round_trip() {
+        let config: BlockingConfig = toml::from_str(
+            "enabled = true\nsinkhole_ipv4 = \"192.168.1.2\"\nsinkhole_ipv6 = \"fd00::2\"",
+        )
+        .unwrap();
+        assert_eq!(config.sinkhole_ipv4, Some(Ipv4Addr::new(192, 168, 1, 2)));
+        assert_eq!(
+            config.sinkhole_ipv6,
+            Some("fd00::2".parse::<Ipv6Addr>().unwrap())
+        );
+
+        let serialized = toml::Value::try_from(&config).unwrap();
+        let blocking = serialized.as_table().unwrap();
+        assert_eq!(blocking["sinkhole_ipv4"].as_str(), Some("192.168.1.2"));
+        assert_eq!(blocking["sinkhole_ipv6"].as_str(), Some("fd00::2"));
+    }
+
+    #[test]
+    fn invalid_sinkhole_address_errors() {
+        assert!(
+            toml::from_str::<BlockingConfig>("enabled = true\nsinkhole_ipv4 = \"10.0.0.300\"")
+                .is_err()
+        );
     }
 }

--- a/crates/infrastructure/src/dns/server.rs
+++ b/crates/infrastructure/src/dns/server.rs
@@ -25,6 +25,10 @@ const DEFAULT_TTL: u32 = 60;
 pub struct BlockPolicy {
     pub mode: BlockResponseMode,
     pub ttl: u32,
+    /// Custom A target for `NullIp` blocks; `None` falls back to `0.0.0.0`.
+    pub sinkhole_ipv4: Option<Ipv4Addr>,
+    /// Custom AAAA target for `NullIp` blocks; `None` falls back to `::`.
+    pub sinkhole_ipv6: Option<Ipv6Addr>,
 }
 
 #[derive(Clone)]
@@ -600,11 +604,11 @@ pub fn build_blocked_wire(
             resp.set_response_code(ResponseCode::NoError);
             if let Some(q) = queries.first() {
                 let rdata = match q.query_type() {
-                    RecordType::A => {
-                        Some(RData::A(hickory_proto::rr::rdata::A(Ipv4Addr::UNSPECIFIED)))
-                    }
+                    RecordType::A => Some(RData::A(hickory_proto::rr::rdata::A(
+                        policy.sinkhole_ipv4.unwrap_or(Ipv4Addr::UNSPECIFIED),
+                    ))),
                     RecordType::AAAA => Some(RData::AAAA(hickory_proto::rr::rdata::AAAA(
-                        Ipv6Addr::UNSPECIFIED,
+                        policy.sinkhole_ipv6.unwrap_or(Ipv6Addr::UNSPECIFIED),
                     ))),
                     // Other record types: NODATA (NOERROR, empty answer).
                     _ => None,
@@ -684,9 +688,11 @@ pub async fn send_blocked_response<R: ResponseHandler>(
         BlockResponseMode::NoData => (ResponseCode::NoError, Vec::new()),
         BlockResponseMode::NullIp => {
             let rdata = match query_type {
-                RecordType::A => Some(RData::A(hickory_proto::rr::rdata::A(Ipv4Addr::UNSPECIFIED))),
+                RecordType::A => Some(RData::A(hickory_proto::rr::rdata::A(
+                    policy.sinkhole_ipv4.unwrap_or(Ipv4Addr::UNSPECIFIED),
+                ))),
                 RecordType::AAAA => Some(RData::AAAA(hickory_proto::rr::rdata::AAAA(
-                    Ipv6Addr::UNSPECIFIED,
+                    policy.sinkhole_ipv6.unwrap_or(Ipv6Addr::UNSPECIFIED),
                 ))),
                 // Other record types: NODATA (NOERROR, empty answer).
                 _ => None,

--- a/crates/infrastructure/src/repositories/config_persistence.rs
+++ b/crates/infrastructure/src/repositories/config_persistence.rs
@@ -384,6 +384,20 @@ pub fn save_config_to_file(config: &Config, path: &str) -> Result<(), ConfigErro
             "block_ttl",
             toml_edit::Value::from(config.blocking.block_ttl as i64),
         );
+        // Optional custom sinkhole targets: write when set, drop the key when
+        // cleared so the file reflects "no custom target" (falls back to null).
+        match config.blocking.sinkhole_ipv4 {
+            Some(addr) => set_val(t, "sinkhole_ipv4", toml_edit::Value::from(addr.to_string())),
+            None => {
+                t.remove("sinkhole_ipv4");
+            }
+        }
+        match config.blocking.sinkhole_ipv6 {
+            Some(addr) => set_val(t, "sinkhole_ipv6", toml_edit::Value::from(addr.to_string())),
+            None => {
+                t.remove("sinkhole_ipv6");
+            }
+        }
     }
 
     // ── [logging] ───────────────────────────────────────────────────────

--- a/crates/infrastructure/tests/block_response_test.rs
+++ b/crates/infrastructure/tests/block_response_test.rs
@@ -31,7 +31,12 @@ fn query(record_type: RecordType) -> Query {
 }
 
 fn policy(mode: BlockResponseMode) -> BlockPolicy {
-    BlockPolicy { mode, ttl: TTL }
+    BlockPolicy {
+        mode,
+        ttl: TTL,
+        sinkhole_ipv4: None,
+        sinkhole_ipv6: None,
+    }
 }
 
 /// Asserts the authority section carries exactly one synthetic SOA with the
@@ -49,15 +54,12 @@ fn assert_soa(msg: &Message) {
 // ── UDP fast path: build_blocked_wire ────────────────────────────────────
 
 fn decode(mode: BlockResponseMode, record_type: RecordType) -> Message {
-    let wire = build_blocked_wire(
-        0x1234,
-        true,
-        &[query(record_type)],
-        policy(mode),
-        false,
-        None,
-    )
-    .expect("wire bytes");
+    decode_with(policy(mode), record_type)
+}
+
+fn decode_with(policy: BlockPolicy, record_type: RecordType) -> Message {
+    let wire = build_blocked_wire(0x1234, true, &[query(record_type)], policy, false, None)
+        .expect("wire bytes");
     Message::from_vec(&wire).expect("valid DNS message")
 }
 
@@ -87,6 +89,52 @@ fn null_ip_aaaa_query_returns_unspecified_v6_with_ttl() {
     match answer.data() {
         RData::AAAA(aaaa) => assert_eq!(aaaa.0, Ipv6Addr::UNSPECIFIED),
         other => panic!("expected AAAA ::, got {other:?}"),
+    }
+}
+
+#[test]
+fn null_ip_a_query_uses_custom_sinkhole_ipv4() {
+    let mut p = policy(BlockResponseMode::NullIp);
+    p.sinkhole_ipv4 = Some(Ipv4Addr::new(192, 168, 1, 2));
+    let msg = decode_with(p, RecordType::A);
+    assert_eq!(msg.answers().len(), 1);
+    match msg.answers()[0].data() {
+        RData::A(a) => assert_eq!(a.0, Ipv4Addr::new(192, 168, 1, 2)),
+        other => panic!("expected custom A, got {other:?}"),
+    }
+}
+
+#[test]
+fn null_ip_aaaa_query_uses_custom_sinkhole_ipv6() {
+    let mut p = policy(BlockResponseMode::NullIp);
+    p.sinkhole_ipv6 = Some(Ipv6Addr::from_str("fd00::2").unwrap());
+    let msg = decode_with(p, RecordType::AAAA);
+    assert_eq!(msg.answers().len(), 1);
+    match msg.answers()[0].data() {
+        RData::AAAA(aaaa) => assert_eq!(aaaa.0, Ipv6Addr::from_str("fd00::2").unwrap()),
+        other => panic!("expected custom AAAA, got {other:?}"),
+    }
+}
+
+#[test]
+fn null_ip_aaaa_falls_back_to_unspecified_when_only_v4_set() {
+    let mut p = policy(BlockResponseMode::NullIp);
+    p.sinkhole_ipv4 = Some(Ipv4Addr::new(192, 168, 1, 2));
+    let msg = decode_with(p, RecordType::AAAA);
+    match msg.answers()[0].data() {
+        RData::AAAA(aaaa) => assert_eq!(aaaa.0, Ipv6Addr::UNSPECIFIED),
+        other => panic!("expected AAAA ::, got {other:?}"),
+    }
+}
+
+#[test]
+fn null_ip_a_falls_back_to_unspecified_when_only_v6_set() {
+    let mut p = policy(BlockResponseMode::NullIp);
+    p.sinkhole_ipv6 = Some(Ipv6Addr::from_str("fd00::2").unwrap());
+    let msg = decode_with(p, RecordType::A);
+    match msg.answers()[0].data() {
+        RData::A(a) => assert_eq!(a.0, Ipv4Addr::UNSPECIFIED),
+        other => panic!("expected A 0.0.0.0, got {other:?}"),
     }
 }
 
@@ -201,18 +249,14 @@ fn make_request(query_type: RecordType, with_edns: bool) -> Request {
 }
 
 async fn send(mode: BlockResponseMode, query_type: RecordType, with_edns: bool) -> Message {
+    send_with(policy(mode), query_type, with_edns).await
+}
+
+async fn send_with(policy: BlockPolicy, query_type: RecordType, with_edns: bool) -> Message {
     let request = make_request(query_type, with_edns);
     let mut handler = CapturingHandler::default();
     let ede = ede::from_domain_error(&DomainError::Blocked);
-    let _ = send_blocked_response(
-        &request,
-        &mut handler,
-        name(),
-        query_type,
-        policy(mode),
-        ede,
-    )
-    .await;
+    let _ = send_blocked_response(&request, &mut handler, name(), query_type, policy, ede).await;
     handler.decoded()
 }
 
@@ -222,6 +266,52 @@ async fn send_null_ip_a_returns_unspecified_v4() {
     assert_eq!(msg.response_code(), ResponseCode::NoError);
     assert_eq!(msg.answers().len(), 1);
     assert_eq!(msg.name_servers().len(), 0);
+    match msg.answers()[0].data() {
+        RData::A(a) => assert_eq!(a.0, Ipv4Addr::UNSPECIFIED),
+        other => panic!("expected A 0.0.0.0, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn send_null_ip_a_uses_custom_sinkhole_ipv4() {
+    let mut p = policy(BlockResponseMode::NullIp);
+    p.sinkhole_ipv4 = Some(Ipv4Addr::new(10, 0, 0, 1));
+    let msg = send_with(p, RecordType::A, false).await;
+    assert_eq!(msg.answers().len(), 1);
+    match msg.answers()[0].data() {
+        RData::A(a) => assert_eq!(a.0, Ipv4Addr::new(10, 0, 0, 1)),
+        other => panic!("expected custom A, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn send_null_ip_aaaa_falls_back_to_unspecified_when_only_v4_set() {
+    let mut p = policy(BlockResponseMode::NullIp);
+    p.sinkhole_ipv4 = Some(Ipv4Addr::new(10, 0, 0, 1));
+    let msg = send_with(p, RecordType::AAAA, false).await;
+    match msg.answers()[0].data() {
+        RData::AAAA(aaaa) => assert_eq!(aaaa.0, Ipv6Addr::UNSPECIFIED),
+        other => panic!("expected AAAA ::, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn send_null_ip_aaaa_uses_custom_sinkhole_ipv6() {
+    let mut p = policy(BlockResponseMode::NullIp);
+    p.sinkhole_ipv6 = Some(Ipv6Addr::from_str("fd00::2").unwrap());
+    let msg = send_with(p, RecordType::AAAA, false).await;
+    assert_eq!(msg.answers().len(), 1);
+    match msg.answers()[0].data() {
+        RData::AAAA(aaaa) => assert_eq!(aaaa.0, Ipv6Addr::from_str("fd00::2").unwrap()),
+        other => panic!("expected custom AAAA, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn send_null_ip_a_falls_back_to_unspecified_when_only_v6_set() {
+    let mut p = policy(BlockResponseMode::NullIp);
+    p.sinkhole_ipv6 = Some(Ipv6Addr::from_str("fd00::2").unwrap());
+    let msg = send_with(p, RecordType::A, false).await;
     match msg.answers()[0].data() {
         RData::A(a) => assert_eq!(a.0, Ipv4Addr::UNSPECIFIED),
         other => panic!("expected A 0.0.0.0, got {other:?}"),

--- a/crates/infrastructure/tests/config_persistence_tests.rs
+++ b/crates/infrastructure/tests/config_persistence_tests.rs
@@ -469,6 +469,64 @@ fn test_save_and_reload_preserves_block_mode_and_ttl() {
     assert_eq!(reloaded.blocking.block_ttl, 300);
 }
 
+#[test]
+fn test_save_and_reload_preserves_sinkhole_addresses() {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    let mut config = load_config(default_config_toml());
+    config.blocking.sinkhole_ipv4 = Some(Ipv4Addr::new(192, 168, 1, 2));
+    config.blocking.sinkhole_ipv6 = Some("fd00::2".parse::<Ipv6Addr>().unwrap());
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("sinkhole_roundtrip.toml");
+    std::fs::write(&path, default_config_toml()).unwrap();
+
+    save_config_to_file(&config, path.to_str().unwrap()).unwrap();
+
+    let written = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        written.contains("sinkhole_ipv4 = \"192.168.1.2\""),
+        "sinkhole_ipv4 should be written, got:\n{written}"
+    );
+    assert!(
+        written.contains("sinkhole_ipv6 = \"fd00::2\""),
+        "sinkhole_ipv6 should be written, got:\n{written}"
+    );
+
+    let reloaded = Config::load(Some(path.to_str().unwrap()), Default::default()).unwrap();
+    assert_eq!(
+        reloaded.blocking.sinkhole_ipv4,
+        Some(Ipv4Addr::new(192, 168, 1, 2))
+    );
+    assert_eq!(
+        reloaded.blocking.sinkhole_ipv6,
+        Some("fd00::2".parse::<Ipv6Addr>().unwrap())
+    );
+}
+
+#[test]
+fn test_clearing_sinkhole_removes_keys_from_toml() {
+    let mut config = load_config(default_config_toml());
+    config.blocking.sinkhole_ipv4 = Some(std::net::Ipv4Addr::new(10, 0, 0, 1));
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("sinkhole_clear.toml");
+    std::fs::write(&path, default_config_toml()).unwrap();
+
+    // Write once with a value, then clear and write again.
+    save_config_to_file(&config, path.to_str().unwrap()).unwrap();
+    config.blocking.sinkhole_ipv4 = None;
+    save_config_to_file(&config, path.to_str().unwrap()).unwrap();
+
+    let written = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        !written.contains("sinkhole_ipv4"),
+        "cleared sinkhole_ipv4 key should be removed, got:\n{written}"
+    );
+    let reloaded = Config::load(Some(path.to_str().unwrap()), Default::default()).unwrap();
+    assert_eq!(reloaded.blocking.sinkhole_ipv4, None);
+}
+
 // ── Error handling ───────────────────────────────────────────────────────
 
 #[test]

--- a/docs/api.md
+++ b/docs/api.md
@@ -243,14 +243,22 @@ Returns DNS-specific settings (non-FQDN blocking, PTR blocking, local domain).
 POST /api/settings
 ```
 
+**Full replace** — unlike `POST /api/config` (a partial update), this endpoint overwrites the entire DNS settings form. Any field you omit reverts to its default: an omitted `sinkhole_ipv4` clears a previously-set sinkhole, an omitted `block_mode` resets it to `null_ip`. Send the complete object:
+
 ```json
 {
   "never_forward_non_fqdn": true,
   "never_forward_reverse_lookups": true,
   "local_domain": "lan",
-  "local_dns_server": "192.168.1.1:53"
+  "local_dns_server": "192.168.1.1:53",
+  "block_mode": "null_ip",
+  "block_ttl": 60,
+  "sinkhole_ipv4": "192.168.1.2",
+  "sinkhole_ipv6": "fd00::2"
 }
 ```
+
+`sinkhole_ipv4` / `sinkhole_ipv6` set a custom block target for `null_ip` mode (empty string = the null address `0.0.0.0` / `::`). A non-empty value that is not a valid address of the matching family is rejected with `{ "success": false, "error": "Invalid IPv4 sinkhole address: …" }` and nothing is saved. See [Custom Sinkhole IP](configuration/blocking.md#custom-sinkhole-ip).
 
 ---
 

--- a/docs/configuration/blocking.md
+++ b/docs/configuration/blocking.md
@@ -68,6 +68,8 @@ sinkhole_ipv6 = "fd00::2"       # AAAA target for blocked domains
 
 The two families are independent: if you set only `sinkhole_ipv4`, blocked `AAAA` queries still return `::` (and vice-versa). The targets apply to **every** domain-verdict block (blocklist, DGA, tunneling, C2), just like `block_mode`. They are ignored in `nxdomain`, `nodata`, and `refused` modes, which carry no address.
 
+A non-empty value must be a valid address of the matching family. A malformed IP is rejected rather than silently ignored: the dashboard and REST API return an error and save nothing, and an invalid value in the config file stops the server from starting (so a typo can't quietly revert the block target to `0.0.0.0` / `::`).
+
 !!! warning "Don't use loopback"
     Point the sinkhole at the **LAN IP** of the host serving the block page, not loopback (`127.0.0.1` / `::1`). A loopback target resolves to each *client's own* machine, not the Ferrous DNS server, so the block page won't load.
 

--- a/docs/configuration/blocking.md
+++ b/docs/configuration/blocking.md
@@ -11,6 +11,8 @@ The `[blocking]` section controls the base blocking settings. Blocklists, client
 enabled = true
 block_mode = "null_ip"
 block_ttl = 60
+# sinkhole_ipv4 = "192.168.1.2"
+# sinkhole_ipv6 = "fd00::2"
 ```
 
 | Option | Default | Description |
@@ -18,6 +20,8 @@ block_ttl = 60
 | `enabled` | `true` | Enable DNS-based blocking globally |
 | `block_mode` | `"null_ip"` | How blocked domains are answered on the wire — see [Block Response Mode](#block-response-mode) |
 | `block_ttl` | `60` | TTL (seconds) clients cache a blocked answer; also bounds the negative-cache lifetime for `nxdomain`/`nodata` |
+| `sinkhole_ipv4` | _(unset)_ | Custom `A` target for `null_ip` blocks — see [Custom Sinkhole IP](#custom-sinkhole-ip). Unset → `0.0.0.0` |
+| `sinkhole_ipv6` | _(unset)_ | Custom `AAAA` target for `null_ip` blocks. Unset → `::` |
 
 !!! warning "Domains are not configured here"
     The `[blocking]` section also accepts `custom_blocked` and `whitelist` arrays, but **they are not consulted by the DNS query pipeline** — listing domains there has no effect on what is blocked or allowed. Blocked domains and allow-listed domains are managed via the dashboard or REST API and persisted in the SQLite database, not in this TOML file. See [Blocklist Management](#blocklist-management-dashboard) and [Allow/Block from Query Log](#allowblock-from-query-log) below.
@@ -47,7 +51,25 @@ block_ttl  = 60          # seconds clients/resolvers cache the blocked answer
     A cacheable `0.0.0.0` answer is the gentlest on both the client and the resolver: the client gets an immediate connection failure and caches it for `block_ttl`, so it stops hammering the resolver. `refused` is non-cacheable (RFC 2308 §7), so clients re-query on every attempt.
 
 !!! warning "Requires a restart"
-    `block_mode` and `block_ttl` are read once at startup. Changing them in the config file or via the dashboard takes effect only after the server is restarted. Blocklist contents (the domains themselves) still update live without a restart.
+    `block_mode`, `block_ttl`, `sinkhole_ipv4`, and `sinkhole_ipv6` are read once at startup. Changing them in the config file or via the dashboard takes effect only after the server is restarted. Blocklist contents (the domains themselves) still update live without a restart.
+
+---
+
+## Custom Sinkhole IP
+
+By default, `null_ip` answers a blocked `A` query with `0.0.0.0` and a blocked `AAAA` query with `::` — addresses that clients can't connect to, so the request fails fast. If you instead run a local **block page** (a small web server that explains the domain was blocked), point blocked domains at it with `sinkhole_ipv4` / `sinkhole_ipv6`:
+
+```toml
+[blocking]
+block_mode = "null_ip"          # sinkhole IPs only apply in null_ip mode
+sinkhole_ipv4 = "192.168.1.2"   # A target for blocked domains
+sinkhole_ipv6 = "fd00::2"       # AAAA target for blocked domains
+```
+
+The two families are independent: if you set only `sinkhole_ipv4`, blocked `AAAA` queries still return `::` (and vice-versa). The targets apply to **every** domain-verdict block (blocklist, DGA, tunneling, C2), just like `block_mode`. They are ignored in `nxdomain`, `nodata`, and `refused` modes, which carry no address.
+
+!!! warning "Don't use loopback"
+    Point the sinkhole at the **LAN IP** of the host serving the block page, not loopback (`127.0.0.1` / `::1`). A loopback target resolves to each *client's own* machine, not the Ferrous DNS server, so the block page won't load.
 
 ---
 

--- a/docs/configuration/ferrous-dns-toml.md
+++ b/docs/configuration/ferrous-dns-toml.md
@@ -564,6 +564,8 @@ custom_blocked = []
 whitelist      = []
 block_mode     = "null_ip"
 block_ttl      = 60
+# sinkhole_ipv4 = "192.168.1.2"
+# sinkhole_ipv6 = "fd00::2"
 ```
 
 | Option | Type | Default | Description |
@@ -573,9 +575,11 @@ block_ttl      = 60
 | `whitelist` | `list` | `[]` | Domains that are always allowed, even if present in a blocklist |
 | `block_mode` | `string` | `"null_ip"` | How blocked domains are answered: `null_ip` (cacheable `0.0.0.0`/`::`, recommended), `nxdomain`, `nodata`, or `refused` (legacy, non-cacheable) |
 | `block_ttl` | `int` | `60` | TTL in seconds clients/resolvers cache a blocked answer; also drives the synthetic SOA `minimum` for `nxdomain`/`nodata` |
+| `sinkhole_ipv4` | `string` | _(unset)_ | Custom `A` target for `null_ip` blocks (e.g. a LAN block-page server); unset returns `0.0.0.0`. See [Custom Sinkhole IP](blocking.md#custom-sinkhole-ip) |
+| `sinkhole_ipv6` | `string` | _(unset)_ | Custom `AAAA` target for `null_ip` blocks; unset returns `::` |
 
 !!! note "Restart required"
-    `block_mode` and `block_ttl` are applied at startup; changing them needs a server restart. See [Block Response Mode](blocking.md#block-response-mode) for what each mode returns.
+    `block_mode`, `block_ttl`, `sinkhole_ipv4`, and `sinkhole_ipv6` are applied at startup; changing them needs a server restart. See [Block Response Mode](blocking.md#block-response-mode) for what each mode returns.
 
 See [Blocking & Filtering](../features/blocking-filtering.md).
 

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -269,6 +269,8 @@ whitelist = []                          # Domains to always allow, even if prese
 block_mode = "null_ip"                  # How blocked domains are answered: "null_ip" (NOERROR + 0.0.0.0/::,
                                         #   cacheable — recommended), "nxdomain", "nodata", or "refused" (legacy)
 block_ttl = 60                          # TTL (seconds) clients cache the null-IP block answer
+# sinkhole_ipv4 = "192.168.1.2"         # Custom A target for "null_ip" blocks (default 0.0.0.0).
+# sinkhole_ipv6 = "fd00::2"             #   Point at a LAN block-page server; omit for the null address.
 
 
 # ── Logging ───────────────────────────────────────────────────────────────────

--- a/web/static/settings.html
+++ b/web/static/settings.html
@@ -478,7 +478,23 @@
                                style="max-width:160px;font-family:monospace">
                         <p style="font-size:11px;color:var(--text-tertiary);margin-top:4px">How long clients cache the Null IP answer.</p>
                     </div>
+                    <div class="form-group" style="margin-bottom:0" x-show="settings.block_mode==='null_ip'" x-cloak>
+                        <label class="form-label">Sinkhole IPv4 (A)</label>
+                        <input type="text" x-model="settings.sinkhole_ipv4" placeholder="0.0.0.0"
+                               style="max-width:200px;font-family:monospace">
+                        <p style="font-size:11px;color:var(--text-tertiary);margin-top:4px">Custom A target for blocked domains. Leave empty for <code>0.0.0.0</code>.</p>
+                    </div>
+                    <div class="form-group" style="margin-bottom:0" x-show="settings.block_mode==='null_ip'" x-cloak>
+                        <label class="form-label">Sinkhole IPv6 (AAAA)</label>
+                        <input type="text" x-model="settings.sinkhole_ipv6" placeholder="::"
+                               style="max-width:200px;font-family:monospace">
+                        <p style="font-size:11px;color:var(--text-tertiary);margin-top:4px">Custom AAAA target. Leave empty for <code>::</code>.</p>
+                    </div>
                 </div>
+                <p x-show="settings.block_mode==='null_ip'" x-cloak style="font-size:12px;color:var(--text-secondary);margin:12px 0 0;display:flex;align-items:flex-start;gap:6px">
+                    <i data-lucide="alert-triangle" style="width:14px;height:14px;color:#F59E0B;flex-shrink:0;margin-top:2px"></i>
+                    <span>Point the sinkhole at this server's LAN IP if it serves a block page. Avoid loopback (<code style="padding:1px 4px;background:var(--bg-tertiary);border-radius:3px">127.0.0.1</code> / <code style="padding:1px 4px;background:var(--bg-tertiary);border-radius:3px">::1</code>) — it resolves to each client's own machine, not this server.</span>
+                </p>
             </div>
         </div>
 

--- a/web/static/settings.js
+++ b/web/static/settings.js
@@ -37,7 +37,9 @@
                 local_domain: '',
                 local_dns_server: '',
                 block_mode: 'null_ip',
-                block_ttl: 60
+                block_ttl: 60,
+                sinkhole_ipv4: '',
+                sinkhole_ipv6: ''
             },
             cacheStats: {total_entries: 0, hit_rate: 0, total_hits: 0, total_misses: 0},
             healthStatus: {},


### PR DESCRIPTION
## Summary

Adds optional `sinkhole_ipv4` / `sinkhole_ipv6` targets so `null_ip`-blocked
`A`/`AAAA` queries resolve to a custom address (e.g. a LAN block-page server)
instead of `0.0.0.0` / `::`. Configurable via TOML, REST API (`/config`,
`/settings`) and the Settings UI, with validate-before-persist and
empty-string-clears semantics. The two families are independent (setting only
v4 leaves blocked AAAA on `::`, and vice-versa). Targets apply to every
domain-verdict block and are ignored outside `null_ip` mode.

## Behavior notes

- **Restart required.** `BlockPolicy` is built once at boot, so a sinkhole
  change persists immediately but only takes effect on the running resolver
  after a restart — `restart_required` is reported and the docs say so.
- **Atomic validation.** A bad sinkhole rejects the whole request before any
  live side effect (pool hot-reload) or file write, so the saved config can't
  diverge from what the resolver serves.
- **Backup scope widened (heads-up).** The backup `[blocking]` snapshot now also
  round-trips `block_mode` and `block_ttl`, which pre-0.9 backups did not carry.
  This is compat-safe via `#[serde(default)]` (old backups import with
  defaults), but it goes slightly beyond the "sinkhole IP" title — calling it
  out for reviewers.

## Tests

- DTO parse/format (empty clears, valid, invalid + wrong-family rejection)
- Both wire paths (`build_blocked_wire` + `send_blocked_response`), v4/v6 custom
  and cross-family fallback
- API-level rejection of invalid IPs + persist-then-clear round-trip through
  `/config`
- Config persistence write/clear round-trip (key removed from TOML on clear)
- Backup export includes block-response config; legacy snapshot imports via
  serde defaults

`make ci` (fmt + clippy `-D warnings` + tests) green.

## Docs

`docs/configuration/blocking.md` gains a "Custom Sinkhole IP" section (incl. the
loopback warning); sample `ferrous-dns.toml` and the UI Settings form updated;
ROADMAP item checked off.