### PR TITLE
feat - passive mDNS/Bonjour listener gated by dns.mdns_enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ See the [full configuration reference](https://ferrous-networking.github.io/ferr
 | `FERROUS_DATABASE`    | `/var/lib/ferrous-dns/ferrous.db`     | SQLite database path                |
 | `FERROUS_LOG_LEVEL`   | `info`                                | Log level: debug, info, warn, error |
 
+> **mDNS device discovery** (`mdns_enabled`, off by default) listens on UDP **5353** for multicast announcements. It requires host networking (`network_mode: host`) — multicast does not traverse Docker bridge port mapping.
+
 ---
 
 ## Features

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,4 +120,5 @@
 - [ ] WebSocket dashboard for slow query monitoring
 - [ ] Query anomaly detection
 - [ ] DoH bypass detection (detect malware using direct DoH to public resolvers)
+- [ ] mDNS / Bonjour device discovery — passive UDP 5353 listener (multicast 224.0.0.251) to label clients by device name instead of bare IPs (listener landed; name parsing + UI labeling in progress)
 ---

--- a/crates/api/src/dto/config.rs
+++ b/crates/api/src/dto/config.rs
@@ -69,6 +69,7 @@ pub struct DnsConfigResponse {
     pub block_private_ptr: bool,
     pub local_domain: Option<String>,
     pub local_dns_server: Option<String>,
+    pub mdns_enabled: bool,
     pub rate_limit: RateLimitConfigResponse,
 }
 
@@ -257,6 +258,7 @@ pub struct DnsConfigUpdate {
     pub block_private_ptr: Option<bool>,
     pub local_domain: Option<String>,
     pub local_dns_server: Option<String>,
+    pub mdns_enabled: Option<bool>,
     pub rate_limit: Option<RateLimitConfigUpdate>,
 }
 

--- a/crates/api/src/handlers/config/get.rs
+++ b/crates/api/src/handlers/config/get.rs
@@ -88,6 +88,7 @@ pub async fn get_config(State(state): State<AppState>) -> Json<ConfigResponse> {
             block_private_ptr: config.dns.block_private_ptr,
             local_domain: config.dns.local_domain.clone(),
             local_dns_server: config.dns.local_dns_server.clone(),
+            mdns_enabled: config.dns.mdns_enabled,
             rate_limit: crate::dto::config::RateLimitConfigResponse {
                 enabled: config.dns.rate_limit.enabled,
                 queries_per_second: config.dns.rate_limit.queries_per_second,

--- a/crates/api/src/handlers/config/update.rs
+++ b/crates/api/src/handlers/config/update.rs
@@ -202,6 +202,9 @@ pub async fn update_config(
                 Some(server)
             };
         }
+        if let Some(v) = dns_update.mdns_enabled {
+            new_config.dns.mdns_enabled = v;
+        }
         if let Some(rl) = dns_update.rate_limit {
             if let Some(v) = rl.enabled {
                 new_config.dns.rate_limit.enabled = v;

--- a/crates/api/tests/backup_api_tests.rs
+++ b/crates/api/tests/backup_api_tests.rs
@@ -1539,3 +1539,49 @@ async fn test_import_mixed_ipv4_and_ipv6_records() {
     assert_eq!(a_count, 2);
     assert_eq!(aaaa_count, 2);
 }
+
+#[tokio::test]
+async fn test_mdns_enabled_survives_export_import_round_trip() {
+    let (app, config, _pool) = create_test_app().await;
+
+    // Enable mDNS in the live config, then export.
+    config.write().await.dns.mdns_enabled = true;
+
+    let export_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/config/export")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(export_response.status(), StatusCode::OK);
+    let export_bytes = export_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let export_json: Value = serde_json::from_slice(&export_bytes).unwrap();
+    // Export must carry the flag — covers build_snapshot_config in export.rs.
+    assert_eq!(export_json["config"]["dns"]["mdns_enabled"], true);
+
+    // Flip it back off, then import the snapshot. Import must restore it to true,
+    // which exercises the apply_config field mapping in import.rs (not just serde).
+    config.write().await.dns.mdns_enabled = false;
+
+    let import_response = app.oneshot(import_request(&export_bytes)).await.unwrap();
+    let body = import_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let import_json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(import_json["success"], true);
+    assert_eq!(import_json["summary"]["config_updated"], true);
+
+    assert!(config.read().await.dns.mdns_enabled);
+}

--- a/crates/api/tests/config_update_api_tests.rs
+++ b/crates/api/tests/config_update_api_tests.rs
@@ -673,6 +673,23 @@ async fn post_config(app: Router, body: serde_json::Value) -> (StatusCode, Value
     (status, json)
 }
 
+async fn get_config(app: Router) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/config")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    (status, json)
+}
+
 fn live_servers(pm: &ferrous_dns_infrastructure::dns::PoolManager) -> Vec<String> {
     pm.get_all_servers().iter().map(|a| a.to_string()).collect()
 }
@@ -884,4 +901,25 @@ async fn test_update_config_persists_mdns_enabled() {
         written.contains("mdns_enabled = true"),
         "config file should carry mdns_enabled = true, got:\n{written}"
     );
+}
+
+#[tokio::test]
+async fn test_get_config_reports_mdns_enabled() {
+    let pool = create_test_db().await;
+    let (app, _pm, _path) = create_test_app(pool).await;
+
+    // Default config: GET reports the flag as false.
+    let (status, json) = get_config(app.clone()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["dns"]["mdns_enabled"], false);
+
+    // After enabling it, GET reflects the new value — covers the response DTO mapping.
+    let (status, _) = post_config(
+        app.clone(),
+        serde_json::json!({ "dns": { "mdns_enabled": true } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (_, json) = get_config(app).await;
+    assert_eq!(json["dns"]["mdns_enabled"], true);
 }

--- a/crates/api/tests/config_update_api_tests.rs
+++ b/crates/api/tests/config_update_api_tests.rs
@@ -867,3 +867,21 @@ async fn test_update_config_persists_then_clears_sinkhole() {
         "cleared sinkhole key must be removed from the file, got:\n{cleared}"
     );
 }
+
+#[tokio::test]
+async fn test_update_config_persists_mdns_enabled() {
+    let pool = create_test_db().await;
+    let (app, _pm, path) = create_test_app(pool).await;
+
+    let (status, json) =
+        post_config(app, serde_json::json!({ "dns": { "mdns_enabled": true } })).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+
+    // The flag must be written through to the config file under [dns].
+    let written = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        written.contains("mdns_enabled = true"),
+        "config file should carry mdns_enabled = true, got:\n{written}"
+    );
+}

--- a/crates/application/src/use_cases/backup/export.rs
+++ b/crates/application/src/use_cases/backup/export.rs
@@ -130,6 +130,7 @@ impl ExportConfigUseCase {
                 cache_max_ttl: config.dns.cache_max_ttl,
                 block_non_fqdn: config.dns.block_non_fqdn,
                 block_private_ptr: config.dns.block_private_ptr,
+                mdns_enabled: config.dns.mdns_enabled,
                 local_domain: config.dns.local_domain.clone(),
                 local_dns_server: config.dns.local_dns_server.clone(),
             },

--- a/crates/application/src/use_cases/backup/import.rs
+++ b/crates/application/src/use_cases/backup/import.rs
@@ -153,6 +153,7 @@ impl ImportConfigUseCase {
         new_config.dns.cache_max_ttl = sc.dns.cache_max_ttl;
         new_config.dns.block_non_fqdn = sc.dns.block_non_fqdn;
         new_config.dns.block_private_ptr = sc.dns.block_private_ptr;
+        new_config.dns.mdns_enabled = sc.dns.mdns_enabled;
         new_config.dns.local_domain = sc.dns.local_domain.clone();
         new_config.dns.local_dns_server = sc.dns.local_dns_server.clone();
 

--- a/crates/application/src/use_cases/backup/snapshot.rs
+++ b/crates/application/src/use_cases/backup/snapshot.rs
@@ -62,6 +62,8 @@ pub struct SnapshotDnsConfig {
     pub cache_max_ttl: u32,
     pub block_non_fqdn: bool,
     pub block_private_ptr: bool,
+    #[serde(default)]
+    pub mdns_enabled: bool,
     pub local_domain: Option<String>,
     pub local_dns_server: Option<String>,
 }

--- a/crates/application/tests/backup_snapshot_mdns_test.rs
+++ b/crates/application/tests/backup_snapshot_mdns_test.rs
@@ -1,0 +1,48 @@
+//! The backup [dns] snapshot must carry `mdns_enabled`: older backups predate the
+//! field and must import as `false` (serde default), and the flag must round-trip
+//! when set.
+
+use ferrous_dns_application::use_cases::backup::snapshot::SnapshotDnsConfig;
+
+/// A complete [dns] snapshot section minus `mdns_enabled` (added per test).
+fn base_dns() -> serde_json::Value {
+    serde_json::json!({
+        "upstream_servers": [],
+        "cache_enabled": true,
+        "cache_eviction_strategy": "lfu",
+        "cache_max_entries": 1000,
+        "cache_min_hit_rate": 0.3,
+        "cache_min_frequency": 10,
+        "cache_min_lfuk_score": 1.5,
+        "cache_compaction_interval": 300,
+        "cache_refresh_threshold": 0.8,
+        "cache_optimistic_refresh": true,
+        "cache_adaptive_thresholds": true,
+        "cache_access_window_secs": 7200,
+        "cache_min_ttl": 0,
+        "cache_max_ttl": 86400,
+        "block_non_fqdn": false,
+        "block_private_ptr": true,
+        "local_domain": null,
+        "local_dns_server": null
+    })
+}
+
+#[test]
+fn missing_mdns_enabled_defaults_to_false() {
+    // Older backups carry no `mdns_enabled` key; import must default it off.
+    let parsed: SnapshotDnsConfig = serde_json::from_value(base_dns()).unwrap();
+    assert!(!parsed.mdns_enabled);
+}
+
+#[test]
+fn mdns_enabled_round_trips() {
+    let mut v = base_dns();
+    v["mdns_enabled"] = serde_json::json!(true);
+
+    let parsed: SnapshotDnsConfig = serde_json::from_value(v).unwrap();
+    assert!(parsed.mdns_enabled);
+
+    let reserialized = serde_json::to_value(&parsed).unwrap();
+    assert_eq!(reserialized["mdns_enabled"], true);
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -168,6 +168,14 @@ async fn async_main() -> anyhow::Result<()> {
         }
     });
 
+    if config.dns.mdns_enabled {
+        tokio::spawn(async move {
+            if let Err(e) = server::start_mdns_listener().await {
+                error!(error = %e, "mDNS listener error");
+            }
+        });
+    }
+
     let tls_config =
         if config.server.encrypted_dns.dot_enabled || config.server.encrypted_dns.doh_enabled {
             server::load_server_tls_config(

--- a/crates/cli/src/server/dns/mdns.rs
+++ b/crates/cli/src/server/dns/mdns.rs
@@ -1,0 +1,90 @@
+use socket2::{Domain, Protocol, Socket, Type};
+use std::io;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::time::Duration;
+use tokio::net::UdpSocket;
+use tracing::{debug, info, warn};
+
+/// Standard mDNS port (RFC 6762).
+const MDNS_PORT: u16 = 5353;
+/// IPv4 mDNS multicast group (RFC 6762).
+const MDNS_GROUP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
+
+/// Build a non-blocking IPv4 UDP socket bound to `bind`, with
+/// `SO_REUSEADDR`/`SO_REUSEPORT` set so it can coexist with a host
+/// avahi/mDNSResponder already bound to 5353.
+fn build_mdns_socket(bind: SocketAddr) -> io::Result<UdpSocket> {
+    let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
+    socket.set_reuse_address(true)?;
+    #[cfg(unix)]
+    socket.set_reuse_port(true)?;
+    socket.bind(&bind.into())?;
+    socket.set_nonblocking(true)?;
+    UdpSocket::from_std(socket.into())
+}
+
+/// Passive mDNS listener: binds UDP 5353, joins the mDNS multicast group, and
+/// logs the datagrams it receives. Parsing announcements into device names and
+/// populating the query log is a follow-up.
+///
+/// Non-fatal by design: if the socket cannot be created (e.g. the port is held
+/// without address reuse) it warns and returns, so the rest of the server keeps
+/// running. Bind to `0.0.0.0` (not the configured `bind_address`) so multicast
+/// reception is robust.
+pub async fn start_mdns_listener() -> anyhow::Result<()> {
+    let bind = SocketAddr::from((Ipv4Addr::UNSPECIFIED, MDNS_PORT));
+
+    let socket = match build_mdns_socket(bind) {
+        Ok(socket) => socket,
+        Err(e) => {
+            warn!(error = %e, %bind, "mDNS listener could not bind; mDNS disabled for this run");
+            return Ok(());
+        }
+    };
+
+    if let Err(e) = socket.join_multicast_v4(MDNS_GROUP, Ipv4Addr::UNSPECIFIED) {
+        warn!(
+            error = %e,
+            group = %MDNS_GROUP,
+            "mDNS listener bound but could not join the multicast group; only unicast traffic will be seen"
+        );
+    }
+
+    info!(%bind, group = %MDNS_GROUP, "mDNS listener active");
+
+    let mut buf = [0u8; 4096];
+    loop {
+        match socket.recv_from(&mut buf).await {
+            Ok((len, src)) => debug!(bytes = len, %src, "mDNS datagram received"),
+            Err(e) => {
+                // A persistent recv error (e.g. an ICMP port-unreachable surfaced
+                // as ECONNREFUSED) must not turn this into a hot, log-flooding
+                // loop. Back off briefly and keep listening through transient ones.
+                warn!(error = %e, "mDNS receive error; backing off");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn build_mdns_socket_binds_and_receives_unicast() {
+        // Ephemeral loopback port — never 5353, which ingests real LAN mDNS chatter.
+        let listener = build_mdns_socket(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .expect("mDNS socket should bind on an ephemeral loopback port");
+        let addr = listener.local_addr().unwrap();
+
+        let sender = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .await
+            .unwrap();
+        sender.send_to(b"hello-mdns", addr).await.unwrap();
+
+        let mut buf = [0u8; 64];
+        let (len, _src) = listener.recv_from(&mut buf).await.unwrap();
+        assert_eq!(&buf[..len], b"hello-mdns");
+    }
+}

--- a/crates/cli/src/server/dns/mod.rs
+++ b/crates/cli/src/server/dns/mod.rs
@@ -1,9 +1,12 @@
 pub(crate) mod connection_limiter;
 pub mod dot;
+mod mdns;
 mod pktinfo;
 mod tcp;
 pub mod tls_config;
 mod udp;
+
+pub use mdns::start_mdns_listener;
 
 use connection_limiter::ConnectionLimiter;
 use ferrous_dns_infrastructure::dns::server::DnsServerHandler;

--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -5,6 +5,7 @@ mod web_tls;
 
 pub use dns::dot::start_dot_server;
 pub use dns::start_dns_server;
+pub use dns::start_mdns_listener;
 pub use dns::tls_config::load_server_tls_config;
 pub use web::start_doh_server;
 pub use web::start_web_server;

--- a/crates/domain/src/config/dns.rs
+++ b/crates/domain/src/config/dns.rs
@@ -93,6 +93,9 @@ pub struct DnsConfig {
     #[serde(default = "default_false")]
     pub block_non_fqdn: bool,
 
+    #[serde(default = "default_false")]
+    pub mdns_enabled: bool,
+
     #[serde(default)]
     pub local_domain: Option<String>,
 
@@ -178,6 +181,7 @@ impl Default for DnsConfig {
             cache_max_ttl: default_cache_max_ttl(),
             block_private_ptr: true,
             block_non_fqdn: false,
+            mdns_enabled: false,
             local_domain: None,
             local_dns_server: None,
             local_records: vec![],

--- a/crates/domain/tests/dns_config_test.rs
+++ b/crates/domain/tests/dns_config_test.rs
@@ -27,6 +27,7 @@ fn test_config_default_values() {
     assert_eq!(config.cache_max_ttl, 86_400);
     assert!(config.block_private_ptr);
     assert!(!config.block_non_fqdn);
+    assert!(!config.mdns_enabled);
     assert!(config.local_domain.is_none());
     assert!(config.local_dns_server.is_none());
     assert!(config.local_records.is_empty());
@@ -48,6 +49,23 @@ fn test_qname_case_randomization_roundtrip() {
     let serialized = toml::to_string(&config).unwrap();
     let reparsed: DnsConfig = toml::from_str(&serialized).unwrap();
     assert!(reparsed.qname_case_randomization);
+}
+
+#[test]
+fn test_mdns_enabled_defaults_off_when_absent() {
+    // Existing configs without the field must still deserialize, defaulting off.
+    let config: DnsConfig = toml::from_str("query_timeout = 3").unwrap();
+    assert!(!config.mdns_enabled);
+}
+
+#[test]
+fn test_mdns_enabled_roundtrip() {
+    let config: DnsConfig = toml::from_str("mdns_enabled = true").unwrap();
+    assert!(config.mdns_enabled);
+
+    let serialized = toml::to_string(&config).unwrap();
+    let reparsed: DnsConfig = toml::from_str(&serialized).unwrap();
+    assert!(reparsed.mdns_enabled);
 }
 
 #[test]
@@ -100,6 +118,7 @@ fn test_config_deserialization_with_all_fields() {
         cache_access_window_secs = 3600
         block_private_ptr = false
         block_non_fqdn = true
+        mdns_enabled = true
         local_domain = "home.lan"
         local_dns_server = "192.168.1.1:53"
     "#;
@@ -119,6 +138,7 @@ fn test_config_deserialization_with_all_fields() {
     assert_eq!(config.cache_access_window_secs, 3600);
     assert!(!config.block_private_ptr);
     assert!(config.block_non_fqdn);
+    assert!(config.mdns_enabled);
     assert_eq!(config.local_domain, Some("home.lan".to_string()));
     assert_eq!(config.local_dns_server, Some("192.168.1.1:53".to_string()));
 }

--- a/crates/infrastructure/src/repositories/config_persistence.rs
+++ b/crates/infrastructure/src/repositories/config_persistence.rs
@@ -233,6 +233,11 @@ pub fn save_config_to_file(config: &Config, path: &str) -> Result<(), ConfigErro
             "block_non_fqdn",
             toml_edit::Value::from(config.dns.block_non_fqdn),
         );
+        set_val(
+            t,
+            "mdns_enabled",
+            toml_edit::Value::from(config.dns.mdns_enabled),
+        );
         match &config.dns.local_domain {
             Some(domain) => set_val(t, "local_domain", toml_edit::Value::from(domain.clone())),
             None => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,12 @@ services:
     container_name: ferrous-dns
     restart: unless-stopped
 
-    ports:
-      - "53:53/udp"
-      - "53:53/tcp"
-      - "8080:8080"
+    # Host networking is required for mDNS/Bonjour device discovery: multicast on
+    # UDP 5353 does not traverse Docker bridge port mapping. Host mode also binds
+    # the DNS/web ports directly on the host, so no `ports:` mapping is used.
+    network_mode: host
+    cap_add:
+      - NET_BIND_SERVICE
 
     volumes:
       - ferrous-data:/data

--- a/docs/configuration/dns.md
+++ b/docs/configuration/dns.md
@@ -14,6 +14,7 @@ default_strategy = "Parallel"
 dnssec_mode = "Permissive"
 block_private_ptr = true
 block_non_fqdn = false
+mdns_enabled = false              # passive mDNS/Bonjour listener on UDP 5353
 # local_domain = "lan"            # optional — no default
 local_dns_server = "10.0.0.1:53"
 ```
@@ -28,6 +29,7 @@ local_dns_server = "10.0.0.1:53"
 | `block_non_fqdn` | `false` | Block queries for non-fully-qualified domain names |
 | `local_domain` | — | Local domain suffix appended to short hostnames |
 | `local_dns_server` | — | Router/DHCP server used for PTR lookups and client hostname resolution |
+| `mdns_enabled` | `false` | Enable the passive mDNS/Bonjour listener (UDP 5353 multicast) for device discovery. In Docker this needs host networking — see [Installation](../getting-started/installation.md#docker) |
 | `rebinding_protection_enabled` | `true` | Block public domains that resolve to private/RFC-1918 (or IPv6 ULA/link-local) addresses — see [DNS Rebinding Protection](../features/malware-detection.md#dns-rebinding-protection) |
 | `rebinding_allowlist` | `[]` | Exact domain names exempt from rebinding protection regardless of resolved IP (split-horizon DNS) |
 

--- a/docs/configuration/ferrous-dns-toml.md
+++ b/docs/configuration/ferrous-dns-toml.md
@@ -182,6 +182,7 @@ block_private_ptr = true
 block_non_fqdn    = true
 local_domain      = "lan"
 local_dns_server  = "10.0.0.1:53"
+mdns_enabled      = false
 ```
 
 | Option | Type | Default | Description |
@@ -194,6 +195,7 @@ local_dns_server  = "10.0.0.1:53"
 | `block_non_fqdn` | `bool` | `true` | Block queries for non-fully-qualified domain names |
 | `local_domain` | `str` | `"lan"` | Local domain suffix appended to short hostnames |
 | `local_dns_server` | `str` | `"10.0.0.1:53"` | Router or DHCP server used for PTR lookups and client hostname resolution |
+| `mdns_enabled` | `bool` | `false` | Enable the passive mDNS/Bonjour listener (UDP 5353 multicast) for device discovery; requires host networking in Docker |
 
 See [DNS & Upstreams](dns.md).
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -465,6 +465,7 @@ default_strategy = "Parallel"              # "Parallel" or "Sequential"
 dnssec_enabled   = true                    # Validate DNSSEC signatures
 block_private_ptr = true                   # Block PTR lookups for RFC-1918 ranges
 block_non_fqdn   = true                    # Block non-FQDN queries
+mdns_enabled     = false                   # Passive mDNS/Bonjour listener (UDP 5353, needs host networking in Docker)
 local_domain     = "lan"                   # Local domain suffix
 local_dns_server = "10.0.0.1:53"           # Router — PTR/hostname/upstream resolution
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ Ports, bind address, database path, and log level are all set inside the mounted
 Access the dashboard at `http://localhost:8080`
 
 !!! note "Network mode"
-    `--network host` is required so Ferrous DNS can bind to port 53 and detect client IPs/MACs correctly. On macOS, host networking is not available in Docker Desktop — use a Linux VM or Docker Compose with explicit port mappings.
+    `--network host` is required so Ferrous DNS can bind to port 53 and detect client IPs/MACs correctly. It is also required for **mDNS device discovery** (`mdns_enabled`): multicast on UDP 5353 does not traverse Docker bridge port mapping, so the listener only works in host mode. On macOS, host networking is not available in Docker Desktop — use a Linux VM or Docker Compose with explicit port mappings.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,6 +87,9 @@ sudo ss -tulnp | grep :53
 # Open port 53 (if using ufw)
 sudo ufw allow 53/udp
 sudo ufw allow 53/tcp
+
+# If mDNS device discovery is enabled (mdns_enabled), also allow UDP 5353
+sudo ufw allow 5353/udp
 ```
 
 ### Check 3: Are upstream servers reachable?
@@ -280,6 +283,9 @@ services:
 
 !!! warning "Client IP detection in bridge mode"
     In bridge mode, all queries appear to come from the Docker gateway IP (usually `172.17.0.1`). Client-specific features (groups, per-client policies) will not work correctly. Use host network mode for accurate client detection.
+
+!!! warning "mDNS device discovery requires host mode"
+    The mDNS listener (`mdns_enabled`) relies on multicast (`224.0.0.251:5353`), which does **not** traverse Docker bridge port mapping — adding `"5353:5353/udp"` to `ports:` will not deliver announcements. Use `network_mode: host` for mDNS to work.
 
 ---
 

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -63,6 +63,7 @@ default_strategy = "Parallel"           # Resolution strategy: "Parallel" (faste
 dnssec_mode = "Permissive"              # DNSSEC enforcement: "Off" (no validation), "Permissive" (validate + tag, no SERVFAIL), "Strict" (SERVFAIL on Bogus). Default: Permissive
 block_private_ptr = true                # Block PTR lookups for private/RFC-1918 IP ranges
 block_non_fqdn = true                   # Block queries for names that are not fully qualified domain names
+mdns_enabled = false                    # Enable mDNS/Bonjour listener to label clients by device name (LAN multicast; off by default)
 local_domain = "lan"                    # Local domain suffix appended to short hostnames
 local_dns_server = "10.0.0.1:53"        # Router/DHCP server — used for PTR lookups to resolve client hostnames
 

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -63,7 +63,7 @@ default_strategy = "Parallel"           # Resolution strategy: "Parallel" (faste
 dnssec_mode = "Permissive"              # DNSSEC enforcement: "Off" (no validation), "Permissive" (validate + tag, no SERVFAIL), "Strict" (SERVFAIL on Bogus). Default: Permissive
 block_private_ptr = true                # Block PTR lookups for private/RFC-1918 IP ranges
 block_non_fqdn = true                   # Block queries for names that are not fully qualified domain names
-mdns_enabled = false                    # Enable mDNS/Bonjour listener to label clients by device name (LAN multicast; off by default)
+mdns_enabled = false                    # Passive mDNS/Bonjour listener on UDP 5353 (LAN multicast); device-name labeling is a future release; off by default
 local_domain = "lan"                    # Local domain suffix appended to short hostnames
 local_dns_server = "10.0.0.1:53"        # Router/DHCP server — used for PTR lookups to resolve client hostnames
 

--- a/web/static/settings.html
+++ b/web/static/settings.html
@@ -565,6 +565,21 @@
                 </select>
             </div>
 
+            <div style="display:flex;align-items:flex-start;justify-content:space-between;padding:16px 0;border-bottom:1px solid var(--border-color)">
+                <div style="flex:1;margin-right:24px">
+                    <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+                        <i data-lucide="wifi" style="width:20px;height:20px;color:var(--color-primary)"></i>
+                        <h4 style="font-size:16px;font-weight:600;margin:0">mDNS Device Discovery</h4>
+                    </div>
+                    <p style="font-size:13px;color:var(--text-secondary);margin:0">Listens for mDNS/Bonjour announcements on the local network so clients show up by device name instead of bare IPs in the query log and dashboard.</p>
+                    <p style="font-size:12px;color:var(--text-tertiary);margin:8px 0 0;font-style:italic">Requires the server to reach the LAN multicast group (in Docker, host networking). Off by default.</p>
+                </div>
+                <div @click="config.dns.mdns_enabled=!config.dns.mdns_enabled"
+                     :class="config.dns.mdns_enabled?'active':''" class="toggle-switch">
+                    <div class="toggle-slider"></div>
+                </div>
+            </div>
+
             <div style="display:flex;align-items:flex-start;justify-content:space-between;padding:16px 0">
                 <div style="flex:1;margin-right:24px">
                     <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">

--- a/web/static/settings.html
+++ b/web/static/settings.html
@@ -571,8 +571,8 @@
                         <i data-lucide="wifi" style="width:20px;height:20px;color:var(--color-primary)"></i>
                         <h4 style="font-size:16px;font-weight:600;margin:0">mDNS Device Discovery</h4>
                     </div>
-                    <p style="font-size:13px;color:var(--text-secondary);margin:0">Listens for mDNS/Bonjour announcements on the local network so clients show up by device name instead of bare IPs in the query log and dashboard.</p>
-                    <p style="font-size:12px;color:var(--text-tertiary);margin:8px 0 0;font-style:italic">Requires the server to reach the LAN multicast group (in Docker, host networking). Off by default.</p>
+                    <p style="font-size:13px;color:var(--text-secondary);margin:0">Once active, clients will show up by device name — learned from mDNS/Bonjour announcements on the local network — instead of bare IPs in the query log and dashboard.</p>
+                    <p style="font-size:12px;color:var(--text-tertiary);margin:8px 0 0;font-style:italic">Not active yet: the mDNS listener ships in a future release, so toggling this currently has no effect. It will require the server to reach the LAN multicast group (in Docker, host networking). Off by default.</p>
                 </div>
                 <div @click="config.dns.mdns_enabled=!config.dns.mdns_enabled"
                      :class="config.dns.mdns_enabled?'active':''" class="toggle-switch">

--- a/web/static/settings.html
+++ b/web/static/settings.html
@@ -571,8 +571,8 @@
                         <i data-lucide="wifi" style="width:20px;height:20px;color:var(--color-primary)"></i>
                         <h4 style="font-size:16px;font-weight:600;margin:0">mDNS Device Discovery</h4>
                     </div>
-                    <p style="font-size:13px;color:var(--text-secondary);margin:0">Once active, clients will show up by device name — learned from mDNS/Bonjour announcements on the local network — instead of bare IPs in the query log and dashboard.</p>
-                    <p style="font-size:12px;color:var(--text-tertiary);margin:8px 0 0;font-style:italic">Not active yet: the mDNS listener ships in a future release, so toggling this currently has no effect. It will require the server to reach the LAN multicast group (in Docker, host networking). Off by default.</p>
+                    <p style="font-size:13px;color:var(--text-secondary);margin:0">Listens for mDNS/Bonjour announcements on the local network (UDP 5353, multicast). The listener is active and receiving, but labeling clients by device name instead of bare IPs in the query log and dashboard arrives in a future release.</p>
+                    <p style="font-size:12px;color:var(--text-tertiary);margin:8px 0 0;font-style:italic">Requires the server to reach the LAN multicast group (in Docker, host networking). Takes effect after a server restart. Off by default.</p>
                 </div>
                 <div @click="config.dns.mdns_enabled=!config.dns.mdns_enabled"
                      :class="config.dns.mdns_enabled?'active':''" class="toggle-switch">

--- a/web/static/settings.js
+++ b/web/static/settings.js
@@ -11,6 +11,7 @@
                     health_check: {enabled: true, interval_seconds: 30, timeout_ms: 2000, failure_threshold: 3},
                     dnssec_mode: 'permissive',
                     cache_enabled: true,
+                    mdns_enabled: false,
                     cache_ttl: 3600,
                     cache_min_ttl: 0,
                     cache_max_ttl: 86400,


### PR DESCRIPTION
## Summary

Adds a `dns.mdns_enabled` config flag (default **false**) that gates a passive mDNS/Bonjour listener. When enabled, the server binds UDP 5353, joins the multicast group `224.0.0.251`, and logs received datagrams — the foundation for future device-name labeling of clients.

## What's in this branch

- **Config flag plumbed end-to-end** — `dns.mdns_enabled` is wired through every layer the codebase requires for a setting to actually persist and survive backup: domain config struct (`#[serde(default)]`), GET/UPDATE API + DTOs, the curated `config_persistence.rs` TOML writer, and the backup snapshot/export/import path (serde-default so older backups import cleanly as `false`).
- **Passive listener, gated and non-fatal** — spawned **only when the flag is true** (`if config.dns.mdns_enabled` in `main.rs`); with the flag false/absent the socket is never created and port 5353 is never bound. Binds `0.0.0.0` with `SO_REUSEADDR`/`SO_REUSEPORT` so it coexists with a host avahi/mDNSResponder, and warns-and-continues on bind/join failure so DNS/web stay up. The recv-error arm backs off 1s to avoid a hot, log-flooding loop.
- **Docker host networking** — `docker-compose.yml` switches to `network_mode: host` + `cap_add: NET_BIND_SERVICE` because multicast cannot traverse Docker's bridge port-mapping. README, install, troubleshooting, and configuration docs updated with the caveat; ROADMAP updated.
- **Settings UI** — honest toggle copy (states the listener is active/receiving, but device-name labeling lands in a future release).

## Tests

- Inline socket roundtrip unit test (`build_mdns_socket_binds_and_receives_unicast`, ephemeral loopback — never binds 5353).
- Domain serde defaults + roundtrip, API GET + POST persistence (reads the written file back), and backup export→import roundtrip over HTTP.
- `make ci` (fmt-check + clippy `-D warnings` + full suite) passes green.

## Deferred (tracked in ROADMAP/docs)

mDNS name parsing → device labels, IPv6 mDNS (`ff02::fb`), hot-reload of the toggle (currently restart-only), and graceful listener shutdown.
