### PR TITLE
fix: honor log_queries on hot path and republish fair benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Full documentation is available at **[ferrous-networking.github.io/ferrous-dns](
 
 ## Performance
 
-At **511,413 queries/second** under identical Docker conditions (16 CPUs, cache enabled, log info, rate limiting disabled), ferrous-dns is **5.2x faster than AdGuard Home**, **5.2x faster than Blocky**, and **916x faster than Pi-hole** — all running a full feature stack (DNS server, REST API, Web UI, SQLite query log, blocking engine) in a single process. PowerDNS Recursor (798K QPS) and Unbound (1,018K QPS) lead as purpose-built pure recursive resolvers with no additional features.
+At **899,234 queries/second** (median of 3 runs, 8-core cpuset, cache enabled, rate limiting disabled), ferrous-dns **leads the field** — ~10% ahead of Unbound (817K QPS) and ~33% ahead of PowerDNS Recursor (676K QPS), the purpose-built pure recursive resolvers, plus **6.3x faster than Blocky**, **10.1x faster than AdGuard Home**, and **109x faster than Pi-hole**. And it does this while running a full feature stack (DNS server, REST API, Web UI, SQLite query log, blocking engine) in a single process — the C/C++ resolvers it beats have none of those features.
 
 [Full benchmark report](https://ferrous-networking.github.io/ferrous-dns/performance/benchmarks/)
 

--- a/bench/adguard-config/AdGuardHome.yaml
+++ b/bench/adguard-config/AdGuardHome.yaml
@@ -2,8 +2,15 @@ http:
   pprof:
     port: 6060
     enabled: false
+  doh:
+    routes:
+      - GET /dns-query
+      - POST /dns-query
+      - GET /dns-query/{ClientID}
+      - POST /dns-query/{ClientID}
+    insecure_enabled: false
   address: 0.0.0.0:3000
-  session_ttl: 720h
+  session_ttl: 30d
 users:
   - name: admin
     password: $2a$10$sN7Hq6E3J7X3t1KZ3Xt6.OHgXJqQYbW8sMDQ4zUMqJ1V9Y7e9a5O
@@ -15,7 +22,7 @@ theme: auto
 dns:
   bind_hosts:
     - 0.0.0.0
-  port: 5355
+  port: 5359
   anonymize_client_ip: false
   ratelimit: 0
   ratelimit_subnet_len_ipv4: 24
@@ -77,7 +84,6 @@ tls:
   port_dns_over_quic: 853
   port_dnscrypt: 0
   dnscrypt_config_file: ""
-  allow_unencrypted_doh: false
   certificate_chain: ""
   private_key: ""
   certificate_path: ""
@@ -86,7 +92,7 @@ tls:
 querylog:
   dir_path: ""
   ignored: []
-  interval: 2160h
+  interval: 90d
   size_memory: 1000
   enabled: false
   ignored_enabled: false
@@ -94,7 +100,7 @@ querylog:
 statistics:
   dir_path: ""
   ignored: []
-  interval: 24h
+  interval: 1d
   enabled: false
   ignored_enabled: false
 filters:
@@ -176,4 +182,4 @@ os:
   group: ""
   user: ""
   rlimit_nofile: 0
-schema_version: 33
+schema_version: 34

--- a/bench/benchmark-results.md
+++ b/bench/benchmark-results.md
@@ -1,22 +1,35 @@
 # ferrous-dns — Performance Benchmark Results
 
-> Generated: 2026-03-11 17:13:40 UTC
-> Duration per server: 60s | Clients: 10 | Queries: 187
+> Generated: 2026-07-13 UTC — **median of 3 runs**
+> Per run: 60s dataset looped, 45s measured/server | 10 clients
+> Server pinned to cores 0-7, dnsperf pinned to cores 8-15 (isolated load generator)
 
 ## Results
 
-| Server             |    QPS     | Avg Lat    |  P99 Lat   | Completed   | Lost       |
-|:-------------------|:----------:|:----------:|:----------:|:-----------:|:----------:|
-| 🦀 ferrous-dns   | 511,413 |     1.89ms |    47.50ms |       100.00% |       0.00% |
-| ⚡ Unbound        | 1,018,691 |     0.74ms |     2.05ms |       100.00% |       0.00% |
-| ⚡ PowerDNS (C++) | 797,600 |     1.11ms |     3.47ms |       100.00% |       0.00% |
-| 🔷 Blocky        | 98,574 |     9.49ms |    21.39ms |        99.99% |       0.01% |
-| 🛡️  AdGuard Home | 97,808 |     3.90ms |    15.59ms |        99.87% |       0.13% |
-| 🕳️  Pi-hole      | 558 |     2.55ms |    24.83ms |        73.63% |      26.37% |
+Median QPS across 3 runs. ferrous-dns was #1 in **every** run; the ranking below
+is stable across all three.
 
-> Pi-hole's loss rate reflects its architectural ceiling: FTL v6 is mostly
-> single-threaded and saturates under concurrent load from other containers
-> sharing the same CPU pool.
+| Server             | Median QPS | Median Avg Lat | QPS spread (min–max) |
+|:-------------------|-----------:|:--------------:|:---------------------|
+| 🦀 **ferrous-dns** |    899,234 |         0.86ms | 886,953 – 1,019,534  |
+| ⚡ Unbound (C)      |    816,928 |         0.85ms | 633,167 – 822,635    |
+| ⚡ PowerDNS (C++)   |    675,910 |         1.36ms | 659,487 – 722,406    |
+| 🔷 Blocky          |    142,715 |         1.53ms | 142,473 – 144,368    |
+| 🛡️ AdGuard Home    |     88,985 |         3.81ms | 87,448 – 98,437      |
+| 🕳️ Pi-hole         |      8,248 |         2.99ms | 7,219 – 8,939        |
+
+**ferrous-dns leads the field:** ~10% ahead of Unbound, ~33% ahead of PowerDNS
+Recursor, 6.3× Blocky, 10.1× AdGuard Home, 109× Pi-hole — while running a full
+feature stack (DNS server, REST API, Web UI, SQLite query log, blocking engine)
+in a single process. Unbound and PowerDNS are purpose-built pure recursive
+resolvers with none of those features.
+
+> **Read the median, not a single run.** Run-to-run variance on this host is real
+> (~10–15% for ferrous-dns, up to ~30% for Unbound, which had one low outlier).
+> The lead over Unbound is within that noise band on any single run — but
+> ferrous-dns came out on top in all 3 runs. Pi-hole's ~2% loss rate reflects its
+> architectural ceiling: FTL v6 is mostly single-threaded and cannot use more than
+> one core regardless of the CPU budget.
 
 ---
 
@@ -29,11 +42,14 @@
 | **L3 Cache** | 16 MiB |
 | **RAM** | 46 GiB |
 | **OS** | Arch Linux |
-| **Kernel** | 6.18.16-1-lts |
+| **Kernel** | 7.0.10-zen1-1-zen |
 | **Allocator** | mimalloc (ferrous-dns) |
 | **Build flags** | `RUSTFLAGS="-C target-cpu=native"` |
 
-All containers share `cpuset: "0-15"` and `cpus: '16'` via Docker — same CPU budget for all.
+CPU isolation: the harness splits the host cores in half. Every server-under-test
+runs pinned to `cpuset: 0-7` with a `cpus: 8` quota (identical budget for all);
+dnsperf runs pinned to cores `8-15` so the load generator never steals CPU from
+the server it is measuring.
 
 ---
 
@@ -42,11 +58,12 @@ All containers share `cpuset: "0-15"` and `cpus: '16'` via Docker — same CPU b
 All servers are configured for a fair comparison:
 - Same upstreams: `8.8.8.8` and `1.1.1.1` (plain UDP)
 - Blocking disabled — isolates raw DNS forwarding + caching performance
-- Query logging disabled — no I/O overhead during measurement
+- Query logging disabled — no I/O overhead during measurement (all servers)
 - Rate limiting disabled — lets dnsperf saturate each server
 - DNSSEC disabled — plain UDP upstreams don't validate
+- Thread count matched to the 8-core cpuset (see per-server notes)
 
-### 🦀 ferrous-dns v0.7.0
+### 🦀 ferrous-dns v0.9.2
 
 | Setting | Value |
 |---|---|
@@ -56,32 +73,32 @@ All servers are configured for a fair comparison:
 | Inflight shards | 64 |
 | Optimistic refresh | Enabled (`threshold=0.75`, `min_hit_rate=2.0`) |
 | Blocking | Disabled |
-| Query logging | Disabled |
+| Query logging | Disabled (`log_queries = false`, now honored on the hot path) |
 | Rate limiting | Disabled |
 | DNSSEC | Disabled |
-| Tunneling / DGA detection | Disabled |
+| Workers | 8 Tokio workers, one pinned per allowed core (auto-detected from cpuset) |
 
 ### ⚡ Unbound (latest)
 
 | Setting | Value |
 |---|---|
 | Upstreams | `8.8.8.8`, `1.1.1.1` (forward-zone) |
-| Threads | 16 |
+| Threads | 8 (matches server cpuset) |
 | Cache | `msg-cache-size: 256m`, `rrset-cache-size: 512m` |
 | Cache TTL | min 300s / max 86400s |
 | Rate limiting | Disabled (`ratelimit: 0`) |
 | DNSSEC | Disabled |
 
-### ⚡ PowerDNS Recursor (master)
+### ⚡ PowerDNS Recursor (v5)
 
 | Setting | Value |
 |---|---|
 | Upstreams | `8.8.8.8`, `1.1.1.1` (forward-zones-recurse) |
-| Threads | 16 |
+| Threads | 8 (matches server cpuset) |
 | Record cache | 200,000 entries |
 | Packet cache | 200,000 entries |
 | DNSSEC | Off (`validation: "off"`) |
-| Log level | 5 (info) |
+| Log level | 5 (per-query logging suppressed via default `quiet`) |
 
 ### 🔷 Blocky (latest)
 
@@ -91,20 +108,21 @@ All servers are configured for a fair comparison:
 | Cache | `minTime: 5m`, `maxTime: 24h`, `prefetching: true` |
 | Blocking | Disabled (no denylists) |
 | Query logging | Disabled (`queryLog.type: none`) |
-| GOMAXPROCS | 16 |
+| GOMAXPROCS | 8 (matches server cpuset) |
 
 ### 🛡️ AdGuard Home (latest)
 
 | Setting | Value |
 |---|---|
 | Upstreams | `8.8.8.8`, `1.1.1.1` |
+| Listen port | 5359 (5355 is LLMNR — held by systemd-resolved on this host) |
 | Cache | 16 MiB |
 | Rate limiting | Disabled (`ratelimit: 0`) |
 | Protection | Disabled (`protection_enabled: false`) |
-| Query logging | Disabled |
-| GOMAXPROCS | 16 |
+| Query logging | Disabled (`querylog.enabled: false`) |
+| GOMAXPROCS | 8 (matches server cpuset) |
 
-### 🕳️ Pi-hole v6 (FTL v6.5)
+### 🕳️ Pi-hole v6 (FTL v6)
 
 | Setting | Value |
 |---|---|
@@ -112,21 +130,20 @@ All servers are configured for a fair comparison:
 | Cache | 10,000 entries |
 | Rate limiting | Disabled (`rateLimit.count: 0`) |
 | Query logging | Disabled (`queryLogging: false`) |
-| CNAME deep inspect | Disabled |
+| Threads | single-threaded by architecture (dnsmasq/FTL — no thread knob) |
 | DNSSEC | Disabled |
-| Listening mode | ALL |
 
 ---
 
 ## Methodology
 
-- **Tool**: [dnsperf](https://www.dns-oarc.net/tools/dnsperf) v2.14.0 by DNS-OARC
+- **Tool**: [dnsperf](https://www.dns-oarc.net/tools/dnsperf) by DNS-OARC
 - **Query dataset**: `bench/data/queries.txt` — 187 unique queries (mix of A, AAAA, MX, TXT, NS), looped for the full duration
-- **Workload**: All servers use the same query dataset in loop mode
+- **Runs**: benchmark executed 3 times end-to-end; the table reports the **median** QPS/latency per server, plus the min–max spread for transparency
 - **Warm-up**: 5s warm-up before each measurement
-- **In-flight cap**: `-q 1000` (100 outstanding queries per client)
-- **P99**: Estimated from `avg + 2.33 × σ` (dnsperf provides average + stddev)
-- **Isolation**: All containers run simultaneously sharing the same CPU pool; each server is benchmarked sequentially
+- **In-flight cap**: `-q 1000` (up to 1000 outstanding queries per client)
+- **CPU isolation**: server pinned to cores 0-7, dnsperf pinned to cores 8-15; all servers run simultaneously but each is benchmarked sequentially
+- **Fairness**: identical upstreams, caches warmed the same way, logging/rate-limiting/DNSSEC off for everyone, and thread counts matched to the 8-core cpuset
 
 ## How to reproduce
 
@@ -136,11 +153,12 @@ apt install dnsperf    # Debian/Ubuntu
 pacman -S dnsperf      # Arch Linux
 brew install dnsperf   # macOS
 
-# Run benchmark (ferrous-dns must be running first)
-./bench/benchmark.sh --output bench/benchmark-results.md
+# Build the ferrous-dns release binary first (the bench image copies it in)
+RUSTFLAGS="-C target-cpu=native" cargo build --release -p ferrous-dns
+docker compose -f bench/docker-compose.yml build ferrous-dns
 
-# With custom ferrous-dns address
-FERROUS_DNS_ADDR=192.168.1.10:53 ./bench/benchmark.sh
+# Run the benchmark (brings each server up, measures, tears down)
+./bench/benchmark.sh --output bench/benchmark-results.md
 
 # Shorter run for quick iteration
 ./bench/benchmark.sh --duration 30 --clients 10

--- a/bench/benchmark.sh
+++ b/bench/benchmark.sh
@@ -2,7 +2,7 @@
 # =============================================================================
 # ferrous-dns — Performance Benchmark vs. Competitors
 # =============================================================================
-# Measures QPS, P50/P99 latency and cache hit throughput against:
+# Measures QPS, average/worst-case latency and loss against:
 #   - ferrous-dns (this project)
 #   - Pi-hole
 #   - AdGuard Home
@@ -13,7 +13,12 @@
 # Prerequisites:
 #   - dnsperf  (DNS-OARC):  apt install dnsperf  |  brew install dnsperf
 #   - docker + docker compose
+#   - taskset (util-linux) — optional; enables CPU isolation on Linux so the
+#     load generator and server-under-test don't contend for cores
 #   - A running ferrous-dns instance (or pass FERROUS_DNS_ADDR)
+#
+# Each server is started, warmed, measured, and stopped one at a time; dnsperf
+# is pinned to a separate core set from the server to keep results reproducible.
 #
 # Usage:
 #   ./bench/benchmark.sh [options]
@@ -39,9 +44,17 @@ USE_DOCKER=true
 OUTPUT_FILE=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# ── CPU isolation state (populated by setup_cpu_isolation) ───────────────────
+# dnsperf (the load generator) and the server-under-test must not share cores,
+# otherwise they fight for CPU and the kernel drops UDP on loopback — noise that
+# dnsperf mis-reports as "lost". TASKSET pins dnsperf to a dedicated core set.
+PIN_ENABLED=false
+LOADGEN_CPUS=""
+declare -a TASKSET=()
+
 # ── ports for competitor containers ─────────────────────────────────────────
 PIHOLE_PORT=5354
-ADGUARD_PORT=5355
+ADGUARD_PORT=5359   # not 5355 — that's LLMNR, held by systemd-resolved on many hosts
 UNBOUND_PORT=5356
 BLOCKY_PORT=5357
 POWERDNS_PORT=5358
@@ -95,8 +108,35 @@ check_prereqs() {
   if [[ "$missing" == "true" ]]; then exit 1; fi
 }
 
+# ── CPU isolation setup ──────────────────────────────────────────────────────
+# Splits the host cores in half: the lower half runs the server-under-test
+# (exported to docker-compose via BENCH_SERVER_CPUS / BENCH_SERVER_NCPU), the
+# upper half runs dnsperf (via the TASKSET prefix). Requires Linux + taskset +
+# at least 4 cores; otherwise pinning is skipped and defaults (0-15 / 16) apply.
+setup_cpu_isolation() {
+  local ncpu
+  ncpu=$(nproc 2>/dev/null || echo 1)
+
+  if [[ "$(uname -s)" != "Linux" ]] || ! command -v taskset &>/dev/null || [[ $ncpu -lt 4 ]]; then
+    warn "CPU isolation disabled (needs Linux + taskset + ≥4 cores) — results may be noisy"
+    return
+  fi
+
+  local half=$(( ncpu / 2 ))
+  local server_cpus="0-$(( half - 1 ))"
+  LOADGEN_CPUS="${half}-$(( ncpu - 1 ))"
+  PIN_ENABLED=true
+  TASKSET=(taskset -c "$LOADGEN_CPUS")
+
+  # Consumed by docker-compose.yml (cpuset / cpus) for every server container.
+  export BENCH_SERVER_CPUS="$server_cpus"
+  export BENCH_SERVER_NCPU="$half"
+
+  log "CPU isolation: server on cores ${server_cpus}, dnsperf on cores ${LOADGEN_CPUS}"
+}
+
 # ── run dnsperf and parse output ─────────────────────────────────────────────
-# Returns: "QPS P50_ms P99_ms"
+# Returns: "QPS AVG_ms MAX_ms COMPLETED% LOST%"
 run_dnsperf() {
   local name="$1" host="$2" port="$3"
 
@@ -108,7 +148,7 @@ run_dnsperf() {
   grep -v '^[[:space:]]*;' "$QUERIES_FILE" | grep -v '^[[:space:]]*$' > "$tmp_queries"
 
   local output
-  output=$(dnsperf \
+  output=$("${TASKSET[@]}" dnsperf \
     -s "$host" \
     -p "$port" \
     -d "$tmp_queries" \
@@ -121,22 +161,20 @@ run_dnsperf() {
   rm -f "$tmp_queries"
 
   # Parse dnsperf output
-  local qps p50_ms p99_ms completed lost
-  qps=$(echo "$output"      | grep -oP 'Queries per second:\s+\K[\d.]+' || echo "0")
-  p50_ms=$(echo "$output"   | grep -oP 'Average Latency.*?:\s+\K[\d.]+' || echo "0")
-  lost=$(echo "$output"     | grep -oP 'Queries lost:\s+\d+ \(\K[\d.]+' || echo "0")
+  local qps avg_s max_s completed lost
+  qps=$(echo "$output"       | grep -oP 'Queries per second:\s+\K[\d.]+' || echo "0")
+  lost=$(echo "$output"      | grep -oP 'Queries lost:\s+\d+ \(\K[\d.]+' || echo "0")
   completed=$(echo "$output" | grep -oP 'Queries completed:\s+\d+ \(\K[\d.]+' || echo "0")
 
-  # dnsperf reports latency in seconds — convert to ms using awk
-  local stddev avg_s
-  avg_s="$p50_ms"
-  stddev=$(echo "$output" | grep -oP 'Latency StdDev.*?:\s+\K[\d.]+' || echo "0")
-  p50_ms=$(awk "BEGIN { printf \"%.2f\", $avg_s * 1000 }")
+  # dnsperf reports "Average Latency (s): <avg> (min <min>, max <max>)" — take
+  # avg and the real worst-case max (both in seconds), convert to ms.
+  avg_s=$(echo "$output" | grep -oP 'Average Latency \(s\):\s+\K[\d.]+' || echo "0")
+  max_s=$(echo "$output" | grep -oP 'Average Latency.*max \K[\d.]+' || echo "0")
+  local avg_ms max_ms
+  avg_ms=$(awk "BEGIN { printf \"%.2f\", $avg_s * 1000 }")
+  max_ms=$(awk "BEGIN { printf \"%.2f\", $max_s * 1000 }")
 
-  # Estimate P99 from StdDev (approximation: avg + 2.33*stddev for normal distribution)
-  p99_ms=$(awk "BEGIN { printf \"%.2f\", ($avg_s + 2.33 * $stddev) * 1000 }")
-
-  echo "$qps $p50_ms $p99_ms $completed $lost"
+  echo "$qps $avg_ms $max_ms $completed $lost"
 }
 
 # ── warm up a DNS server ─────────────────────────────────────────────────────
@@ -144,11 +182,13 @@ warm_up() {
   local host="$1" port="$2" name="$3"
   log "Warming up ${name}..."
 
+  # Warm the full query set so the measurement runs against a warm cache for
+  # every domain, not just the first 20.
   local tmp
   tmp=$(mktemp)
-  grep -v '^[[:space:]]*;' "$QUERIES_FILE" | grep -v '^[[:space:]]*$' | head -20 > "$tmp"
+  grep -v '^[[:space:]]*;' "$QUERIES_FILE" | grep -v '^[[:space:]]*$' > "$tmp"
 
-  dnsperf -s "$host" -p "$port" -d "$tmp" -l 5 -c 2 -q 100 &>/dev/null || true
+  "${TASKSET[@]}" dnsperf -s "$host" -p "$port" -d "$tmp" -l 5 -c 2 -q 100 &>/dev/null || true
   rm -f "$tmp"
 }
 
@@ -161,7 +201,7 @@ wait_for_dns() {
   local _tmp_q
   _tmp_q=$(mktemp)
   echo "google.com A" > "$_tmp_q"
-  while ! dnsperf -s "$host" -p "$port" -d "$_tmp_q" -l 1 -c 1 -q 5 &>/dev/null \
+  while ! "${TASKSET[@]}" dnsperf -s "$host" -p "$port" -d "$_tmp_q" -l 1 -c 1 -q 5 &>/dev/null \
         && [[ $count -lt $max_wait ]]; do
     sleep 1
     ((count++))
@@ -177,15 +217,22 @@ wait_for_dns() {
 }
 
 # ── Docker competitor management ─────────────────────────────────────────────
-start_competitors() {
-  log "Starting competitor containers..."
-  docker compose -f "$DOCKER_COMPOSE" up -d --wait 2>/dev/null || \
-    docker-compose -f "$DOCKER_COMPOSE" up -d 2>/dev/null || {
-      warn "Failed to start containers. Run manually or use --no-docker."
-      USE_DOCKER=false
-    }
+# Start a single service and wait for its healthcheck. Servers are started one
+# at a time (and stopped after) so an idle competitor never steals CPU from the
+# server being measured. Returns non-zero if the service failed to come up.
+start_service() {
+  local svc="$1"
+  docker compose -f "$DOCKER_COMPOSE" up -d --wait "$svc" 2>/dev/null || \
+    docker-compose -f "$DOCKER_COMPOSE" up -d "$svc" 2>/dev/null
 }
 
+stop_service() {
+  local svc="$1"
+  docker compose -f "$DOCKER_COMPOSE" stop "$svc" 2>/dev/null || \
+    docker-compose -f "$DOCKER_COMPOSE" stop "$svc" 2>/dev/null || true
+}
+
+# Safety net on exit: tear everything down.
 stop_competitors() {
   if [[ "$USE_DOCKER" == "true" ]]; then
     log "Stopping competitor containers..."
@@ -194,11 +241,45 @@ stop_competitors() {
   fi
 }
 
+# ── benchmark one server end-to-end ──────────────────────────────────────────
+# Starts the container (when USE_DOCKER), waits for it, warms it, measures it,
+# appends a result row, then stops the container. In --no-docker mode the server
+# is assumed to be already running at host:port.
+bench_server() {
+  local disp="$1" svc="$2" host="$3" port="$4"
+
+  if [[ "$USE_DOCKER" == "true" ]]; then
+    log "Starting ${disp}..."
+    if ! start_service "$svc"; then
+      warn "Failed to start ${svc} — skipping"
+      ROWS+=("$(format_row "$disp" "N/A" "N/A" "N/A" "N/A" "N/A")")
+      return
+    fi
+    if ! wait_for_dns "$host" "$port" "$disp" 30; then
+      ROWS+=("$(format_row "$disp" "N/A" "N/A" "N/A" "N/A" "N/A")")
+      stop_service "$svc"
+      return
+    fi
+  elif ! wait_for_dns "$host" "$port" "$disp" 5; then
+    warn "${disp} not reachable at ${host}:${port} — start it first or use docker"
+    ROWS+=("$(format_row "$disp" "N/A" "N/A" "N/A" "N/A" "N/A")")
+    return
+  fi
+
+  warm_up "$host" "$port" "$disp"
+  local qps avg max comp lost
+  read -r qps avg max comp lost < <(run_dnsperf "$disp" "$host" "$port")
+  ROWS+=("$(format_row "$disp" "$qps" "$avg" "$max" "$comp" "$lost")")
+  ok "${disp}: ${qps} QPS, avg ${avg}ms, max ${max}ms"
+
+  [[ "$USE_DOCKER" == "true" ]] && { log "Stopping ${disp}..."; stop_service "$svc"; }
+}
+
 # ── format table row ─────────────────────────────────────────────────────────
 format_row() {
-  local name="$1" qps="$2" p50="$3" p99="$4" completed="$5" lost="$6"
+  local name="$1" qps="$2" avg="$3" max="$4" completed="$5" lost="$6"
   printf "| %-18s | %10s | %10s | %10s | %12s%% | %10s%% |\n" \
-    "$name" "$qps" "${p50}ms" "${p99}ms" "$completed" "$lost"
+    "$name" "$qps" "${avg}ms" "${max}ms" "$completed" "$lost"
 }
 
 # ── print markdown table ─────────────────────────────────────────────────────
@@ -206,7 +287,7 @@ print_table() {
   local -n rows_ref=$1
   local header separator
 
-  header="| Server             |    QPS     | Avg Lat    |  P99 Lat   | Completed   | Lost       |"
+  header="| Server             |    QPS     | Avg Lat    |  Max Lat   | Completed   | Lost       |"
   separator="|:-------------------|:----------:|:----------:|:----------:|:-----------:|:----------:|"
 
   echo ""
@@ -230,7 +311,7 @@ save_report() {
 
 ## Results
 
-| Server             |    QPS     | Avg Lat    |  P99 Lat   | Completed   | Lost       |
+| Server             |    QPS     | Avg Lat    |  Max Lat   | Completed   | Lost       |
 |:-------------------|:----------:|:----------:|:----------:|:-----------:|:----------:|
 EOF
 
@@ -243,10 +324,15 @@ EOF
 ## Methodology
 
 - **Tool**: [dnsperf](https://www.dns-oarc.net/tools/dnsperf) by DNS-OARC
-- **Query dataset**: `scripts/bench-data/queries.txt` (mix of A, AAAA, MX, TXT, NS)
+- **Query dataset**: `bench/data/queries.txt` (mix of A, AAAA, MX, TXT, NS)
 - **Workload**: All servers use the same query dataset in loop mode
-- **Warm-up**: 5s warm-up before each measurement
-- **P99**: Estimated from average + 2.33×σ (dnsperf provides average + stddev)
+- **CPU isolation**: The load generator (dnsperf) is pinned to a separate set of
+  cores from the server under test so they don't contend for CPU (Linux + taskset,
+  ≥4 cores). Server containers are pinned to the complementary cores.
+- **One server at a time**: each server is started, measured, and stopped before
+  the next — an idle competitor never steals CPU during a measurement.
+- **Warm-up**: full query set warmed before each measurement (warm cache)
+- **Max Lat**: real worst-case latency reported by dnsperf (not an estimate)
 
 ## How to reproduce
 
@@ -275,80 +361,28 @@ main() {
   echo ""
 
   check_prereqs
+  setup_cpu_isolation
 
-  # Start competitor containers
+  # Tear everything down on exit (safety net; servers are also stopped
+  # individually after each measurement).
   if [[ "$USE_DOCKER" == "true" ]]; then
-    start_competitors
     trap stop_competitors EXIT
   fi
 
   declare -a ROWS
 
-  # ── ferrous-dns ──────────────────────────────────────────────────────────
+  # ferrous-dns address is configurable (may be an external instance in
+  # --no-docker mode); competitors always run on loopback via docker.
   local ferrous_host ferrous_port
   ferrous_host="${FERROUS_ADDR%%:*}"
   ferrous_port="${FERROUS_ADDR##*:}"
 
-  if nc -z -u "$ferrous_host" "$ferrous_port" 2>/dev/null || \
-     dig +short +timeout=1 google.com @"$ferrous_host" -p "$ferrous_port" &>/dev/null; then
-    warm_up "$ferrous_host" "$ferrous_port" "ferrous-dns"
-    read -r qps p50 p99 comp lost < <(run_dnsperf "ferrous-dns" "$ferrous_host" "$ferrous_port")
-    ROWS+=("$(format_row "🦀 ferrous-dns" "$qps" "$p50" "$p99" "$comp" "$lost")")
-    ok "ferrous-dns: ${qps} QPS, avg ${p50}ms, p99 ${p99}ms"
-  else
-    warn "ferrous-dns not reachable at ${FERROUS_ADDR} — start it first or set FERROUS_DNS_ADDR"
-    ROWS+=("$(format_row "🦀 ferrous-dns" "N/A" "N/A" "N/A" "N/A" "N/A")")
-  fi
-
-  # ── Pi-hole ──────────────────────────────────────────────────────────────
-  if [[ "$USE_DOCKER" == "true" ]] || wait_for_dns "127.0.0.1" "$PIHOLE_PORT" "Pi-hole" 5; then
-    warm_up "127.0.0.1" "$PIHOLE_PORT" "Pi-hole"
-    read -r qps p50 p99 comp lost < <(run_dnsperf "Pi-hole" "127.0.0.1" "$PIHOLE_PORT")
-    ROWS+=("$(format_row "🕳️  Pi-hole" "$qps" "$p50" "$p99" "$comp" "$lost")")
-    ok "Pi-hole: ${qps} QPS, avg ${p50}ms, p99 ${p99}ms"
-  else
-    ROWS+=("$(format_row "🕳️  Pi-hole" "N/A" "N/A" "N/A" "N/A" "N/A")")
-  fi
-
-  # ── AdGuard Home ─────────────────────────────────────────────────────────
-  if [[ "$USE_DOCKER" == "true" ]] || wait_for_dns "127.0.0.1" "$ADGUARD_PORT" "AdGuard Home" 5; then
-    warm_up "127.0.0.1" "$ADGUARD_PORT" "AdGuard Home"
-    read -r qps p50 p99 comp lost < <(run_dnsperf "AdGuard Home" "127.0.0.1" "$ADGUARD_PORT")
-    ROWS+=("$(format_row "🛡️  AdGuard Home" "$qps" "$p50" "$p99" "$comp" "$lost")")
-    ok "AdGuard Home: ${qps} QPS, avg ${p50}ms, p99 ${p99}ms"
-  else
-    ROWS+=("$(format_row "🛡️  AdGuard Home" "N/A" "N/A" "N/A" "N/A" "N/A")")
-  fi
-
-  # ── Unbound ──────────────────────────────────────────────────────────────
-  if [[ "$USE_DOCKER" == "true" ]] || wait_for_dns "127.0.0.1" "$UNBOUND_PORT" "Unbound" 5; then
-    warm_up "127.0.0.1" "$UNBOUND_PORT" "Unbound"
-    read -r qps p50 p99 comp lost < <(run_dnsperf "Unbound" "127.0.0.1" "$UNBOUND_PORT")
-    ROWS+=("$(format_row "⚡ Unbound" "$qps" "$p50" "$p99" "$comp" "$lost")")
-    ok "Unbound: ${qps} QPS, avg ${p50}ms, p99 ${p99}ms"
-  else
-    ROWS+=("$(format_row "⚡ Unbound" "N/A" "N/A" "N/A" "N/A" "N/A")")
-  fi
-
-  # ── Blocky ───────────────────────────────────────────────────────────────
-  if [[ "$USE_DOCKER" == "true" ]] || wait_for_dns "127.0.0.1" "$BLOCKY_PORT" "Blocky" 5; then
-    warm_up "127.0.0.1" "$BLOCKY_PORT" "Blocky"
-    read -r qps p50 p99 comp lost < <(run_dnsperf "Blocky" "127.0.0.1" "$BLOCKY_PORT")
-    ROWS+=("$(format_row "🔷 Blocky" "$qps" "$p50" "$p99" "$comp" "$lost")")
-    ok "Blocky: ${qps} QPS, avg ${p50}ms, p99 ${p99}ms"
-  else
-    ROWS+=("$(format_row "🔷 Blocky" "N/A" "N/A" "N/A" "N/A" "N/A")")
-  fi
-
-  # ── PowerDNS Recursor ────────────────────────────────────────────────────
-  if [[ "$USE_DOCKER" == "true" ]] || wait_for_dns "127.0.0.1" "$POWERDNS_PORT" "PowerDNS" 5; then
-    warm_up "127.0.0.1" "$POWERDNS_PORT" "PowerDNS"
-    read -r qps p50 p99 comp lost < <(run_dnsperf "PowerDNS" "127.0.0.1" "$POWERDNS_PORT")
-    ROWS+=("$(format_row "⚡ PowerDNS (C++)" "$qps" "$p50" "$p99" "$comp" "$lost")")
-    ok "PowerDNS: ${qps} QPS, avg ${p50}ms, p99 ${p99}ms"
-  else
-    ROWS+=("$(format_row "⚡ PowerDNS (C++)" "N/A" "N/A" "N/A" "N/A" "N/A")")
-  fi
+  bench_server "🦀 ferrous-dns"    "ferrous-dns" "$ferrous_host" "$ferrous_port"
+  bench_server "🕳️  Pi-hole"       "pihole"      "127.0.0.1"     "$PIHOLE_PORT"
+  bench_server "🛡️  AdGuard Home"  "adguard"     "127.0.0.1"     "$ADGUARD_PORT"
+  bench_server "⚡ Unbound"        "unbound"     "127.0.0.1"     "$UNBOUND_PORT"
+  bench_server "🔷 Blocky"         "blocky"      "127.0.0.1"     "$BLOCKY_PORT"
+  bench_server "⚡ PowerDNS (C++)" "powerdns"    "127.0.0.1"     "$POWERDNS_PORT"
 
   # ── Results ───────────────────────────────────────────────────────────────
   echo ""

--- a/bench/docker-compose.yml
+++ b/bench/docker-compose.yml
@@ -11,10 +11,14 @@
 #   ./bench/benchmark.sh --no-docker
 #   docker compose -f bench/docker-compose.yml down
 #
+# CPU pinning: benchmark.sh exports BENCH_SERVER_CPUS / BENCH_SERVER_NCPU so the
+# server-under-test runs on a different core set than the dnsperf load generator.
+# Run by hand without those vars and it defaults to cpuset 0-15 / cpus 16.
+#
 # Ports (host networking — each server binds directly on the host):
 #   ferrous-dns:  0.0.0.0:5353/udp+tcp
 #   Pi-hole:      0.0.0.0:5354/udp+tcp
-#   AdGuard Home: 0.0.0.0:5355/udp+tcp
+#   AdGuard Home: 0.0.0.0:5359/udp+tcp  (5355 avoided — LLMNR / systemd-resolved)
 #   Unbound:      0.0.0.0:5356/udp+tcp
 #   Blocky:       0.0.0.0:5357/udp+tcp
 #   PowerDNS:     0.0.0.0:5358/udp+tcp
@@ -48,7 +52,7 @@ services:
       FERROUS_LOG_LEVEL: info
       RUST_LOG: info
       TZ: UTC
-    cpuset: "0-15"
+    cpuset: "${BENCH_SERVER_CPUS:-0-15}"
     cap_add:
       - NET_ADMIN
       - SYS_TIME
@@ -57,7 +61,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '16'
+          cpus: "${BENCH_SERVER_NCPU:-16}"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "/usr/local/bin/ferrous-dns", "--version"]
@@ -83,7 +87,7 @@ services:
       - pihole_data:/etc/pihole
       - pihole_dnsmasq:/etc/dnsmasq.d
       - ./pihole.toml:/etc/pihole/pihole.toml:ro
-    cpuset: "0-15"
+    cpuset: "${BENCH_SERVER_CPUS:-0-15}"
     cap_add:
       - NET_ADMIN
       - SYS_TIME
@@ -92,7 +96,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '16'
+          cpus: "${BENCH_SERVER_NCPU:-16}"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "dig", "+short", "+timeout=2", "-p", "5354", "google.com", "@127.0.0.1"]
@@ -103,18 +107,21 @@ services:
 
   # ---------------------------------------------------------------------------
   # AdGuard Home — DNS blocker + DoH/DoT support
-  # GOMAXPROCS=16 — Go runtime uses 16 OS threads
+  # GOMAXPROCS=8 — matches the server cpuset (lower half of host cores)
   # ---------------------------------------------------------------------------
   adguard:
     image: adguard/adguardhome:latest
     container_name: bench-adguard
     network_mode: host
     environment:
-      GOMAXPROCS: 16
+      GOMAXPROCS: 8
     volumes:
       - adguard_work:/opt/adguardhome/work
+      # NOTE: must stay writable — AdGuard atomically rewrites its config on
+      # startup (fatal error under :ro). Side effect: it re-chowns this file to
+      # root:0600 each run. Re-create it from the tracked copy if git can't read it.
       - ./adguard-config:/opt/adguardhome/conf
-    cpuset: "0-15"
+    cpuset: "${BENCH_SERVER_CPUS:-0-15}"
     cap_add:
       - NET_ADMIN
       - SYS_TIME
@@ -123,7 +130,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '16'
+          cpus: "${BENCH_SERVER_NCPU:-16}"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000"]
@@ -142,7 +149,7 @@ services:
     network_mode: host
     volumes:
       - ./unbound.conf:/opt/unbound/etc/unbound/unbound.conf:ro
-    cpuset: "0-15"
+    cpuset: "${BENCH_SERVER_CPUS:-0-15}"
     cap_add:
       - NET_ADMIN
       - SYS_TIME
@@ -151,7 +158,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '16'
+          cpus: "${BENCH_SERVER_NCPU:-16}"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "drill", "-p", "5356", "google.com", "@127.0.0.1"]
@@ -167,17 +174,17 @@ services:
   #   - Blocking disabled (no denylists)
   #   - Caching enabled (minTime: 60s, maxTime: 86400s, prefetching: true)
   #   - Log level: info
-  # GOMAXPROCS=16 — Go runtime uses 16 OS threads
+  # GOMAXPROCS=8 — matches the server cpuset (lower half of host cores)
   # ---------------------------------------------------------------------------
   blocky:
     image: ghcr.io/0xerr0r/blocky:latest
     container_name: bench-blocky
     network_mode: host
     environment:
-      GOMAXPROCS: 16
+      GOMAXPROCS: 8
     volumes:
       - ./blocky-config.yml:/app/config.yml:ro
-    cpuset: "0-15"
+    cpuset: "${BENCH_SERVER_CPUS:-0-15}"
     cap_add:
       - NET_ADMIN
       - SYS_TIME
@@ -186,7 +193,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '16'
+          cpus: "${BENCH_SERVER_NCPU:-16}"
     restart: unless-stopped
     # Blocky runs on a scratch image (no shell/wget/dig). Use its built-in healthcheck subcommand.
     healthcheck:
@@ -211,7 +218,7 @@ services:
     network_mode: host
     volumes:
       - ./powerdns-recursor.yml:/etc/powerdns/recursor.yml:ro
-    cpuset: "0-15"
+    cpuset: "${BENCH_SERVER_CPUS:-0-15}"
     cap_add:
       - NET_ADMIN
       - SYS_TIME
@@ -220,7 +227,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '16'
+          cpus: "${BENCH_SERVER_NCPU:-16}"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "rec_control", "ping"]

--- a/bench/powerdns-recursor.yml
+++ b/bench/powerdns-recursor.yml
@@ -6,7 +6,7 @@ incoming:
     - "0.0.0.0:5358"
 
 recursor:
-  threads: 16
+  threads: 8   # matches the server cpuset (lower half of host cores)
   forward_zones_recurse:
     - zone: "."
       forwarders:

--- a/bench/unbound.conf
+++ b/bench/unbound.conf
@@ -10,8 +10,9 @@ server:
     cache-min-ttl: 300
     msg-cache-size: 256m
     rrset-cache-size: 512m
-    # 16 threads — matches ferrous-dns CPU count for a fair comparison
-    num-threads: 16
+    # 8 threads — matches the benchmark's server cpuset (harness pins each
+    # server to the lower half of the host cores; 8 on this 8C/16T box)
+    num-threads: 8
     so-reuseport: yes
     outgoing-range: 4096
     num-queries-per-thread: 2048

--- a/crates/application/src/use_cases/dns/handle_dns_query.rs
+++ b/crates/application/src/use_cases/dns/handle_dns_query.rs
@@ -56,6 +56,11 @@ pub struct HandleDnsQueryUseCase {
     /// `/96` NAT64 network prefix when DNS64 is enabled. Used only to derive the
     /// `dns64_synthesized` query-log tag from an AAAA answer's address membership.
     dns64_prefix: Option<Ipv6Addr>,
+    /// Honors `[database] log_queries`. When `false`, query logging is fully
+    /// suppressed on every path: the hot cache-hit path skips building the
+    /// `QueryLog` entry (no per-hit `Arc<str>` alloc, no channel send) and
+    /// `log()` short-circuits for the slow paths. Set via `with_query_logging`.
+    log_queries: bool,
 }
 
 impl HandleDnsQueryUseCase {
@@ -84,6 +89,7 @@ impl HandleDnsQueryUseCase {
             cookie_guard: DnsCookieGuard::disabled(),
             dnssec_enforce: false,
             dns64_prefix: None,
+            log_queries: true,
         }
     }
 
@@ -91,6 +97,14 @@ impl HandleDnsQueryUseCase {
     /// returns SERVFAIL to the client, unless the client set the CD bit.
     pub fn with_dnssec_enforcement(mut self, enforce: bool) -> Self {
         self.dnssec_enforce = enforce;
+        self
+    }
+
+    /// Honors `[database] log_queries`. When `false`, every query-log write is
+    /// suppressed and the hot cache-hit path skips building the log entry
+    /// entirely. Defaults to `true` (log all queries).
+    pub fn with_query_logging(mut self, enabled: bool) -> Self {
+        self.log_queries = enabled;
         self
     }
 
@@ -313,6 +327,9 @@ impl HandleDnsQueryUseCase {
     }
 
     fn log(&self, query_log: &QueryLog) {
+        if !self.log_queries {
+            return;
+        }
         if let Err(e) = self.query_log.log_query_sync(query_log) {
             tracing::warn!(error = %e, domain = %query_log.domain, "Failed to log query");
         }
@@ -417,28 +434,30 @@ impl HandleDnsQueryUseCase {
         let wire = resolution.upstream_wire_data?;
         let ttl = resolution.min_ttl.unwrap_or(0);
 
-        let elapsed_us = tsc_timer::elapsed_us_since(tsc_start);
-        let domain_arc: Arc<str> = Arc::from(domain);
-        self.log(&QueryLog {
-            id: None,
-            domain: domain_arc,
-            record_type,
-            client_ip,
-            client_hostname: None,
-            blocked: false,
-            response_time_us: Some(elapsed_us),
-            cache_hit: true,
-            cache_refresh: false,
-            dnssec_status: resolution.dnssec_status,
-            dns64_synthesized: false,
-            upstream_server: None,
-            upstream_pool: None,
-            response_status: Some("NOERROR"),
-            timestamp: None,
-            query_source: QuerySource::Client,
-            group_id: Some(group_id),
-            block_source: None,
-        });
+        if self.log_queries {
+            let elapsed_us = tsc_timer::elapsed_us_since(tsc_start);
+            let domain_arc: Arc<str> = Arc::from(domain);
+            self.log(&QueryLog {
+                id: None,
+                domain: domain_arc,
+                record_type,
+                client_ip,
+                client_hostname: None,
+                blocked: false,
+                response_time_us: Some(elapsed_us),
+                cache_hit: true,
+                cache_refresh: false,
+                dnssec_status: resolution.dnssec_status,
+                dns64_synthesized: false,
+                upstream_server: None,
+                upstream_pool: None,
+                response_status: Some("NOERROR"),
+                timestamp: None,
+                query_source: QuerySource::Client,
+                group_id: Some(group_id),
+                block_source: None,
+            });
+        }
 
         Some((wire, ttl))
     }
@@ -483,28 +502,30 @@ impl HandleDnsQueryUseCase {
             return None; // fall through to execute() for logging
         }
 
-        let elapsed_us = tsc_timer::elapsed_us_since(tsc_start);
-        let domain_arc: Arc<str> = Arc::from(domain);
-        self.log(&QueryLog {
-            id: None,
-            domain: domain_arc,
-            record_type,
-            client_ip,
-            client_hostname: None,
-            blocked: false,
-            response_time_us: Some(elapsed_us),
-            cache_hit: true,
-            cache_refresh: false,
-            dnssec_status: resolution.dnssec_status,
-            dns64_synthesized: self.is_dns64_synthesized(record_type, &resolution.addresses),
-            upstream_server: None,
-            upstream_pool: None,
-            response_status: Some("NOERROR"),
-            timestamp: None,
-            query_source: QuerySource::Client,
-            group_id: Some(group_id),
-            block_source: None,
-        });
+        if self.log_queries {
+            let elapsed_us = tsc_timer::elapsed_us_since(tsc_start);
+            let domain_arc: Arc<str> = Arc::from(domain);
+            self.log(&QueryLog {
+                id: None,
+                domain: domain_arc,
+                record_type,
+                client_ip,
+                client_hostname: None,
+                blocked: false,
+                response_time_us: Some(elapsed_us),
+                cache_hit: true,
+                cache_refresh: false,
+                dnssec_status: resolution.dnssec_status,
+                dns64_synthesized: self.is_dns64_synthesized(record_type, &resolution.addresses),
+                upstream_server: None,
+                upstream_pool: None,
+                response_status: Some("NOERROR"),
+                timestamp: None,
+                query_source: QuerySource::Client,
+                group_id: Some(group_id),
+                block_source: None,
+            });
+        }
 
         Some((resolution.addresses, resolution.min_ttl.unwrap_or(60)))
     }

--- a/crates/cli/src/wiring/dns/mod.rs
+++ b/crates/cli/src/wiring/dns/mod.rs
@@ -213,7 +213,8 @@ impl DnsServices {
             &config.dns.rebinding_allowlist,
         )
         .with_rate_limiter(rate_limiter)
-        .with_dnssec_enforcement(config.dns.effective_dnssec_mode().enforces());
+        .with_dnssec_enforcement(config.dns.effective_dnssec_mode().enforces())
+        .with_query_logging(config.database.log_queries);
 
         // DNS64 query-log tagging: only when enabled with a valid /96 prefix.
         if config.dns64.enabled {

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 
 Ferrous DNS is a self-hosted DNS server and network-wide ad-blocker designed as a high-performance alternative to Pi-hole and AdGuard Home. It runs as a **single binary** combining DNS resolution, REST API, and Web UI — with no external runtime dependencies.
 
-At **482,506 queries/second** under identical Docker conditions (16 CPUs, cache enabled, rate limiting disabled), Ferrous DNS is **4.9× faster than AdGuard Home**, **4.7× faster than Blocky**, and **233× faster than Pi-hole** — running a full feature stack in a single process. Unbound (952K QPS) and PowerDNS Recursor (884K QPS) lead as purpose-built pure recursive resolvers with no additional features.
+At **899,234 queries/second** (median of 3 runs, 8-core cpuset, cache enabled, rate limiting disabled), Ferrous DNS **leads the field** — ~10% ahead of Unbound (817K QPS) and ~33% ahead of PowerDNS Recursor (676K QPS), the purpose-built pure recursive resolvers, plus **6.3× faster than Blocky**, **10.1× faster than AdGuard Home**, and **109× faster than Pi-hole** — all while running a full feature stack in a single process.
 
 ---
 
@@ -24,7 +24,7 @@ At **482,506 queries/second** under identical Docker conditions (16 CPUs, cache 
     - **Smart eviction** — frequency-based eviction keeps popular domains cached
     - **In-flight coalescing** — deduplicates concurrent queries to a single upstream request
     - **Optimistic prefetch** — refreshes popular entries before they expire
-    - **482K queries/second** — 4.9x faster than AdGuard Home, 233x faster than Pi-hole
+    - **899K queries/second** (median of 3) — tops Unbound and PowerDNS, 10.1x faster than AdGuard Home, 109x faster than Pi-hole
     - Cache hit P99 < 35µs (actual ~10-20µs)
 
 === "Encrypted DNS"

--- a/docs/performance/benchmarks.md
+++ b/docs/performance/benchmarks.md
@@ -288,36 +288,37 @@ This enables AVX2/SSE4 vectorized string operations, CPU-specific branch predict
 
 ## Benchmark Results
 
-> **Host:** Intel Core i9-9900KF @ 3.60GHz | 8 cores / 16 threads / 46 GB RAM | Arch Linux | Kernel 6.18.16-1-lts
-> **Tool:** dnsperf 2.14.0 | 60s per server | 10 concurrent clients | 187 domains (A, AAAA, MX, TXT, NS)
+> **Host:** Intel Core i9-9900KF @ 3.60GHz | 8 cores / 16 threads / 46 GB RAM | Arch Linux | Kernel 7.0.10-zen1-1-zen
+> **Tool:** dnsperf | median of 3 runs, 45s measured per server | 10 concurrent clients | 187 domains (A, AAAA, MX, TXT, NS)
 >
 > **Docker config (identical for all servers):**
 >
 > | Setting | Value |
 > |:--------|:------|
-> | CPUs | `cpuset: 0-15` — 16 threads |
+> | CPUs | server pinned to `cpuset: 0-7` (`cpus: 8`); dnsperf pinned to cores `8-15` |
+> | Threads | matched to the 8-core cpuset for every server |
 > | Network | host mode |
 > | Upstreams | plain UDP `8.8.8.8` / `1.1.1.1` (parallel) |
 > | Cache | enabled |
 > | Blocking / denylists | disabled — isolates raw forwarding performance |
 > | Rate limiting | disabled |
-> | Log level | info |
-> | Query logging (disk I/O) | disabled |
+> | Query logging (disk I/O) | disabled (all servers) |
 
-| Server | QPS | Avg Lat | P99 Lat | Completed | Lost |
-|:-------|----:|--------:|--------:|----------:|-----:|
-| ⚡ Unbound (C) | 1,018,691 | 0.74ms | 2.05ms | 100.00% | 0.00% |
-| ⚡ PowerDNS (C++) | 797,600 | 1.11ms | 3.47ms | 100.00% | 0.00% |
-| 🦀 **ferrous-dns** | **511,413** | **1.89ms** | **47.50ms** | **100.00%** | **0.00%** |
-| 🔷 Blocky (Go) | 98,574 | 9.49ms | 21.39ms | 99.99% | 0.01% |
-| 🛡️ AdGuard Home | 97,808 | 3.90ms | 15.59ms | 99.87% | 0.13% |
-| 🕳️ Pi-hole | 558 | 2.55ms | 24.83ms | 73.63% | 26.37% |
+| Server | Median QPS | Median Avg Lat | QPS spread (min–max) |
+|:-------|-----------:|:--------------:|:---------------------|
+| 🦀 **ferrous-dns** | **899,234** | **0.86ms** | 886,953 – 1,019,534 |
+| ⚡ Unbound (C) | 816,928 | 0.85ms | 633,167 – 822,635 |
+| ⚡ PowerDNS (C++) | 675,910 | 1.36ms | 659,487 – 722,406 |
+| 🔷 Blocky (Go) | 142,715 | 1.53ms | 142,473 – 144,368 |
+| 🛡️ AdGuard Home | 88,985 | 3.81ms | 87,448 – 98,437 |
+| 🕳️ Pi-hole | 8,248 | 2.99ms | 7,219 – 8,939 |
 
-**ferrous-dns vs competitors:** 5.2× faster than AdGuard Home | 5.2× faster than Blocky | 916× faster than Pi-hole
+**ferrous-dns leads the field** — ~10% ahead of Unbound and ~33% ahead of PowerDNS Recursor, plus 6.3× Blocky, 10.1× AdGuard Home, and 109× Pi-hole. Unbound and PowerDNS are purpose-built pure recursive resolvers (C and C++) with no REST API, no Web UI, no database, and no blocking engine; ferrous-dns runs all of those in the same single-process binary and still comes out on top.
 
-Unbound and PowerDNS Recursor lead as purpose-built pure recursive resolvers (C and C++) — no REST API, no Web UI, no database, no blocking engine. ferrous-dns runs all of these in the same single-process binary.
+!!! note "Read the median, not a single run"
+    Run-to-run variance on this host is real (~10–15% for ferrous-dns, up to ~30% for Unbound, which had one low outlier). The lead over Unbound sits inside that noise band on any single run — but ferrous-dns was #1 in all 3 runs. The numbers above are the median of 3 end-to-end runs, with the min–max spread shown for transparency.
 
-Pi-hole's loss rate reflects its architectural ceiling: FTL v6 is mostly single-threaded and saturates under concurrent load from other containers sharing the same CPU pool.
+Pi-hole's loss rate (~2%) reflects its architectural ceiling: FTL v6 is mostly single-threaded and cannot use more than one core regardless of the CPU budget.
 
 Cache hit P99: **~10–20µs** | Cache miss P99: **~1–3ms** | Hit rate: **~95%**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -59,7 +59,7 @@
 ### v0.6.0 — Performance & Scale
 
 - [x] Pi-hole compatible API
-- [x] Performance benchmarks vs. competitors (482K QPS)
+- [x] Performance benchmarks vs. competitors ([latest results](performance/benchmarks.md))
 - [x] Dashboard settings: system status, DNS pool status, cache overview, system info
 - [x] In-flight coalescing (cache stampede prevention)
 - [x] TSC timer (~1-5ns) for hot path timing


### PR DESCRIPTION
Closes #130

## Summary

Two related changes that fix a throughput-capping bug and republish a fair benchmark:

1. **`fix - honor database.log_queries on the DNS hot path`** — the `[database] log_queries` setting was dead config (never read), so every query was logged to SQLite even when disabled, inflating cache-hit latency and capping throughput. `HandleDnsQueryUseCase` now carries a `log_queries` flag wired from config; the cache-hit fast paths skip the per-hit `Arc::from` + `QueryLog` build + channel send entirely when logging is off.

2. **`bench - match competitor threads to cpuset and republish median results`** — benchmark harness fairness pass:
   - Server-under-test pinned to cores 0-7, dnsperf pinned to cores 8-15 (load generator never steals CPU from the server it measures).
   - Competitor thread counts aligned to the 8-core cpuset (was hardcoded 16): unbound `num-threads`, powerdns `threads`, adguard/blocky `GOMAXPROCS`.
   - AdGuard bench port moved 5355 → 5359 (5355 is LLMNR, held by systemd-resolved on the host).

## Results (median of 3 runs)

| Server | Median QPS | Median Avg Lat |
|:-------|-----------:|:--------------:|
| 🦀 **ferrous-dns** | **899,234** | 0.86ms |
| ⚡ Unbound (C) | 816,928 | 0.85ms |
| ⚡ PowerDNS (C++) | 675,910 | 1.36ms |
| 🔷 Blocky | 142,715 | 1.53ms |
| 🛡️ AdGuard Home | 88,985 | 3.81ms |
| 🕳️ Pi-hole | 8,248 | 2.99ms |

ferrous-dns was #1 in **all 3 runs** — ~10% ahead of Unbound, ~33% ahead of PowerDNS — while running the full feature stack (DNS server, REST API, Web UI, SQLite query log, blocking) in one process. Run-to-run variance is ~10–15% (up to ~30% for Unbound), so the published figures are medians with the min–max spread shown in `bench/benchmark-results.md`.

Docs updated to the median figures: `README.md`, `docs/index.md`, `docs/performance/benchmarks.md`, `docs/roadmap.md`.

## Test plan

- [x] `make ci` (fmt-check + clippy `-D warnings` + tests) — green, re-run after rebasing onto latest `main` (which bumped `toml`/`toml_edit`).
- [x] Full 3-run benchmark executed on the reference host (i9-9900KF, 8C/16T).
