### PR TITLE
fix: remove baked-in Docker credentials + close config-doc gaps

### DIFF
--- a/crates/domain/src/config/auth.rs
+++ b/crates/domain/src/config/auth.rs
@@ -41,8 +41,8 @@ pub struct AdminConfig {
     #[serde(default = "default_admin_username")]
     pub username: String,
 
-    /// Argon2id password hash. Set via `--reset-password` CLI or setup endpoint.
-    /// When empty/None, first-run setup is triggered.
+    /// Argon2id password hash. Set via the setup endpoint (first-run wizard).
+    /// When empty/None, first-run setup is triggered; clear it to reset a lost password.
     pub password_hash: Option<String>,
 }
 

--- a/docs/configuration/dns.md
+++ b/docs/configuration/dns.md
@@ -32,6 +32,7 @@ local_dns_server = "10.0.0.1:53"
 | `mdns_enabled` | `false` | Enable the passive mDNS/Bonjour listener (UDP 5353 multicast) for device discovery. In Docker this needs host networking — see [Installation](../getting-started/installation.md#docker) |
 | `rebinding_protection_enabled` | `true` | Block public domains that resolve to private/RFC-1918 (or IPv6 ULA/link-local) addresses — see [DNS Rebinding Protection](../features/malware-detection.md#dns-rebinding-protection) |
 | `rebinding_allowlist` | `[]` | Exact domain names exempt from rebinding protection regardless of resolved IP (split-horizon DNS) |
+| `qname_case_randomization` | `false` | Randomize QNAME letter case on upstream A/AAAA queries (draft-vixie-dns-0x20) for extra anti-spoofing entropy; off by default because some upstreams/forwarders normalize case and would fail validation. DNS Cookies on A/AAAA queries are always on regardless of this flag |
 
 ---
 

--- a/docs/configuration/ferrous-dns-toml.md
+++ b/docs/configuration/ferrous-dns-toml.md
@@ -162,7 +162,7 @@ password_hash = ""
 | `password_hash` | `str` | `""` | Argon2id hash; empty string triggers the setup wizard on first run |
 
 !!! tip "Setting the password"
-    Set the admin password via the web setup wizard on first run, or reset it at any time with the `--reset-password` CLI flag. The Argon2id hash is written back to the config file automatically.
+    Set the admin password via the web setup wizard on first run — the Argon2id hash is written back to the config file automatically. To reset a forgotten password, clear this field (`password_hash = ""`) and restart; the setup wizard runs again on next access.
 
 See [Security](../features/security.md).
 

--- a/docs/configuration/ferrous-dns-toml.md
+++ b/docs/configuration/ferrous-dns-toml.md
@@ -40,7 +40,9 @@ FERROUS_CONFIG=path/to/ferrous-dns.toml ferrous-dns
 | [`[dns.nxdomain_hijack]`](#nxdomain-hijack) | ISP NXDOMAIN hijack detection and reversal | [Malware Detection](../features/malware-detection.md#nxdomain-hijack-detection) |
 | [`[dns.response_ip_filter]`](#response-ip-filter) | Block responses resolving to known C2 IPs | [Malware Detection](../features/malware-detection.md#response-ip-filtering) |
 | [`[[dns.local_records]]`](#local-records) | Static A/AAAA records with auto-PTR | [DNS & Upstreams](dns.md#local-records) |
+| [`[dns_cookies]`](#dns-cookies) | DNS Cookies anti-spoofing (RFC 7873) | [Security](../features/security.md) |
 | [`[blocking]`](#blocking) | Ad and malware blocking via blocklists | [Blocking & Filtering](../features/blocking-filtering.md) |
+| [`[dns64]`](#dns64) | NAT64 AAAA synthesis for IPv6-only clients (RFC 6147) | [DNS64](../features/dns64.md) |
 | [`[logging]`](#logging) | Log level | — |
 | [`[database]`](#database) | SQLite persistence, query log pipeline, connection pools | [Database configuration](database.md) |
 
@@ -57,6 +59,7 @@ web_port                 = 8080
 bind_address             = "0.0.0.0"
 pihole_compat            = false
 proxy_protocol_enabled   = false
+metrics_enabled          = false
 ```
 
 | Option | Type | Default | Description |
@@ -66,6 +69,8 @@ proxy_protocol_enabled   = false
 | `bind_address` | `str` | `"0.0.0.0"` | Network interface to bind to; `0.0.0.0` listens on all interfaces |
 | `pihole_compat` | `bool` | `false` | Expose Pi-hole v6 compatible API at `/api/*`; Ferrous DNS native API moves to `/ferrous/api/*` |
 | `proxy_protocol_enabled` | `bool` | `false` | Enable PROXY Protocol v2 on TCP DNS and DoT listeners |
+| `metrics_enabled` | `bool` | `false` | Serve an unauthenticated Prometheus text-exposition endpoint at `/metrics` on the web port |
+| `cors_allowed_origins` | `list` | _(dashboard origin)_ | Browser origins allowed to call the REST API via CORS |
 
 !!! warning "PROXY Protocol"
     Only enable `proxy_protocol_enabled` when a trusted load balancer always sits in front of Ferrous DNS. Without a load balancer, all TCP DNS connections will be rejected because the server expects a PROXY Protocol header on every connection.
@@ -177,12 +182,14 @@ Core DNS resolver options: upstream fallback, timeouts, DNSSEC validation, local
 upstream_servers  = []
 query_timeout     = 3
 default_strategy  = "Parallel"
-dnssec_enabled    = true
+dnssec_mode       = "Permissive"
 block_private_ptr = true
 block_non_fqdn    = true
+rebinding_protection_enabled = true
 local_domain      = "lan"
 local_dns_server  = "10.0.0.1:53"
 mdns_enabled      = false
+qname_case_randomization = false
 ```
 
 | Option | Type | Default | Description |
@@ -190,12 +197,15 @@ mdns_enabled      = false
 | `upstream_servers` | `list` | `[]` | Fallback upstream servers used when no pool matches; supports all URI schemes |
 | `query_timeout` | `int` | `3` | Seconds to wait for an upstream response before trying the next server |
 | `default_strategy` | `str` | `"Parallel"` | Default resolution strategy for `upstream_servers`: `"Parallel"` or `"Sequential"` |
-| `dnssec_enabled` | `bool` | `true` | Validate DNSSEC signatures on upstream responses |
+| `dnssec_mode` | `str` | `"Permissive"` | DNSSEC enforcement: `"Off"` (no validation), `"Permissive"` (validate + tag, no SERVFAIL), `"Strict"` (SERVFAIL on Bogus). The legacy `dnssec_enabled` bool is still accepted (`true` → Permissive, `false` → Off) |
 | `block_private_ptr` | `bool` | `true` | Block PTR lookups for private/RFC-1918 IP ranges |
-| `block_non_fqdn` | `bool` | `true` | Block queries for non-fully-qualified domain names |
+| `block_non_fqdn` | `bool` | `false` | Block queries for non-fully-qualified domain names |
+| `rebinding_protection_enabled` | `bool` | `true` | Block responses where a public domain resolves to a private/RFC-1918 IP (DNS rebinding protection) |
+| `rebinding_allowlist` | `list` | `[]` | Domains exempt from rebinding protection (split-horizon DNS: VPN endpoints, router admin panels) |
 | `local_domain` | `str` | `"lan"` | Local domain suffix appended to short hostnames |
 | `local_dns_server` | `str` | `"10.0.0.1:53"` | Router or DHCP server used for PTR lookups and client hostname resolution |
 | `mdns_enabled` | `bool` | `false` | Enable the passive mDNS/Bonjour listener (UDP 5353 multicast) for device discovery; requires host networking in Docker |
+| `qname_case_randomization` | `bool` | `false` | Randomize QNAME letter case on upstream A/AAAA queries (draft-vixie-dns-0x20) for extra anti-spoofing entropy; off because some upstreams do not preserve case |
 
 See [DNS & Upstreams](dns.md).
 
@@ -584,6 +594,51 @@ block_ttl      = 60
     `block_mode`, `block_ttl`, `sinkhole_ipv4`, and `sinkhole_ipv6` are applied at startup; changing them needs a server restart. See [Block Response Mode](blocking.md#block-response-mode) for what each mode returns.
 
 See [Blocking & Filtering](../features/blocking-filtering.md).
+
+---
+
+## `[dns64]` {#dns64}
+
+NAT64 AAAA synthesis (RFC 6147). Synthesizes `AAAA` records for IPv4-only domains so IPv6-only clients can reach them through a NAT64 gateway. Requires a NAT64 gateway on the network — without one, IPv6-only clients break. Applied at startup; changes need a restart.
+
+```toml title="ferrous-dns.toml"
+[dns64]
+enabled = false
+prefix  = "64:ff9b::/96"
+```
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `enabled` | `bool` | `false` | Enable DNS64 AAAA synthesis; only turn on with a NAT64 gateway present |
+| `prefix` | `str` | `"64:ff9b::/96"` | NAT64 prefix; only `/96` is supported (well-known prefix per RFC 6052) |
+
+See [DNS64](../features/dns64.md).
+
+---
+
+## `[dns_cookies]` {#dns-cookies}
+
+DNS Cookies (RFC 7873) anti-spoofing. The server echoes an HMAC-SHA256 server cookie on every response so clients can verify they are talking to the same server, mitigating UDP spoofing and amplification abuse. Enabled by default.
+
+```toml title="ferrous-dns.toml"
+[dns_cookies]
+enabled              = true
+server_secret        = ""
+secret_rotation_secs = 3600
+require_valid_cookie = false
+```
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `enabled` | `bool` | `true` | Enable DNS Cookies on UDP responses |
+| `server_secret` | `str` | `""` (ephemeral) | 64-char hex (32 bytes) secret so cookies survive restarts; generate with `openssl rand -hex 32`. Empty uses an ephemeral secret regenerated on each restart |
+| `secret_rotation_secs` | `int` | `3600` | Seconds between server-secret rotations |
+| `require_valid_cookie` | `bool` | `false` | Strict mode: refuse queries without a valid cookie (REFUSED + EDE 25). Only enable when every client supports RFC 7873 |
+
+!!! warning "Do not commit a shared `server_secret`"
+    Leave `server_secret` empty (ephemeral) or generate a unique value per deployment. A fixed secret baked into an image means every install shares the same cookie key, defeating the anti-spoofing guarantee.
+
+See [Security](../features/security.md).
 
 ---
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -42,7 +42,7 @@ bind_address = "0.0.0.0"
 
 [dns]
 query_timeout    = 5
-dnssec_enabled   = false          # disable for ~20% lower cache-miss latency on ARM
+dnssec_mode      = "Off"          # disable for ~20% lower cache-miss latency on ARM
 block_private_ptr = true
 block_non_fqdn   = true
 local_domain     = "lan"
@@ -168,7 +168,7 @@ password_hash = ""                       # ← set via setup wizard on first run
 
 [dns]
 query_timeout     = 3
-dnssec_enabled    = true
+dnssec_mode       = "Permissive"
 block_private_ptr = true
 block_non_fqdn    = true
 local_domain      = "lan"
@@ -301,7 +301,7 @@ password_hash = ""                        # ← set via setup wizard on first ru
 
 [dns]
 query_timeout     = 2             # tighter timeout — upstreams must be fast
-dnssec_enabled    = true
+dnssec_mode       = "Permissive"
 block_private_ptr = true
 block_non_fqdn    = true
 local_domain      = "corp"
@@ -467,7 +467,7 @@ password_hash = ""                          # Argon2id hash (set via setup wizar
 upstream_servers = []                       # Fallback upstreams when no pool matches
 query_timeout    = 3                        # Seconds to wait for upstream response
 default_strategy = "Parallel"              # "Parallel" or "Sequential"
-dnssec_enabled   = true                    # Validate DNSSEC signatures
+dnssec_mode      = "Permissive"            # Validate DNSSEC signatures
 block_private_ptr = true                   # Block PTR lookups for RFC-1918 ranges
 block_non_fqdn   = true                    # Block non-FQDN queries
 mdns_enabled     = false                   # Passive mDNS/Bonjour listener (UDP 5353, needs host networking in Docker)

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -11,6 +11,7 @@ The `[server]` section controls ports, bind address, API authentication, and enc
 dns_port = 53
 web_port = 8080
 bind_address = "0.0.0.0"
+metrics_enabled = false
 ```
 
 | Option | Default | Description |
@@ -18,6 +19,7 @@ bind_address = "0.0.0.0"
 | `dns_port` | `53` | UDP and TCP port for DNS queries |
 | `web_port` | `8080` | HTTP/HTTPS port for the dashboard and REST API |
 | `bind_address` | `0.0.0.0` | Network interface to bind to. Use a specific IP to restrict access |
+| `metrics_enabled` | `false` | Serve an unauthenticated Prometheus text-exposition endpoint at `/metrics` on the web port (opt-in) |
 
 ---
 

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -37,7 +37,7 @@ login_rate_limit_window_secs = 900      # Lockout window (15 min)
 
 [auth.admin]
 username = "admin"                      # Admin username
-password_hash = ""                      # Argon2id hash (set via setup wizard or CLI)
+password_hash = ""                      # Argon2id hash (set via setup wizard; empty triggers it)
 ```
 
 | Option | Type | Default | Description |

--- a/docs/features/upstream-management.md
+++ b/docs/features/upstream-management.md
@@ -291,7 +291,7 @@ Fast encrypted DNS with a plain UDP safety net:
 ```toml
 [dns]
 query_timeout    = 3
-dnssec_enabled   = true
+dnssec_mode      = "Permissive"
 default_strategy = "Parallel"
 
 [[dns.pools]]
@@ -327,7 +327,7 @@ Balanced load across multiple providers with automatic failover:
 ```toml
 [dns]
 query_timeout    = 2
-dnssec_enabled   = true
+dnssec_mode      = "Permissive"
 default_strategy = "Balanced"
 
 [[dns.pools]]

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -114,7 +114,7 @@ web_port = 8080
 bind_address = "0.0.0.0"
 
 [dns]
-dnssec_enabled = true
+dnssec_mode = "Permissive"
 local_domain = "lan"
 local_dns_server = "192.168.1.1:53"  # your router
 

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -265,7 +265,7 @@ login_rate_limit_window_secs = 900      # Lockout window in seconds (900 = 15 mi
 
 [auth.admin]
 username = "admin"                      # Admin username (TOML admin — always recoverable via file edit)
-password_hash = "$argon2id$v=19$m=19456,t=2,p=1$9pNep2fexSNQtaie80I/Mg$T9qgw7GKOCSUUZdfUNaMLVV13yftftRGoeFmFGFKa8I"                      # Argon2id hash — set via setup wizard or --reset-password CLI
+password_hash = ""                      # Argon2id hash — empty triggers the first-run setup wizard; set via the wizard
 
 
 # ── Blocking ──────────────────────────────────────────────────────────────────

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -63,6 +63,8 @@ default_strategy = "Parallel"           # Resolution strategy: "Parallel" (faste
 dnssec_mode = "Permissive"              # DNSSEC enforcement: "Off" (no validation), "Permissive" (validate + tag, no SERVFAIL), "Strict" (SERVFAIL on Bogus). Default: Permissive
 block_private_ptr = true                # Block PTR lookups for private/RFC-1918 IP ranges
 block_non_fqdn = true                   # Block queries for names that are not fully qualified domain names
+rebinding_protection_enabled = true     # Block responses where a public domain resolves to a private/RFC-1918 IP (DNS rebinding)
+# rebinding_allowlist = []              # Domains exempt from rebinding protection (split-horizon DNS: VPN, router admin panels)
 mdns_enabled = false                    # Passive mDNS/Bonjour listener on UDP 5353 (LAN multicast); device-name labeling is a future release; off by default
 local_domain = "lan"                    # Local domain suffix appended to short hostnames
 local_dns_server = "10.0.0.1:53"        # Router/DHCP server — used for PTR lookups to resolve client hostnames
@@ -393,6 +395,6 @@ sqlite_mmap_size_mb = 64
 # support RFC 7873 (dig, modern resolvers). Default is permissive.
 [dns_cookies]
 # enabled = true                                                                   # default: true
-server_secret = "b552a5c0a9e055c9d220da606301419406f6aabf8f750d54ee6374f74eb6688f" # replace with: openssl rand -hex 32
+server_secret = ""                                                                 # empty = ephemeral secret (regenerated each restart); set a unique 64-char hex via: openssl rand -hex 32
 # secret_rotation_secs = 3600                                                      # default: 3600
 # require_valid_cookie = false                                                      # default: false (permissive)


### PR DESCRIPTION
## Summary
Started as the fix for #175 (Docker default admin password) and grew to cover a config-documentation audit of `ferrous-dns.toml`.

### Security — leaked credentials baked into the Docker image
- Closes #175. Cleared the pre-generated Argon2id `password_hash` for `admin` in the shipped `ferrous-dns.toml`; it was silently bypassing the first-run setup wizard and shipping a hidden default credential.
- Cleared a real HMAC `[dns_cookies] server_secret` committed into the same file — every Docker install otherwise shared one DNS-cookie key. Empty = ephemeral per-restart secret.

### Docs — config coverage gaps (audit of every TOML key vs `docs/`)
- Documented previously-undocumented keys: `[dns] qname_case_randomization`, `[server] metrics_enabled` / `cors_allowed_origins`.
- Added the missing `[dns64]` and `[dns_cookies]` sections to the master reference `docs/configuration/ferrous-dns-toml.md` (they existed only on feature pages).
- Fixed stale master-reference entries: `dnssec_enabled` → `dnssec_mode`; `block_non_fqdn` default `true` → `false`; added `rebinding_protection_enabled` / `rebinding_allowlist`.
- Corrected docs/comments referencing a non-existent `--reset-password` CLI flag; the real recovery path is editing `password_hash` back to `""` and restarting.

### Recovery for already-affected containers
Edit `/data/config/ferrous-dns.toml` on the volume, set `password_hash = ""` (and optionally a fresh `server_secret`), and restart. Deleting the file doesn't help on the old image — the entrypoint re-copies the same baked-in defaults.

## Test plan
- [x] `make ci` passes (fmt-check + clippy `-D warnings` + tests).
- [x] Shipped `ferrous-dns.toml` still parses as valid TOML; no residual secrets in the file.
- [ ] Manual: fresh `docker compose up`, confirm the web UI shows the setup wizard.