### PR TITLE
feat(dns): DNS-over-QUIC (DoQ) server listener (RFC 9250)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ name = "ferrous-dns"
 version = "0.9.3"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "base64",
  "clap",
@@ -885,6 +886,8 @@ dependencies = [
  "hyper-util",
  "libc",
  "mimalloc",
+ "quinn",
+ "rcgen",
  "reqwest",
  "ring",
  "rustc-hash",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,7 +87,7 @@
 - [x] Upstream anti-spoofing — off-path forgery validation on every plain-UDP (Do53) upstream response: transaction-ID + question name/type checks always on; DNS Cookies (RFC 7873) always sent and validated gracefully on A/AAAA; opt-in 0x20 QNAME case randomization (draft-vixie-dns-0x20) via `qname_case_randomization`. Encrypted transports (DoT/DoH/DoQ) skip cookie/0x20 *validation* (TLS already authenticates the upstream), tolerating upstreams that normalize QNAME case
 - [ ] EDNS UDP payload size negotiation + correct TC truncation (RFC 6891 §6.2.5 / RFC 7766) — honor client-advertised buffer, set TC=1 on oversized responses
 - [x] DNSSEC validation enforcement (RFC 4035 / RFC 6840) — SERVFAIL on Bogus, AD bit set/clear from validation, honor client CD bit (upgrade from current advisory `dnssec_status` tagging)
-- [ ] DNS-over-QUIC (DoQ) server listener (RFC 9250) — serve encrypted DNS to clients over QUIC (upstream DoQ already supported)
+- [x] DNS-over-QUIC (DoQ) server listener (RFC 9250) — serve encrypted DNS to clients over QUIC (upstream DoQ already supported)
 - [x] DNS64 / NAT64 AAAA synthesis (RFC 6147) — `[dns64]` `enabled` / `prefix` (well-known `64:ff9b::/96`, /96 only) synthesizes AAAA from A records for IPv6-only clients; reverse PTR synthesis; `dns64_synthesized` query-log tag + Prometheus metric. NAT64 packet translation remains the network gateway's job
 - [ ] EDNS Client Subnet (RFC 7871) — strip client ECS by default for privacy; optional configurable subnet injection upstream for CDN-correct results
 - [x] Custom sinkhole IP for blocked responses (configurable A/AAAA target beyond `0.0.0.0` / `::`) — `[blocking]` `sinkhole_ipv4` / `sinkhole_ipv6`, applied to `null_ip` blocked answers

--- a/crates/api/src/dto/config.rs
+++ b/crates/api/src/dto/config.rs
@@ -88,6 +88,7 @@ pub struct RateLimitConfigResponse {
     pub stale_entry_ttl_secs: u64,
     pub tcp_max_connections_per_ip: u32,
     pub dot_max_connections_per_ip: u32,
+    pub doq_max_connections_per_ip: u32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -300,6 +301,7 @@ pub struct RateLimitConfigUpdate {
     pub stale_entry_ttl_secs: Option<u64>,
     pub tcp_max_connections_per_ip: Option<u32>,
     pub dot_max_connections_per_ip: Option<u32>,
+    pub doq_max_connections_per_ip: Option<u32>,
 }
 
 #[derive(Deserialize, Debug, ToSchema)]

--- a/crates/api/src/handlers/config/get.rs
+++ b/crates/api/src/handlers/config/get.rs
@@ -102,6 +102,7 @@ pub async fn get_config(State(state): State<AppState>) -> Json<ConfigResponse> {
                 stale_entry_ttl_secs: config.dns.rate_limit.stale_entry_ttl_secs,
                 tcp_max_connections_per_ip: config.dns.rate_limit.tcp_max_connections_per_ip,
                 dot_max_connections_per_ip: config.dns.rate_limit.dot_max_connections_per_ip,
+                doq_max_connections_per_ip: config.dns.rate_limit.doq_max_connections_per_ip,
             },
         },
         blocking: BlockingConfigResponse {

--- a/crates/api/src/handlers/config/update.rs
+++ b/crates/api/src/handlers/config/update.rs
@@ -239,6 +239,9 @@ pub async fn update_config(
             if let Some(v) = rl.dot_max_connections_per_ip {
                 new_config.dns.rate_limit.dot_max_connections_per_ip = v;
             }
+            if let Some(v) = rl.doq_max_connections_per_ip {
+                new_config.dns.rate_limit.doq_max_connections_per_ip = v;
+            }
             if let Some(v) = rl.whitelist {
                 new_config.dns.rate_limit.whitelist = v;
             }

--- a/crates/application/src/use_cases/dns/rate_limiter/mod.rs
+++ b/crates/application/src/use_cases/dns/rate_limiter/mod.rs
@@ -207,6 +207,7 @@ mod tests {
             stale_entry_ttl_secs: 300,
             tcp_max_connections_per_ip: 30,
             dot_max_connections_per_ip: 15,
+            doq_max_connections_per_ip: 15,
         }
     }
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -47,6 +47,9 @@ reqwest.workspace = true
 ring.workspace = true
 utoipa.workspace = true
 utoipa-scalar.workspace = true
+quinn.workspace = true
 
 [dev-dependencies]
 tempfile = "3.8"
+rcgen = "0.14"
+async-trait.workspace = true

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4,6 +4,8 @@
 //! code paths (like crypto provider installation) that would otherwise be
 //! private to `main.rs`.
 
+pub mod server;
+
 /// Installs the process-wide rustls crypto provider.
 ///
 /// The dependency tree pulls in both the `ring` and `aws-lc-rs` crypto

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,8 +15,8 @@ use tracing::{error, info};
 
 mod args;
 mod bootstrap;
-mod server;
 mod wiring;
+use ferrous_dns::server;
 
 fn main() -> anyhow::Result<()> {
     ferrous_dns::install_crypto_provider();
@@ -144,6 +144,7 @@ async fn async_main() -> anyhow::Result<()> {
     let handler_use_case = dns_services.handler_use_case;
     let tcp_conn_limiter = dns_services.tcp_conn_limiter;
     let dot_conn_limiter = dns_services.dot_conn_limiter;
+    let doq_conn_limiter = dns_services.doq_conn_limiter;
     let block_policy = BlockPolicy {
         mode: config.blocking.block_mode,
         ttl: config.blocking.block_ttl,
@@ -184,6 +185,7 @@ async fn async_main() -> anyhow::Result<()> {
                 &config.server.encrypted_dns.tls_cert_path,
                 &config.server.encrypted_dns.tls_key_path,
                 "DoT/DoH",
+                &[],
             )?
         } else {
             None
@@ -211,6 +213,32 @@ async fn async_main() -> anyhow::Result<()> {
                 .await
                 {
                     error!(error = %e, "DoT server error");
+                }
+            });
+        }
+    }
+
+    if config.server.encrypted_dns.doq_enabled {
+        let doq_tls_config = server::load_server_tls_config(
+            &config.server.encrypted_dns.tls_cert_path,
+            &config.server.encrypted_dns.tls_key_path,
+            "DoQ",
+            &[b"doq"],
+        )?;
+        if let Some(tls_cfg) = doq_tls_config {
+            let doq_addr = format!(
+                "{}:{}",
+                config.server.bind_address, config.server.encrypted_dns.doq_port
+            );
+            let doq_handler = Arc::new(DnsServerHandler::new(
+                handler_use_case.clone(),
+                block_policy,
+            ));
+            tokio::spawn(async move {
+                if let Err(e) =
+                    server::start_doq_server(doq_addr, doq_handler, tls_cfg, doq_conn_limiter).await
+                {
+                    error!(error = %e, "DoQ server error");
                 }
             });
         }
@@ -246,6 +274,7 @@ async fn async_main() -> anyhow::Result<()> {
             &config.server.web_tls.tls_cert_path,
             &config.server.web_tls.tls_key_path,
             "Web HTTPS",
+            &[],
         )?
     } else {
         None

--- a/crates/cli/src/server/dns/connection_limiter.rs
+++ b/crates/cli/src/server/dns/connection_limiter.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 /// Uses an RAII guard: when a connection is accepted, `try_acquire()` returns
 /// a `ConnectionGuard` that decrements the count on drop.
 #[derive(Clone)]
-pub(crate) struct ConnectionLimiter {
+pub struct ConnectionLimiter {
     counts: Arc<DashMap<IpAddr, AtomicU32, FxBuildHasher>>,
     max_per_ip: u32,
 }
@@ -17,7 +17,7 @@ pub(crate) struct ConnectionLimiter {
 /// RAII guard that decrements the connection count when the connection closes.
 ///
 /// When `limited` is `false` (unlimited mode), the guard is a no-op on drop.
-pub(crate) struct ConnectionGuard {
+pub struct ConnectionGuard {
     counts: Arc<DashMap<IpAddr, AtomicU32, FxBuildHasher>>,
     ip: IpAddr,
     limited: bool,
@@ -25,7 +25,7 @@ pub(crate) struct ConnectionGuard {
 
 impl ConnectionLimiter {
     /// Creates a new limiter. `max_per_ip = 0` means unlimited.
-    pub(crate) fn new(max_per_ip: u32) -> Self {
+    pub fn new(max_per_ip: u32) -> Self {
         Self {
             counts: Arc::new(DashMap::with_hasher(FxBuildHasher)),
             max_per_ip,
@@ -34,7 +34,7 @@ impl ConnectionLimiter {
 
     /// Tries to acquire a connection slot for `ip`.
     /// Returns `Some(guard)` if within limit, `None` if the limit is exceeded.
-    pub(crate) fn try_acquire(&self, ip: IpAddr) -> Option<ConnectionGuard> {
+    pub fn try_acquire(&self, ip: IpAddr) -> Option<ConnectionGuard> {
         if self.max_per_ip == 0 {
             return Some(ConnectionGuard {
                 counts: Arc::clone(&self.counts),

--- a/crates/cli/src/server/dns/doq.rs
+++ b/crates/cli/src/server/dns/doq.rs
@@ -1,0 +1,166 @@
+use super::connection_limiter::{ConnectionGuard, ConnectionLimiter};
+use ferrous_dns_infrastructure::dns::server::DnsServerHandler;
+use quinn::crypto::rustls::QuicServerConfig;
+use quinn::VarInt;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, info, warn};
+
+/// Idle keep-alive interval for accepted DoQ connections.
+const DOQ_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Upper bound on concurrent in-flight queries (bidirectional streams) per
+/// connection. The per-IP `ConnectionLimiter` caps how many connections a
+/// client may open; this caps how many streams each connection may multiplex,
+/// so a single connection cannot open unbounded streams.
+const DOQ_MAX_CONCURRENT_BIDI_STREAMS: u32 = 100;
+
+/// How long a stream may take to deliver its length-prefixed query before it is
+/// dropped. Guards against a client that opens a stream and then stalls
+/// (slow-loris), which QUIC keep-alive would otherwise leave lingering.
+const DOQ_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Builds and binds a QUIC server endpoint for DoQ (DNS-over-QUIC, RFC 9250)
+/// on `bind_addr`, advertising whatever ALPN the supplied `tls_config` carries
+/// (the caller sets `doq`). Binding is synchronous, so the returned endpoint is
+/// ready to accept connections immediately.
+pub fn bind_doq_endpoint(
+    bind_addr: &str,
+    tls_config: Arc<rustls::ServerConfig>,
+) -> anyhow::Result<quinn::Endpoint> {
+    let addr: SocketAddr = bind_addr.parse()?;
+
+    let quic_crypto = QuicServerConfig::try_from(tls_config)?;
+    let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(quic_crypto));
+    // A freshly built ServerConfig uniquely owns its transport config, so this
+    // never no-ops; expect() surfaces the invariant instead of silently
+    // skipping the transport tuning below.
+    let transport_config = Arc::get_mut(&mut server_config.transport)
+        .expect("fresh quinn ServerConfig has a uniquely-owned transport config");
+    transport_config.keep_alive_interval(Some(DOQ_KEEP_ALIVE_INTERVAL));
+    transport_config.max_concurrent_bidi_streams(VarInt::from_u32(DOQ_MAX_CONCURRENT_BIDI_STREAMS));
+
+    Ok(quinn::Endpoint::server(server_config, addr)?)
+}
+
+pub async fn start_doq_server(
+    bind_addr: String,
+    handler: Arc<DnsServerHandler>,
+    tls_config: Arc<rustls::ServerConfig>,
+    doq_conn_limiter: ConnectionLimiter,
+) -> anyhow::Result<()> {
+    let endpoint = bind_doq_endpoint(&bind_addr, tls_config)?;
+    info!(bind_address = %endpoint.local_addr()?, "Starting DoQ server (DNS-over-QUIC, RFC 9250)");
+    serve_doq(endpoint, handler, doq_conn_limiter).await;
+    Ok(())
+}
+
+/// Runs the accept loop for an already-bound DoQ endpoint. Split from
+/// `start_doq_server` so tests can bind on an ephemeral port, read the resolved
+/// address, and drive the loop without a bind race.
+pub async fn serve_doq(
+    endpoint: quinn::Endpoint,
+    handler: Arc<DnsServerHandler>,
+    doq_conn_limiter: ConnectionLimiter,
+) {
+    while let Some(incoming) = endpoint.accept().await {
+        let peer_addr = incoming.remote_address();
+        let guard = match doq_conn_limiter.try_acquire(peer_addr.ip()) {
+            Some(g) => g,
+            None => {
+                debug!(client = %peer_addr, "DoQ connection rejected: per-IP limit");
+                incoming.refuse();
+                continue;
+            }
+        };
+        tokio::spawn(handle_doq_connection(incoming, handler.clone(), guard));
+    }
+}
+
+async fn handle_doq_connection(
+    incoming: quinn::Incoming,
+    handler: Arc<DnsServerHandler>,
+    _guard: ConnectionGuard,
+) {
+    let peer_addr = incoming.remote_address();
+
+    let connection = match incoming.await {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(client = %peer_addr, error = %e, "DoQ handshake failed");
+            return;
+        }
+    };
+
+    debug!(client = %peer_addr, "DoQ connection accepted");
+    let client_ip = connection.remote_address().ip();
+
+    loop {
+        let (send_stream, recv_stream) = match connection.accept_bi().await {
+            Ok(streams) => streams,
+            Err(quinn::ConnectionError::ApplicationClosed(_)) => break,
+            Err(e) => {
+                debug!(client = %peer_addr, error = %e, "DoQ connection error");
+                break;
+            }
+        };
+        tokio::spawn(handle_doq_stream(
+            send_stream,
+            recv_stream,
+            handler.clone(),
+            client_ip,
+        ));
+    }
+
+    debug!(client = %peer_addr, "DoQ connection closed");
+}
+
+async fn handle_doq_stream(
+    mut send_stream: quinn::SendStream,
+    mut recv_stream: quinn::RecvStream,
+    handler: Arc<DnsServerHandler>,
+    client_ip: IpAddr,
+) {
+    let mut len_buf = [0u8; 2];
+    if !read_exact_within_timeout(&mut recv_stream, &mut len_buf).await {
+        return;
+    }
+    let msg_len = u16::from_be_bytes(len_buf) as usize;
+    if msg_len == 0 {
+        return;
+    }
+
+    let mut dns_buf = vec![0u8; msg_len];
+    if !read_exact_within_timeout(&mut recv_stream, &mut dns_buf).await {
+        return;
+    }
+
+    if let Some(resp) = handler
+        .handle_raw_udp_fallback(&dns_buf, client_ip, false)
+        .await
+    {
+        let resp_len = (resp.len() as u16).to_be_bytes();
+        if send_stream.write_all(&resp_len).await.is_err() {
+            return;
+        }
+        if send_stream.write_all(&resp).await.is_err() {
+            return;
+        }
+    }
+
+    // A finish() error here means the peer already reset/closed the stream —
+    // a benign client-side condition, so log at debug like the other drop paths.
+    if let Err(e) = send_stream.finish() {
+        debug!(error = %e, "DoQ send stream finish skipped (peer already closed)");
+    }
+}
+
+/// Reads exactly `buf.len()` bytes from `recv_stream`, giving up (returning
+/// `false`) on read error, EOF, or if `DOQ_STREAM_READ_TIMEOUT` elapses first.
+async fn read_exact_within_timeout(recv_stream: &mut quinn::RecvStream, buf: &mut [u8]) -> bool {
+    matches!(
+        tokio::time::timeout(DOQ_STREAM_READ_TIMEOUT, recv_stream.read_exact(buf)).await,
+        Ok(Ok(()))
+    )
+}

--- a/crates/cli/src/server/dns/mod.rs
+++ b/crates/cli/src/server/dns/mod.rs
@@ -1,4 +1,5 @@
-pub(crate) mod connection_limiter;
+pub mod connection_limiter;
+pub mod doq;
 pub mod dot;
 mod mdns;
 mod pktinfo;

--- a/crates/cli/src/server/dns/tls_config.rs
+++ b/crates/cli/src/server/dns/tls_config.rs
@@ -15,6 +15,7 @@ pub fn load_server_tls_config(
     cert_path: &str,
     key_path: &str,
     listener_name: &str,
+    alpn: &[&[u8]],
 ) -> anyhow::Result<Option<Arc<rustls::ServerConfig>>> {
     if !Path::new(cert_path).exists() {
         warn!(
@@ -45,10 +46,11 @@ pub fn load_server_tls_config(
     let key = PrivateKeyDer::from_pem_reader(key_file)
         .with_context(|| format!("No valid private key found in {key_path}"))?;
 
-    let config = rustls::ServerConfig::builder()
+    let mut config = rustls::ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(certs, key)
         .context("Failed to build rustls ServerConfig")?;
+    config.alpn_protocols = alpn.iter().map(|p| p.to_vec()).collect();
 
     Ok(Some(Arc::new(config)))
 }

--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -3,6 +3,8 @@ pub mod doh;
 pub mod web;
 mod web_tls;
 
+pub use dns::connection_limiter::ConnectionLimiter;
+pub use dns::doq::{bind_doq_endpoint, serve_doq, start_doq_server};
 pub use dns::dot::start_dot_server;
 pub use dns::start_dns_server;
 pub use dns::start_mdns_listener;

--- a/crates/cli/src/wiring/dns/mod.rs
+++ b/crates/cli/src/wiring/dns/mod.rs
@@ -39,6 +39,7 @@ pub struct DnsServices {
     pub ptr_registry: Option<Arc<dyn PtrRecordRegistry>>,
     pub tcp_conn_limiter: ConnectionLimiter,
     pub dot_conn_limiter: ConnectionLimiter,
+    pub doq_conn_limiter: ConnectionLimiter,
     pub tunneling_eviction_job: Option<TunnelingEvictionJob>,
     pub nxdomain_hijack_eviction_job: Option<NxdomainHijackEvictionJob>,
     pub response_ip_filter_eviction_job: Option<ResponseIpFilterEvictionJob>,
@@ -331,6 +332,8 @@ impl DnsServices {
             ConnectionLimiter::new(config.dns.rate_limit.tcp_max_connections_per_ip);
         let dot_conn_limiter =
             ConnectionLimiter::new(config.dns.rate_limit.dot_max_connections_per_ip);
+        let doq_conn_limiter =
+            ConnectionLimiter::new(config.dns.rate_limit.doq_max_connections_per_ip);
 
         info!("DNS services initialized successfully with load balancing");
 
@@ -345,6 +348,7 @@ impl DnsServices {
             ptr_registry,
             tcp_conn_limiter,
             dot_conn_limiter,
+            doq_conn_limiter,
             tunneling_eviction_job,
             nxdomain_hijack_eviction_job,
             response_ip_filter_eviction_job,

--- a/crates/cli/tests/doq_test.rs
+++ b/crates/cli/tests/doq_test.rs
@@ -1,0 +1,506 @@
+//! DNS-over-QUIC (DoQ) server listener (RFC 9250) end-to-end tests.
+//!
+//! Starts the real `start_doq_server` accept loop against a self-signed test
+//! certificate and drives it with a real `quinn` client, mirroring the
+//! upstream DoQ client setup in
+//! `ferrous_dns_infrastructure::dns::transport::quic`.
+
+use async_trait::async_trait;
+use ferrous_dns::server::{
+    bind_doq_endpoint, load_server_tls_config, serve_doq, ConnectionLimiter,
+};
+use ferrous_dns_application::ports::{
+    BlockFilterEnginePort, CacheStats, DnsResolution, DnsResolver, FilterDecision,
+    PagedQueryResult, QueryLogRepository, TimeGranularity, TimelineBucket, TlsCertificatePort,
+};
+use ferrous_dns_application::use_cases::HandleDnsQueryUseCase;
+use ferrous_dns_domain::{
+    BlockResponseMode, DnsQuery, DnssecStats, DomainError, QueryLog, QueryLogFilter, QueryStats,
+};
+use ferrous_dns_infrastructure::dns::server::{BlockPolicy, DnsServerHandler};
+use ferrous_dns_infrastructure::tls::TlsCertificateService;
+use hickory_proto::op::{Message, MessageType, OpCode, Query as WireQuery};
+use hickory_proto::rr::{DNSClass, Name, RData, RecordType as HickoryRecordType};
+use hickory_proto::serialize::binary::{BinEncodable, BinEncoder};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+// ── Minimal port doubles (hand-rolled per crate test-placement convention —
+// application crate mocks aren't reachable from the cli crate's test binary) ──
+
+/// Resolver whose cache always hits with a fixed set of addresses, regardless
+/// of the query's domain/type.
+struct CannedAddressResolver {
+    addresses: Vec<IpAddr>,
+    ttl: u32,
+}
+
+#[async_trait]
+impl DnsResolver for CannedAddressResolver {
+    async fn resolve(&self, _query: &DnsQuery) -> Result<DnsResolution, DomainError> {
+        unimplemented!("cache hit only")
+    }
+
+    fn try_cache(&self, _query: &DnsQuery) -> Option<DnsResolution> {
+        let mut res = DnsResolution::new(self.addresses.clone(), true);
+        res.min_ttl = Some(self.ttl);
+        Some(res)
+    }
+}
+
+/// Allows every domain; assigns the default group.
+struct AllowAllFilter;
+
+#[async_trait]
+impl BlockFilterEnginePort for AllowAllFilter {
+    fn resolve_group(&self, _ip: IpAddr) -> i64 {
+        0
+    }
+    fn check(&self, _domain: &str, _group_id: i64) -> FilterDecision {
+        FilterDecision::Allow
+    }
+    fn store_cname_decision(&self, _domain: &str, _group_id: i64, _ttl_secs: u64) {}
+    async fn reload(&self) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn load_client_groups(&self) -> Result<(), DomainError> {
+        Ok(())
+    }
+    fn compiled_domain_count(&self) -> usize {
+        0
+    }
+    fn is_blocking_enabled(&self) -> bool {
+        false
+    }
+    fn set_blocking_enabled(&self, _enabled: bool) {}
+}
+
+/// Drops every logged query.
+struct NoopQueryLog;
+
+#[async_trait]
+impl QueryLogRepository for NoopQueryLog {
+    async fn log_query(&self, _query: &QueryLog) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn get_recent(
+        &self,
+        _limit: u32,
+        _period_hours: f32,
+    ) -> Result<Vec<QueryLog>, DomainError> {
+        unimplemented!()
+    }
+    async fn get_recent_paged(
+        &self,
+        _limit: u32,
+        _offset: u32,
+        _period_hours: f32,
+        _cursor: Option<i64>,
+        _filter: &QueryLogFilter,
+    ) -> Result<PagedQueryResult, DomainError> {
+        unimplemented!()
+    }
+    async fn get_stats(&self, _period_hours: f32) -> Result<QueryStats, DomainError> {
+        unimplemented!()
+    }
+    async fn get_dnssec_stats(&self, _period_hours: f32) -> Result<DnssecStats, DomainError> {
+        unimplemented!()
+    }
+    async fn get_timeline(
+        &self,
+        _period_hours: u32,
+        _granularity: TimeGranularity,
+    ) -> Result<Vec<TimelineBucket>, DomainError> {
+        unimplemented!()
+    }
+    async fn count_queries_since(&self, _seconds_ago: i64) -> Result<u64, DomainError> {
+        unimplemented!()
+    }
+    async fn get_cache_stats(&self, _period_hours: f32) -> Result<CacheStats, DomainError> {
+        unimplemented!()
+    }
+    async fn get_top_blocked_domains(
+        &self,
+        _limit: u32,
+        _period_hours: f32,
+    ) -> Result<Vec<(String, u64)>, DomainError> {
+        unimplemented!()
+    }
+    async fn get_top_allowed_domains(
+        &self,
+        _limit: u32,
+        _period_hours: f32,
+    ) -> Result<Vec<(String, u64)>, DomainError> {
+        unimplemented!()
+    }
+    async fn get_distinct_recent_domains(
+        &self,
+        _limit: u32,
+        _period_hours: f32,
+    ) -> Result<Vec<(String, u64)>, DomainError> {
+        unimplemented!()
+    }
+    async fn get_top_clients(
+        &self,
+        _limit: u32,
+        _period_hours: f32,
+    ) -> Result<Vec<(String, Option<String>, u64)>, DomainError> {
+        unimplemented!()
+    }
+    async fn delete_older_than(&self, _days: u32) -> Result<u64, DomainError> {
+        unimplemented!()
+    }
+}
+
+/// Builds a handler that always resolves to `addresses` with the given TTL.
+fn handler_with_canned_addresses(addresses: Vec<IpAddr>, ttl: u32) -> Arc<DnsServerHandler> {
+    let resolver: Arc<dyn DnsResolver> = Arc::new(CannedAddressResolver { addresses, ttl });
+    let use_case = Arc::new(HandleDnsQueryUseCase::new(
+        resolver,
+        Arc::new(AllowAllFilter),
+        Arc::new(NoopQueryLog),
+    ));
+    Arc::new(DnsServerHandler::new(
+        use_case,
+        BlockPolicy {
+            mode: BlockResponseMode::NullIp,
+            ttl: 60,
+            sinkhole_ipv4: None,
+            sinkhole_ipv6: None,
+        },
+    ))
+}
+
+/// Builds a valid wire-format A-record query for `name`.
+fn build_a_query(name: &str) -> Vec<u8> {
+    let fqdn = if name.ends_with('.') {
+        name.to_string()
+    } else {
+        format!("{name}.")
+    };
+    let mut query = WireQuery::new();
+    query.set_name(Name::from_str(&fqdn).unwrap());
+    query.set_query_type(HickoryRecordType::A);
+    query.set_query_class(DNSClass::IN);
+
+    let mut message = Message::new(fastrand::u16(..), MessageType::Query, OpCode::Query);
+    message.metadata.recursion_desired = true;
+    message.add_query(query);
+
+    let mut buf = Vec::with_capacity(64);
+    let mut encoder = BinEncoder::new(&mut buf);
+    message.emit(&mut encoder).unwrap();
+    buf
+}
+
+/// Starts a DoQ listener on an ephemeral loopback port with a fresh
+/// self-signed cert and the given connection limiter. The endpoint is bound
+/// synchronously before this returns, so callers can connect immediately with
+/// no bind race — the resolved `SocketAddr` (actual port) is returned.
+async fn start_test_doq_server(conn_limiter: ConnectionLimiter) -> SocketAddr {
+    start_test_doq_server_on("127.0.0.1:0", conn_limiter).await
+}
+
+async fn start_test_doq_server_on(bind: &str, conn_limiter: ConnectionLimiter) -> SocketAddr {
+    ferrous_dns::install_crypto_provider();
+
+    let dir = tempfile::tempdir().unwrap();
+    let cert_path = dir.path().join("cert.pem");
+    let key_path = dir.path().join("key.pem");
+    TlsCertificateService
+        .generate_self_signed(cert_path.to_str().unwrap(), key_path.to_str().unwrap())
+        .await
+        .unwrap();
+
+    let tls_config = load_server_tls_config(
+        cert_path.to_str().unwrap(),
+        key_path.to_str().unwrap(),
+        "doq_test",
+        &[b"doq"],
+    )
+    .unwrap()
+    .unwrap();
+
+    let endpoint = bind_doq_endpoint(bind, tls_config).unwrap();
+    let addr = endpoint.local_addr().unwrap();
+    let handler =
+        handler_with_canned_addresses(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))], 300);
+    tokio::spawn(serve_doq(endpoint, handler, conn_limiter));
+    addr
+}
+
+/// Dummy certificate verifier that accepts any certificate — the test server
+/// uses a throwaway self-signed cert, so there's nothing to chain to a root.
+#[derive(Debug)]
+struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
+
+impl SkipServerVerification {
+    fn new() -> Arc<Self> {
+        Arc::new(Self(
+            Arc::new(rustls::crypto::aws_lc_rs::default_provider()),
+        ))
+    }
+}
+
+impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+/// Builds a `quinn` client endpoint configured for DoQ (ALPN `doq`) that
+/// trusts any server certificate — mirrors
+/// `ferrous_dns_infrastructure::dns::transport::quic`'s client setup, minus
+/// the pooling and with a permissive verifier for the test's self-signed cert.
+fn build_test_client_endpoint() -> quinn::Endpoint {
+    build_client_endpoint("127.0.0.1:0", vec![b"doq".to_vec()])
+}
+
+/// Builds a `quinn` client endpoint bound to `local`, offering the given ALPN
+/// protocol list. Trusts any server certificate (self-signed test cert).
+fn build_client_endpoint(local: &str, alpn: Vec<Vec<u8>>) -> quinn::Endpoint {
+    let mut tls_config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(SkipServerVerification::new())
+        .with_no_client_auth();
+    tls_config.alpn_protocols = alpn;
+
+    let quic_config = quinn::crypto::rustls::QuicClientConfig::try_from(Arc::new(tls_config))
+        .expect("valid QUIC TLS config");
+    let client_config = quinn::ClientConfig::new(Arc::new(quic_config));
+
+    let mut endpoint =
+        quinn::Endpoint::client(local.parse().unwrap()).expect("QUIC client endpoint");
+    endpoint.set_default_client_config(client_config);
+    endpoint
+}
+
+/// Opens a bi-stream on `connection`, sends `query_bytes` length-prefixed,
+/// and reads back a length-prefixed response.
+async fn send_query_on(connection: &quinn::Connection, query_bytes: &[u8]) -> Vec<u8> {
+    let (mut send, mut recv) = connection.open_bi().await.unwrap();
+    send.write_all(&(query_bytes.len() as u16).to_be_bytes())
+        .await
+        .unwrap();
+    send.write_all(query_bytes).await.unwrap();
+    send.finish().unwrap();
+
+    let mut len_buf = [0u8; 2];
+    recv.read_exact(&mut len_buf).await.unwrap();
+    let resp_len = u16::from_be_bytes(len_buf) as usize;
+    let mut resp = vec![0u8; resp_len];
+    recv.read_exact(&mut resp).await.unwrap();
+    resp
+}
+
+#[tokio::test]
+async fn round_trip_returns_expected_answer() {
+    let addr = start_test_doq_server(ConnectionLimiter::new(0)).await;
+
+    let endpoint = build_test_client_endpoint();
+    let connection = endpoint.connect(addr, "localhost").unwrap().await.unwrap();
+
+    let query = build_a_query("example.com");
+    let query_id = u16::from_be_bytes([query[0], query[1]]);
+
+    let response = send_query_on(&connection, &query).await;
+    let msg = Message::from_vec(&response).unwrap();
+
+    assert_eq!(msg.id, query_id);
+    assert_eq!(msg.answers.len(), 1);
+    match &msg.answers[0].data {
+        RData::A(a) => assert_eq!(a.0, Ipv4Addr::new(93, 184, 216, 34)),
+        other => panic!("expected an A record, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn multiple_streams_on_one_connection_each_get_a_response() {
+    let addr = start_test_doq_server(ConnectionLimiter::new(0)).await;
+
+    let endpoint = build_test_client_endpoint();
+    let connection = endpoint.connect(addr, "localhost").unwrap().await.unwrap();
+
+    let queries: Vec<Vec<u8>> = vec![
+        build_a_query("one.example.com"),
+        build_a_query("two.example.com"),
+        build_a_query("three.example.com"),
+    ];
+    let query_ids: Vec<u16> = queries
+        .iter()
+        .map(|q| u16::from_be_bytes([q[0], q[1]]))
+        .collect();
+
+    let futures = queries.iter().map(|q| send_query_on(&connection, q));
+    let responses = futures::future::join_all(futures).await;
+
+    for (response, expected_id) in responses.iter().zip(query_ids.iter()) {
+        let msg = Message::from_vec(response).unwrap();
+        assert_eq!(msg.id, *expected_id);
+        assert_eq!(msg.answers.len(), 1);
+    }
+}
+
+#[tokio::test]
+async fn per_ip_connection_limit_is_enforced() {
+    let addr = start_test_doq_server(ConnectionLimiter::new(1)).await;
+
+    let first_endpoint = build_test_client_endpoint();
+    let first_connection = first_endpoint
+        .connect(addr, "localhost")
+        .unwrap()
+        .await
+        .unwrap();
+
+    // First connection stays open, occupying the one allowed slot. The second
+    // must be actively refused (incoming.refuse()) — which resolves promptly to
+    // a ConnectionError — NOT left hanging. A timeout here is a failure, not a
+    // pass: it would mean the server stalled instead of rejecting.
+    let second_endpoint = build_test_client_endpoint();
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(5),
+        second_endpoint.connect(addr, "localhost").unwrap(),
+    )
+    .await;
+
+    match outcome {
+        Ok(Ok(_conn)) => {
+            panic!("second connection should have been refused by the per-IP limit")
+        }
+        Ok(Err(_refused)) => { /* refused as expected */ }
+        Err(_elapsed) => {
+            panic!("refused connection should resolve promptly, not hang past the timeout")
+        }
+    }
+
+    drop(first_connection);
+}
+
+#[tokio::test]
+async fn wrong_alpn_is_rejected() {
+    let addr = start_test_doq_server(ConnectionLimiter::new(0)).await;
+
+    // A client offering only a non-`doq` ALPN must fail the QUIC/TLS handshake:
+    // the server advertises `doq` alone, so there is no protocol overlap.
+    let endpoint = build_client_endpoint("127.0.0.1:0", vec![b"h3".to_vec()]);
+    let result = endpoint.connect(addr, "localhost").unwrap().await;
+
+    assert!(
+        result.is_err(),
+        "handshake with a non-doq ALPN must be rejected, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn malformed_streams_do_not_break_the_connection() {
+    let addr = start_test_doq_server(ConnectionLimiter::new(0)).await;
+
+    let endpoint = build_test_client_endpoint();
+    let connection = endpoint.connect(addr, "localhost").unwrap().await.unwrap();
+
+    // (a) Zero-length prefix: the server reads the 2-byte length, sees 0, and
+    // drops the stream without dispatching anything.
+    let (mut send, _recv) = connection.open_bi().await.unwrap();
+    send.write_all(&0u16.to_be_bytes()).await.unwrap();
+    send.finish().unwrap();
+
+    // (b) Length prefix that overstates the body, then EOF: the body read hits
+    // an unexpected EOF and the stream is dropped — no response, no hang.
+    let (mut send, _recv) = connection.open_bi().await.unwrap();
+    send.write_all(&100u16.to_be_bytes()).await.unwrap();
+    send.write_all(b"short").await.unwrap();
+    send.finish().unwrap();
+
+    // (c) Well-framed but not a valid DNS message: the handler parses nothing
+    // and returns no response, so the client reads back zero bytes.
+    let garbage = b"\xff\xff not a dns message";
+    let (mut send, mut recv) = connection.open_bi().await.unwrap();
+    send.write_all(&(garbage.len() as u16).to_be_bytes())
+        .await
+        .unwrap();
+    send.write_all(garbage).await.unwrap();
+    send.finish().unwrap();
+    let leftover = recv.read_to_end(512).await.unwrap_or_default();
+    assert!(
+        leftover.is_empty(),
+        "a malformed query must not produce a response"
+    );
+
+    // The connection survived all three malformed streams: a valid query on a
+    // fresh stream still round-trips correctly.
+    let query = build_a_query("example.com");
+    let response = send_query_on(&connection, &query).await;
+    let msg = Message::from_vec(&response).unwrap();
+    assert_eq!(msg.answers.len(), 1);
+    match &msg.answers[0].data {
+        RData::A(a) => assert_eq!(a.0, Ipv4Addr::new(93, 184, 216, 34)),
+        other => panic!("expected an A record, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn round_trip_over_ipv6() {
+    // Some CI sandboxes have no IPv6 loopback — skip rather than fail there.
+    if std::net::UdpSocket::bind("[::1]:0").is_err() {
+        eprintln!("skipping round_trip_over_ipv6: no IPv6 loopback available");
+        return;
+    }
+
+    let addr = start_test_doq_server_on("[::1]:0", ConnectionLimiter::new(2)).await;
+
+    let endpoint = build_client_endpoint("[::1]:0", vec![b"doq".to_vec()]);
+    let connection = endpoint.connect(addr, "localhost").unwrap().await.unwrap();
+
+    // Exercises the IPv6 peer path: the per-connection client_ip is a v6 address
+    // and the limiter is keyed on it.
+    let query = build_a_query("example.com");
+    let response = send_query_on(&connection, &query).await;
+    let msg = Message::from_vec(&response).unwrap();
+    assert_eq!(msg.answers.len(), 1);
+    match &msg.answers[0].data {
+        RData::A(a) => assert_eq!(a.0, Ipv4Addr::new(93, 184, 216, 34)),
+        other => panic!("expected an A record, got {other:?}"),
+    }
+}

--- a/crates/cli/tests/tls_config_test.rs
+++ b/crates/cli/tests/tls_config_test.rs
@@ -1,0 +1,60 @@
+use ferrous_dns::server::load_server_tls_config;
+
+/// Generates a throwaway self-signed cert/key pair and writes them to temp
+/// files, mirroring the pattern in `ferrous_dns_infrastructure::tls::generate_self_signed_cert`.
+fn write_test_cert() -> (tempfile::NamedTempFile, tempfile::NamedTempFile) {
+    let mut params = rcgen::CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+    params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "localhost");
+    let key_pair = rcgen::KeyPair::generate().unwrap();
+    let cert = params.self_signed(&key_pair).unwrap();
+
+    let cert_file = tempfile::NamedTempFile::new().unwrap();
+    let key_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(cert_file.path(), cert.pem()).unwrap();
+    std::fs::write(key_file.path(), key_pair.serialize_pem()).unwrap();
+    (cert_file, key_file)
+}
+
+#[test]
+fn sets_requested_alpn_protocols() {
+    ferrous_dns::install_crypto_provider();
+    let (cert_file, key_file) = write_test_cert();
+    let config = load_server_tls_config(
+        cert_file.path().to_str().unwrap(),
+        key_file.path().to_str().unwrap(),
+        "test",
+        &[b"doq"],
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(config.alpn_protocols, vec![b"doq".to_vec()]);
+}
+
+#[test]
+fn empty_alpn_matches_current_dot_doh_behavior() {
+    ferrous_dns::install_crypto_provider();
+    let (cert_file, key_file) = write_test_cert();
+    let config = load_server_tls_config(
+        cert_file.path().to_str().unwrap(),
+        key_file.path().to_str().unwrap(),
+        "test",
+        &[],
+    )
+    .unwrap()
+    .unwrap();
+    assert!(config.alpn_protocols.is_empty());
+}
+
+#[test]
+fn missing_cert_returns_none_regardless_of_alpn() {
+    let result = load_server_tls_config(
+        "/nonexistent/cert.pem",
+        "/nonexistent/key.pem",
+        "test",
+        &[b"doq"],
+    )
+    .unwrap();
+    assert!(result.is_none());
+}

--- a/crates/domain/src/config/encrypted_dns.rs
+++ b/crates/domain/src/config/encrypted_dns.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-/// Configuration for DoT and DoH server-side listeners.
+/// Configuration for DoT, DoH, and DoQ server-side listeners.
 ///
-/// Both protocols are disabled by default. Enabling either requires a valid TLS
+/// All three protocols are disabled by default. Enabling any requires a valid TLS
 /// certificate and private key in PEM format. Default paths point to `/data/`,
 /// the standard Docker volume mount for Ferrous DNS containers.
 ///
@@ -31,11 +31,20 @@ pub struct EncryptedDnsConfig {
     #[serde(default)]
     pub doh_port: Option<u16>,
 
-    /// Path to the PEM certificate file shared by DoT and DoH.
+    /// Enable the DNS-over-QUIC listener (RFC 9250) on `doq_port`.
+    #[serde(default)]
+    pub doq_enabled: bool,
+
+    /// UDP port for DNS-over-QUIC. Standard port is 853 (shared numeral with
+    /// `dot_port`; no collision since DoQ is UDP-based and DoT is TCP-based).
+    #[serde(default = "default_dot_port")]
+    pub doq_port: u16,
+
+    /// Path to the PEM certificate file shared by DoT, DoH, and DoQ.
     #[serde(default = "default_cert_path")]
     pub tls_cert_path: String,
 
-    /// Path to the PEM private key file shared by DoT and DoH.
+    /// Path to the PEM private key file shared by DoT, DoH, and DoQ.
     #[serde(default = "default_key_path")]
     pub tls_key_path: String,
 }
@@ -59,6 +68,8 @@ impl Default for EncryptedDnsConfig {
             dot_port: default_dot_port(),
             doh_enabled: false,
             doh_port: None,
+            doq_enabled: false,
+            doq_port: default_dot_port(),
             tls_cert_path: default_cert_path(),
             tls_key_path: default_key_path(),
         }

--- a/crates/domain/src/config/rate_limit.rs
+++ b/crates/domain/src/config/rate_limit.rs
@@ -54,6 +54,10 @@ pub struct RateLimitConfig {
     /// Maximum concurrent DNS-over-TLS connections per IP address.
     #[serde(default = "default_dot_max")]
     pub dot_max_connections_per_ip: u32,
+
+    /// Maximum concurrent DNS-over-QUIC connections per IP address.
+    #[serde(default = "default_doq_max")]
+    pub doq_max_connections_per_ip: u32,
 }
 
 impl Default for RateLimitConfig {
@@ -71,6 +75,7 @@ impl Default for RateLimitConfig {
             stale_entry_ttl_secs: default_stale_ttl(),
             tcp_max_connections_per_ip: default_tcp_max(),
             dot_max_connections_per_ip: default_dot_max(),
+            doq_max_connections_per_ip: default_doq_max(),
         }
     }
 }
@@ -107,6 +112,10 @@ fn default_dot_max() -> u32 {
     15
 }
 
+fn default_doq_max() -> u32 {
+    15
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,6 +135,7 @@ mod tests {
         assert_eq!(config.stale_entry_ttl_secs, 300);
         assert_eq!(config.tcp_max_connections_per_ip, 30);
         assert_eq!(config.dot_max_connections_per_ip, 15);
+        assert_eq!(config.doq_max_connections_per_ip, 15);
     }
 
     #[test]
@@ -166,6 +176,7 @@ mod tests {
             stale_entry_ttl_secs = 300
             tcp_max_connections_per_ip = 30
             dot_max_connections_per_ip = 15
+            doq_max_connections_per_ip = 15
         "#;
         let config: RateLimitConfig = toml::from_str(toml).unwrap();
         assert!(config.enabled);
@@ -173,6 +184,7 @@ mod tests {
         assert_eq!(config.burst_size, 500);
         assert_eq!(config.whitelist.len(), 2);
         assert_eq!(config.slip_ratio, 2);
+        assert_eq!(config.doq_max_connections_per_ip, 15);
     }
 
     #[test]
@@ -190,6 +202,7 @@ mod tests {
             stale_entry_ttl_secs: 120,
             tcp_max_connections_per_ip: 8,
             dot_max_connections_per_ip: 4,
+            doq_max_connections_per_ip: 4,
         };
         let toml_str = toml::to_string(&original).unwrap();
         let restored: RateLimitConfig = toml::from_str(&toml_str).unwrap();
@@ -210,6 +223,10 @@ mod tests {
         assert_eq!(
             restored.dot_max_connections_per_ip,
             original.dot_max_connections_per_ip
+        );
+        assert_eq!(
+            restored.doq_max_connections_per_ip,
+            original.doq_max_connections_per_ip
         );
     }
 }

--- a/crates/domain/tests/encrypted_dns_config_test.rs
+++ b/crates/domain/tests/encrypted_dns_config_test.rs
@@ -1,0 +1,43 @@
+use ferrous_dns_domain::EncryptedDnsConfig;
+
+#[test]
+fn defaults_disable_doq() {
+    let config = EncryptedDnsConfig::default();
+    assert!(!config.doq_enabled);
+    assert_eq!(config.doq_port, 853);
+}
+
+#[test]
+fn parses_doq_fields_from_toml() {
+    let toml = r#"
+        dot_enabled   = true
+        dot_port      = 853
+        doh_enabled   = true
+        doh_port      = 8053
+        doq_enabled   = true
+        doq_port      = 8853
+        tls_cert_path = "/data/cert.pem"
+        tls_key_path  = "/data/key.pem"
+    "#;
+    let config: EncryptedDnsConfig = toml::from_str(toml).unwrap();
+    assert!(config.doq_enabled);
+    assert_eq!(config.doq_port, 8853);
+}
+
+#[test]
+fn round_trips_doq_fields() {
+    let original = EncryptedDnsConfig {
+        dot_enabled: true,
+        dot_port: 853,
+        doh_enabled: false,
+        doh_port: None,
+        doq_enabled: true,
+        doq_port: 8853,
+        tls_cert_path: "/data/cert.pem".to_string(),
+        tls_key_path: "/data/key.pem".to_string(),
+    };
+    let toml_str = toml::to_string(&original).unwrap();
+    let restored: EncryptedDnsConfig = toml::from_str(&toml_str).unwrap();
+    assert_eq!(restored.doq_enabled, original.doq_enabled);
+    assert_eq!(restored.doq_port, original.doq_port);
+}

--- a/crates/infrastructure/src/repositories/config_persistence.rs
+++ b/crates/infrastructure/src/repositories/config_persistence.rs
@@ -362,6 +362,11 @@ pub fn save_config_to_file(config: &Config, path: &str) -> Result<(), ConfigErro
             "dot_max_connections_per_ip",
             toml_edit::Value::from(config.dns.rate_limit.dot_max_connections_per_ip as i64),
         );
+        set_val(
+            rl,
+            "doq_max_connections_per_ip",
+            toml_edit::Value::from(config.dns.rate_limit.doq_max_connections_per_ip as i64),
+        );
         set_val(rl, "whitelist", str_array(&config.dns.rate_limit.whitelist));
     }
 

--- a/docs/configuration/dns.md
+++ b/docs/configuration/dns.md
@@ -219,6 +219,7 @@ dry_run                    = false
 stale_entry_ttl_secs       = 300
 tcp_max_connections_per_ip = 30
 dot_max_connections_per_ip = 15
+doq_max_connections_per_ip = 15
 ```
 
 | Option | Default | Description |
@@ -235,6 +236,7 @@ dot_max_connections_per_ip = 15
 | `stale_entry_ttl_secs` | `300` | Seconds before an idle subnet bucket is evicted from memory |
 | `tcp_max_connections_per_ip` | `30` | Max concurrent TCP DNS connections per IP. 0 = unlimited |
 | `dot_max_connections_per_ip` | `15` | Max concurrent DoT connections per IP. 0 = unlimited |
+| `doq_max_connections_per_ip` | `15` | Max concurrent DoQ connections per IP. 0 = unlimited |
 
 !!! tip "Tuning for your network"
     For a typical household (~100 devices), the defaults work well. The `whitelist` should include your local networks to avoid rate-limiting internal traffic. Use `dry_run = true` to validate thresholds before enforcing.

--- a/docs/configuration/ferrous-dns-toml.md
+++ b/docs/configuration/ferrous-dns-toml.md
@@ -27,7 +27,7 @@ FERROUS_CONFIG=path/to/ferrous-dns.toml ferrous-dns
 |:--------|:--------|:-------|
 | [`[server]`](#server) | Ports, bind address, Pi-hole compat, PROXY Protocol | [Server config](server.md) |
 | [`[server.web_tls]`](#web-tls) | HTTPS for the web dashboard and REST API | [Server config](server.md#web-tls) |
-| [`[server.encrypted_dns]`](#encrypted-dns) | DoT and DoH server-side listeners | [Encrypted DNS](../features/encrypted-dns.md) |
+| [`[server.encrypted_dns]`](#encrypted-dns) | DoT, DoH, and DoQ server-side listeners | [Encrypted DNS](../features/encrypted-dns.md) |
 | [`[auth]`](#auth) | Session authentication for dashboard and API | [Security](../features/security.md) |
 | [`[auth.admin]`](#auth-admin) | Admin username and password hash | [Security](../features/security.md) |
 | [`[dns]`](#dns) | Upstream fallback, timeouts, DNSSEC, privacy controls | [DNS & Upstreams](dns.md) |
@@ -98,7 +98,7 @@ tls_key_path  = "/data/key.pem"
 
 ## `[server.encrypted_dns]` {#encrypted-dns}
 
-Enables DNS-over-TLS (DoT) and DNS-over-HTTPS (DoH) server-side listeners. This section is commented out by default. If the cert or key files are missing at startup, the affected listeners are skipped with a warning; plain DNS continues normally.
+Enables DNS-over-TLS (DoT), DNS-over-HTTPS (DoH), and DNS-over-QUIC (DoQ) server-side listeners. This section is commented out by default. If the cert or key files are missing at startup, the affected listeners are skipped with a warning; plain DNS continues normally.
 
 ```toml title="ferrous-dns.toml"
 [server.encrypted_dns]
@@ -106,6 +106,8 @@ dot_enabled   = false
 dot_port      = 853
 doh_enabled   = false
 # doh_port    = 443           # omit to co-host DoH on web_port
+doq_enabled   = false
+doq_port      = 853           # UDP port; no collision with dot_port (TCP)
 tls_cert_path = "/data/cert.pem"
 tls_key_path  = "/data/key.pem"
 ```
@@ -116,6 +118,8 @@ tls_key_path  = "/data/key.pem"
 | `dot_port` | `int` | `853` | TCP port for DoT (RFC 7858 standard: 853) |
 | `doh_enabled` | `bool` | `false` | Enable the `/dns-query` DoH endpoint |
 | `doh_port` | `int` | — | Dedicated HTTPS port for DoH; omit to co-host on `web_port` |
+| `doq_enabled` | `bool` | `false` | Enable the DNS-over-QUIC listener |
+| `doq_port` | `int` | `853` | UDP port for DoQ (RFC 9250 standard: 853) |
 | `tls_cert_path` | `str` | `"/data/cert.pem"` | Path to the PEM-encoded TLS certificate |
 | `tls_key_path` | `str` | `"/data/key.pem"` | Path to the PEM-encoded TLS private key |
 
@@ -359,6 +363,7 @@ slip_ratio                 = 2
 dry_run                    = false
 tcp_max_connections_per_ip = 30
 dot_max_connections_per_ip = 15
+doq_max_connections_per_ip = 15
 stale_entry_ttl_secs       = 300
 ```
 
@@ -375,6 +380,7 @@ stale_entry_ttl_secs       = 300
 | `dry_run` | `bool` | `false` | Log rate limit events without enforcing them |
 | `tcp_max_connections_per_ip` | `int` | `30` | Maximum concurrent TCP DNS connections per client IP |
 | `dot_max_connections_per_ip` | `int` | `15` | Maximum concurrent DoT connections per client IP |
+| `doq_max_connections_per_ip` | `int` | `15` | Maximum concurrent DoQ connections per client IP |
 | `stale_entry_ttl_secs` | `int` | `300` | Seconds of inactivity before a token bucket entry is evicted |
 
 See [Rate Limiting](rate-limiting.md).

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -100,6 +100,7 @@ slip_ratio             = 2
 whitelist              = ["127.0.0.0/8", "::1/128", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
 tcp_max_connections_per_ip = 16
 dot_max_connections_per_ip = 8
+doq_max_connections_per_ip = 8
 
 # ── Blocking ──────────────────────────────────────────────────────────────────
 
@@ -234,6 +235,7 @@ slip_ratio             = 2       # 50% TC=1 for rate-limited traffic
 whitelist              = ["127.0.0.0/8", "::1/128", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
 tcp_max_connections_per_ip = 30
 dot_max_connections_per_ip = 15
+doq_max_connections_per_ip = 15
 
 # ── Blocking ──────────────────────────────────────────────────────────────────
 
@@ -373,6 +375,7 @@ ipv6_prefix_len        = 48
 whitelist              = []      # no exemptions on public resolvers
 tcp_max_connections_per_ip = 30
 dot_max_connections_per_ip = 15
+doq_max_connections_per_ip = 15
 
 # ── Blocking ──────────────────────────────────────────────────────────────────
 
@@ -453,6 +456,8 @@ password_hash = ""                          # Argon2id hash (set via setup wizar
 # dot_port      = 853
 # doh_enabled   = true
 # doh_port      = 443                       # omit to co-host on web_port
+# doq_enabled   = true
+# doq_port      = 853                       # UDP port; no collision with dot_port (TCP)
 # tls_cert_path = "/data/cert.pem"
 # tls_key_path  = "/data/key.pem"
 
@@ -534,6 +539,7 @@ dry_run                    = false      # true = log only, don't enforce
 stale_entry_ttl_secs       = 300        # idle bucket eviction
 tcp_max_connections_per_ip = 30         # TCP connection limit per IP
 dot_max_connections_per_ip = 15         # DoT connection limit per IP
+doq_max_connections_per_ip = 15         # DoQ connection limit per IP
 
 # ── Local DNS Records ─────────────────────────────────────────────────────────
 
@@ -595,7 +601,7 @@ sqlite_mmap_size_mb          = 64
 | [`[server]`](server.md) | Ports, bind address, Pi-hole compat |
 | [`[server.web_tls]`](server.md#web-tls) | TLS certificate for the dashboard and REST API |
 | [`[auth]`](server.md#authentication) | Authentication, sessions, API tokens, rate limiting |
-| [`[server.encrypted_dns]`](server.md#encrypted-dns) | DoT and DoH server-side listeners |
+| [`[server.encrypted_dns]`](server.md#encrypted-dns) | DoT, DoH, and DoQ server-side listeners |
 | [`[dns]`](dns.md) | Upstream resolution, DNSSEC, local records |
 | [`[[dns.pools]]`](dns.md#upstream-pools) | Upstream server groups and strategies |
 | [`[dns.health_check]`](dns.md#health-checks) | Upstream health monitoring |

--- a/docs/configuration/rate-limiting.md
+++ b/docs/configuration/rate-limiting.md
@@ -38,6 +38,7 @@ dry_run                    = false      # true = log only
 stale_entry_ttl_secs       = 300        # idle bucket eviction
 tcp_max_connections_per_ip = 30         # TCP connection limit
 dot_max_connections_per_ip = 15         # DoT connection limit
+doq_max_connections_per_ip = 15         # DoQ connection limit
 ```
 
 ---
@@ -88,6 +89,7 @@ Subnet 10.0.0.0/24:
 |:-------|:-----|:--------|:------------|
 | `tcp_max_connections_per_ip` | `u32` | `30` | Max concurrent TCP DNS connections per IP address. `0` = unlimited |
 | `dot_max_connections_per_ip` | `u32` | `15` | Max concurrent DoT connections per IP address. `0` = unlimited |
+| `doq_max_connections_per_ip` | `u32` | `15` | Max concurrent DoQ connections per IP address. `0` = unlimited |
 
 ---
 

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -142,7 +142,7 @@ proxy_protocol_enabled = true
 
 ## Encrypted DNS {#encrypted-dns}
 
-Ferrous DNS can serve **DNS-over-TLS (DoT)** and **DNS-over-HTTPS (DoH)** directly to clients. Both require a TLS certificate and private key in PEM format.
+Ferrous DNS can serve **DNS-over-TLS (DoT)**, **DNS-over-HTTPS (DoH)**, and **DNS-over-QUIC (DoQ)** directly to clients. All three require a TLS certificate and private key in PEM format.
 
 ```toml
 [server.encrypted_dns]
@@ -150,6 +150,8 @@ dot_enabled   = true
 dot_port      = 853
 doh_enabled   = true
 doh_port      = 443        # omit to co-host DoH on web_port
+doq_enabled   = true
+doq_port      = 853        # UDP port; no collision with dot_port (TCP)
 tls_cert_path = "/data/cert.pem"
 tls_key_path  = "/data/key.pem"
 ```
@@ -160,6 +162,8 @@ tls_key_path  = "/data/key.pem"
 | `dot_port` | `853` | TCP port for DoT (RFC 7858 standard: 853) |
 | `doh_enabled` | `false` | Enable DoH endpoint (`/dns-query`) |
 | `doh_port` | — | Dedicated HTTPS port for DoH; omit to co-host on `web_port` |
+| `doq_enabled` | `false` | Enable DoQ listener |
+| `doq_port` | `853` | UDP port for DoQ (RFC 9250 standard: 853) |
 | `tls_cert_path` | `/data/cert.pem` | Path to TLS certificate (PEM) |
 | `tls_key_path` | `/data/key.pem` | Path to TLS private key (PEM) |
 

--- a/docs/features/encrypted-dns.md
+++ b/docs/features/encrypted-dns.md
@@ -58,18 +58,19 @@ servers = [
 
 ## Server-Side Encrypted DNS
 
-Ferrous DNS can serve DNS-over-TLS and DNS-over-HTTPS to clients on your network, so devices can connect to Ferrous DNS securely.
+Ferrous DNS can serve DNS-over-TLS, DNS-over-HTTPS, and DNS-over-QUIC to clients on your network, so devices can connect to Ferrous DNS securely.
 
-The two protocols terminate TLS differently:
+The three protocols terminate TLS differently:
 
 - **DoT** is terminated by Ferrous DNS itself, using the certificate and key in `[server.encrypted_dns]`.
 - **DoH** is served as plain HTTP and expects a **reverse proxy** (nginx, Traefik, Caddy) in front of it to terminate TLS. The DoH endpoint reads `X-Real-IP` / `X-Forwarded-For` for correct client attribution, so it must sit behind a proxy that sets those headers.
+- **DoQ** is terminated by Ferrous DNS itself, same as DoT — QUIC's TLS 1.3 handshake uses the same certificate and key, just over UDP instead of TCP.
 
 ### Requirements
 
 - A TLS certificate and private key in PEM format (used by the DoT listener)
 - A reverse proxy terminating HTTPS for DoH
-- Open firewall ports (853 for DoT; on the proxy, 443 or custom for DoH)
+- Open firewall ports (TCP/853 for DoT, UDP/853 for DoQ — no collision since they're different transports; on the proxy, 443 or custom for DoH)
 
 ### Configuration
 
@@ -79,8 +80,10 @@ dot_enabled   = true
 dot_port      = 853
 doh_enabled   = true
 doh_port      = 8053       # optional: plain-HTTP port for the proxy to forward to; omit to co-host on web_port
-tls_cert_path = "/data/cert.pem"   # certificate for the DoT listener
-tls_key_path  = "/data/key.pem"    # private key for the DoT listener
+doq_enabled   = true
+doq_port      = 853        # UDP port for DNS-over-QUIC (standard: 853)
+tls_cert_path = "/data/cert.pem"   # certificate for the DoT and DoQ listeners
+tls_key_path  = "/data/key.pem"    # private key for the DoT and DoQ listeners
 ```
 
 !!! note "DoH TLS termination"
@@ -157,6 +160,28 @@ tls_key_path  = "/etc/letsencrypt/live/dns.yourdomain.com/privkey.pem"
     DNSOverTLS=yes
     ```
 
+### DNS-over-QUIC (DoQ)
+
+=== "Android"
+
+    Settings > Network > Private DNS > Enter hostname (Android 13+ supports DoQ automatically when the resolver advertises it via DDR; otherwise use a DoQ-aware app):
+    ```text
+    192.168.1.100
+    ```
+
+=== "AdGuard Home / dnscrypt-proxy clients"
+
+    Point the client's upstream at:
+    ```text
+    quic://192.168.1.100:853
+    ```
+
+=== "kdig (testing)"
+
+    ```bash
+    kdig +quic @192.168.1.100 example.com
+    ```
+
 ### DNS-over-HTTPS (DoH)
 
 === "Firefox"
@@ -185,6 +210,9 @@ tls_key_path  = "/etc/letsencrypt/live/dns.yourdomain.com/privkey.pem"
     ```bash
     # Test DoT
     kdig @192.168.1.100 +tls example.com
+
+    # Test DoQ
+    kdig @192.168.1.100 +quic example.com
 
     # Test DoH
     curl -H "accept: application/dns-json" \

--- a/docs/features/security.md
+++ b/docs/features/security.md
@@ -334,22 +334,29 @@ Set `dry_run = true` to log rate-limit events without actually refusing queries.
 
 ---
 
-## TCP/DoT Connection Limiting {#connection-limiting}
+## TCP/DoT/DoQ Connection Limiting {#connection-limiting}
 
-Per-IP connection limits protect against TCP and DoT connection exhaustion:
+Per-IP connection limits protect against TCP, DoT, and DoQ connection exhaustion:
 
 ```toml title="ferrous-dns.toml"
 [dns.rate_limit]
 tcp_max_connections_per_ip = 30    # max concurrent TCP DNS connections per IP
 dot_max_connections_per_ip = 15    # max concurrent DoT connections per IP
+doq_max_connections_per_ip = 15    # max concurrent DoQ connections per IP
 ```
 
 | Option | Default | Description |
 |:-------|:--------|:------------|
 | `tcp_max_connections_per_ip` | `30` | Max concurrent TCP connections per IP. 0 = unlimited |
 | `dot_max_connections_per_ip` | `15` | Max concurrent DoT connections per IP. 0 = unlimited |
+| `doq_max_connections_per_ip` | `15` | Max concurrent DoQ connections per IP. 0 = unlimited |
 
 Connections that exceed the limit are immediately closed. The connection counter is automatically decremented when a connection closes, preventing resource leaks.
+
+Because a single QUIC connection multiplexes many streams, DoQ adds two further per-connection safeguards on top of the per-IP limit above (both fixed, not configurable):
+
+- **Concurrent stream cap** — each DoQ connection may have at most **100** in-flight query streams at once, so one admitted connection cannot open unbounded streams.
+- **Stream read timeout** — a stream that opens but does not deliver its complete length-prefixed query within **5 seconds** is dropped, closing the slow-loris vector that QUIC keep-alive would otherwise keep alive.
 
 ---
 

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -37,8 +37,9 @@ tls_cert_path = "/data/cert.pem"
 tls_key_path  = "/data/key.pem"
 
 
-# ── Encrypted DNS (DoT / DoH) ─────────────────────────────────────────────────
-# Serves DNS-over-TLS (RFC 7858) and/or DNS-over-HTTPS (RFC 8484).
+# ── Encrypted DNS (DoT / DoH / DoQ) ───────────────────────────────────────────
+# Serves DNS-over-TLS (RFC 7858), DNS-over-HTTPS (RFC 8484), and/or
+# DNS-over-QUIC (RFC 9250).
 # Requires a TLS certificate and private key in PEM format.
 # Default paths point to /data/ — the standard Docker volume for Ferrous DNS.
 # If the cert/key files are absent at startup, the affected listeners are skipped
@@ -50,6 +51,8 @@ tls_key_path  = "/data/key.pem"
 # dot_port      = 853                     # TCP port for DNS-over-TLS (standard: 853)
 # doh_enabled   = true                    # Enable /dns-query endpoint on web_port or doh_port
 # doh_port      = 443                     # Dedicated port for DoH (omit to co-host on web_port)
+# doq_enabled   = true                    # Enable DoQ listener on doq_port
+# doq_port      = 853                     # UDP port for DNS-over-QUIC (standard: 853; no collision with TCP dot_port)
 # tls_cert_path = "/data/cert.pem"
 # tls_key_path  = "/data/key.pem"
 
@@ -133,6 +136,7 @@ slip_ratio = 2                          # 50% of rate-limited responses send TC=
 dry_run = false                         # Enforce limits in production (set true to test first)
 tcp_max_connections_per_ip = 30         # Browsers + DoH clients pool TCP; 100 devices behind NAT need room
 dot_max_connections_per_ip = 15         # Android Private DNS keeps 2-4 persistent conns per device
+doq_max_connections_per_ip = 15         # Same budget as DoT — DoQ multiplexes many queries per connection
 stale_entry_ttl_secs = 300              # Evict idle subnet buckets after 5 minutes
 
 

--- a/web/static/settings.html
+++ b/web/static/settings.html
@@ -1002,6 +1002,19 @@
                     </div>
                 </div>
 
+                <div style="display:flex;align-items:flex-start;justify-content:space-between;padding:16px 0;border-bottom:1px solid var(--border-color)">
+                    <div style="flex:1;margin-right:24px">
+                        <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+                            <i data-lucide="zap" style="width:20px;height:20px;color:var(--color-primary)"></i>
+                            <h4 style="font-size:16px;font-weight:600;margin:0">DoQ Max Connections per IP</h4>
+                        </div>
+                        <p style="font-size:13px;color:var(--text-secondary);margin:0">Maximum concurrent DNS-over-QUIC connections per IP address.</p>
+                    </div>
+                    <div style="flex-shrink:0;width:150px">
+                        <input type="number" x-model.number="config.dns.rate_limit.doq_max_connections_per_ip" min="0" placeholder="15" style="width:100%;text-align:right">
+                    </div>
+                </div>
+
                 <div style="padding:16px 0">
                     <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
                         <i data-lucide="list-checks" style="width:20px;height:20px;color:var(--color-primary)"></i>

--- a/web/static/settings.js
+++ b/web/static/settings.js
@@ -28,7 +28,7 @@
                         ipv4_prefix_len: 24, ipv6_prefix_len: 48, whitelist: [],
                         nxdomain_per_second: 50, slip_ratio: 0, dry_run: false,
                         stale_entry_ttl_secs: 300, tcp_max_connections_per_ip: 30,
-                        dot_max_connections_per_ip: 15
+                        dot_max_connections_per_ip: 15, doq_max_connections_per_ip: 15
                     }
                 }
             },


### PR DESCRIPTION
## Summary

Adds a **DNS-over-QUIC (DoQ, RFC 9250) server listener**, letting clients query ferrous-dns over encrypted QUIC. Completes the encrypted-serving trio alongside the existing DoT and DoH listeners (upstream DoQ was already supported).

The listener mirrors the DoT/DoH pattern: a single `quinn` server endpoint, one task per QUIC connection, and each bidirectional stream carries one length-prefixed DNS message dispatched through the shared `DnsServerHandler` path. TLS advertises ALPN `doq`, and the per-IP `ConnectionLimiter` from DoT is reused.

## Configuration

| Field | Section | Default | Purpose |
|---|---|---|---|
| `doq_enabled` | `[server.encrypted_dns]` | `false` | Enable the DoQ listener |
| `doq_port` | `[server.encrypted_dns]` | `853` | UDP/QUIC bind port (distinct transport from TCP `dot_port`) |
| `doq_max_connections_per_ip` | `[dns.rate_limit]` | `15` | Per-IP concurrent DoQ connection cap (`0` = unlimited) |

All three are threaded through every layer — domain struct + serde defaults → API DTO → config get/update handlers → the `toml_edit` persistence writer → web UI form — matching the DoT/DoH siblings, so they round-trip on `POST /config` and survive restarts. Backward compatible: existing configs without these fields deserialize unchanged.

## Hardening

Because a QUIC connection multiplexes many streams, DoQ adds two per-connection safeguards on top of the per-IP limit:

- **Concurrent stream cap** — max 100 in-flight query streams per connection.
- **Stream read timeout** — a stream that doesn't deliver its full length-prefixed query within 5s is dropped (slow-loris mitigation).

## Tests

`crates/cli/tests/doq_test.rs` drives a real `start`-ed DoQ listener with a real `quinn` client over an ephemeral port (race-free — bound synchronously):

- round-trip returns the expected answer
- multiple streams multiplexed on one connection each get a response
- per-IP connection limit **refuses** the over-limit connection (asserts a prompt `ConnectionError`, not a hang)
- wrong-ALPN handshake is rejected
- malformed/empty framing (zero-length prefix, overstated length + EOF, unparseable DNS) leaves the connection usable
- IPv6 peer path (skips gracefully where no IPv6 loopback)

Plus `tls_config_test.rs` (new `alpn` parameter) and `encrypted_dns_config_test.rs` (config parse/default/round-trip).

## Review

Three independent code-review agents (implementation, config-wiring, tests/docs) each returned **APPROVE WITH NITS**; the actionable nits (log level, test-hang masking, flake-proofing, stream cap, read timeout, and the missing ALPN/malformed/IPv6 test cases) are all addressed in this branch.

## Docs & roadmap

- Documented `doq_*` config across `docs/configuration/*` and `docs/features/encrypted-dns.md`; added the per-connection stream cap + read-timeout note to `docs/features/security.md`.
- `ROADMAP.md`: DoQ server listener checkbox flipped to `[x]`.

`make ci` (fmt-check + clippy `-D warnings` + full suite) passes clean.