### PR TITLE
fix(cache): re-seed bloom on rotation so live entries stay cacheable

### DIFF
--- a/crates/infrastructure/src/dns/cache/storage.rs
+++ b/crates/infrastructure/src/dns/cache/storage.rs
@@ -422,11 +422,42 @@ impl DnsCache {
         self.eviction_policy.strategy()
     }
 
-    pub fn rotate_bloom(&self) {
+    /// Rotates the two-slot aging bloom and re-seeds it from the live cache.
+    ///
+    /// The filter is an authoritative negative gate in [`Self::get`]: when a
+    /// key's bits are absent the lookup reports a miss without ever consulting
+    /// the backing map. Bits are otherwise written only by `insert` and by a
+    /// read hit, so an entry that went unread across two rotations used to
+    /// become invisible while still holding a valid TTL — the query left for
+    /// upstream and the optimistic refresh job had no way to prevent it.
+    /// Re-seeding ties bloom membership to what the cache actually holds
+    /// rather than to how recently a key was read.
+    ///
+    /// Returns how many keys were re-seeded into the new active slot.
+    pub fn rotate_bloom(&self) -> usize {
         self.bloom.rotate();
+
+        let now = coarse_now_secs();
+        let mut reseeded = 0usize;
+
+        for entry in self.cache.iter() {
+            let record = entry.value();
+            if record.is_marked_for_deletion() {
+                continue;
+            }
+            if record.is_expired_at_secs(now) && !record.is_stale_usable_at_secs(now) {
+                continue;
+            }
+            self.bloom.set(entry.key());
+            reseeded += 1;
+        }
+
         for key in self.permanent_keys.iter() {
             self.bloom.set(key.key());
         }
+
+        debug!(reseeded, "Bloom rotated and re-seeded from live cache");
+        reseeded
     }
 
     pub fn min_ttl(&self) -> u32 {
@@ -486,6 +517,10 @@ impl DnsCache {
                     record.expires_at_secs,
                 );
             }
+
+            // A renewed TTL is worthless if the bloom gate no longer admits the
+            // key, so re-arm it here too instead of waiting for the next rotation.
+            self.bloom.set(&key);
             true
         } else {
             false

--- a/crates/infrastructure/src/dns/cache_maintenance.rs
+++ b/crates/infrastructure/src/dns/cache_maintenance.rs
@@ -16,8 +16,8 @@ use tracing::{debug, info};
 
 const BACKPRESSURE_MS_PER_CANDIDATE: u64 = 2;
 
-/// Minimum bloom rotation interval in refresh cycles.
-/// Ensures bloom entries survive long enough to match cache min_ttl.
+/// Minimum bloom rotation interval in refresh cycles. Rotation re-seeds every
+/// live key, so this only bounds how often that `O(entries)` pass runs.
 const MIN_BLOOM_ROTATION_CYCLES: u64 = 3;
 
 /// Infrastructure adapter implementing `CacheMaintenancePort`.
@@ -38,9 +38,9 @@ impl DnsCacheMaintenance {
         query_log: Option<Arc<dyn QueryLogRepository>>,
         refresh_interval_secs: u64,
     ) -> Self {
-        // Bloom rotation throttled so entries survive ≥ min_ttl seconds.
-        // The 2-slot aging bloom survives 1–2 rotations, so entries live
-        // N*interval to 2*N*interval seconds.
+        // Rotation only governs how quickly bits left behind by removed keys
+        // are purged: `rotate_bloom` re-seeds every live entry into the new
+        // slot, so an entry's visibility no longer depends on this cadence.
         let min_ttl = cache.min_ttl() as u64;
         let interval = refresh_interval_secs.max(1);
         let bloom_rotation_cycles = (min_ttl / interval).max(MIN_BLOOM_ROTATION_CYCLES);
@@ -241,7 +241,12 @@ impl CacheMaintenancePort for DnsCacheMaintenance {
             .fetch_add(1, AtomicOrdering::Relaxed)
             + 1;
         if cycle.is_multiple_of(self.bloom_rotation_cycles) {
-            self.cache.rotate_bloom();
+            let cache_for_bloom = Arc::clone(&self.cache);
+            if let Err(e) =
+                tokio::task::spawn_blocking(move || cache_for_bloom.rotate_bloom()).await
+            {
+                debug!(error = %e, "Bloom rotation task panicked");
+            }
         }
 
         let cache_for_scan = Arc::clone(&self.cache);

--- a/crates/infrastructure/tests/cache_bloom_rotation_test.rs
+++ b/crates/infrastructure/tests/cache_bloom_rotation_test.rs
@@ -1,0 +1,136 @@
+//! The bloom filter is an authoritative negative gate on `DnsCache::get`, so a
+//! rotation that drops a live key turns a valid cached answer into an upstream
+//! query. These tests pin the re-seeding behaviour that prevents that.
+
+use ferrous_dns_domain::RecordType;
+use ferrous_dns_infrastructure::dns::{CachedData, DnsCache, DnsCacheConfig, EvictionStrategy};
+use std::sync::Arc;
+
+fn create_cache(min_ttl: u32) -> DnsCache {
+    DnsCache::new(DnsCacheConfig {
+        max_entries: 1000,
+        eviction_strategy: EvictionStrategy::HitRate,
+        min_threshold: 0.0,
+        refresh_threshold: 0.75,
+        batch_eviction_percentage: 0.1,
+        adaptive_thresholds: false,
+        min_frequency: 0,
+        min_lfuk_score: 0.0,
+        shard_amount: 8,
+        access_window_secs: 43_200,
+        eviction_sample_size: 8,
+        lfuk_k_value: 0.5,
+        refresh_sample_rate: 1.0,
+        min_ttl,
+        max_ttl: 86_400,
+    })
+}
+
+/// `CanonicalName` never lands in the thread-local L1, which is consulted
+/// before the bloom — so `get` here really exercises the bloom gate.
+fn make_cname_data(name: &str) -> CachedData {
+    CachedData::CanonicalName(Arc::from(name))
+}
+
+#[test]
+fn unread_live_entry_survives_repeated_rotations() {
+    let cache = create_cache(300);
+    cache.insert(
+        "example.com",
+        RecordType::A,
+        make_cname_data("cdn.example.net"),
+        3600,
+        None,
+    );
+
+    for _ in 0..5 {
+        cache.rotate_bloom();
+    }
+
+    assert_eq!(
+        cache.get_remaining_ttl("example.com", &RecordType::A),
+        Some(3600),
+        "record must still be fresh"
+    );
+    assert!(
+        cache.get("example.com", &RecordType::A).is_some(),
+        "a live record must stay visible even when never read between rotations"
+    );
+}
+
+#[test]
+fn refresh_record_rearms_the_bloom() {
+    let cache = create_cache(300);
+    cache.insert(
+        "example.com",
+        RecordType::A,
+        make_cname_data("cdn.example.net"),
+        3600,
+        None,
+    );
+
+    assert!(cache.refresh_record(
+        "example.com",
+        &RecordType::A,
+        Some(3600),
+        make_cname_data("cdn2.example.net"),
+        None,
+    ));
+
+    cache.rotate_bloom();
+    cache.rotate_bloom();
+
+    assert!(
+        cache.get("example.com", &RecordType::A).is_some(),
+        "an entry renewed by the optimistic refresh job must stay visible"
+    );
+}
+
+#[test]
+fn rotation_does_not_reseed_expired_entries() {
+    let cache = create_cache(0);
+    cache.insert(
+        "expired.com",
+        RecordType::A,
+        make_cname_data("gone.example.net"),
+        0,
+        None,
+    );
+    cache.insert(
+        "alive.com",
+        RecordType::A,
+        make_cname_data("cdn.example.net"),
+        3600,
+        None,
+    );
+
+    assert_eq!(
+        cache.rotate_bloom(),
+        1,
+        "only the live entry should be re-seeded"
+    );
+
+    cache.rotate_bloom();
+
+    assert!(cache.get("alive.com", &RecordType::A).is_some());
+    assert!(cache.get("expired.com", &RecordType::A).is_none());
+}
+
+#[test]
+fn rotation_reseeds_permanent_entries() {
+    let cache = create_cache(300);
+    cache.insert_permanent(
+        "printer.lan",
+        RecordType::A,
+        make_cname_data("printer.local"),
+        None,
+    );
+
+    cache.rotate_bloom();
+    cache.rotate_bloom();
+
+    assert!(
+        cache.get("printer.lan", &RecordType::A).is_some(),
+        "permanent (local DNS) records must never age out of the bloom"
+    );
+}


### PR DESCRIPTION
## Problem

Repeated queries for the same domain kept escaping to upstream even though the record was still cached with a full TTL. Reported from a live query log: gaps of 31s and 3min between identical queries were served from cache, while gaps of 23min, 50min and 2h40m all went upstream.

It is not TTL expiry. The bloom filter is an **authoritative negative gate** in `DnsCache::get` — when a key's bits are absent the lookup reports a miss without ever consulting the backing `DashMap`:

```rust
let in_bloom = self.bloom.check(&borrowed);
if !in_bloom {
    // ... negative cache probe ...
    self.metrics.misses.fetch_add(1, AtomicOrdering::Relaxed);
    return None;   // never looks at self.cache
}
```

Bits were only ever written by `insert`, `insert_permanent`, and `bloom.refresh` **on a read hit**. `rotate_bloom` re-seeded nothing but `permanent_keys`. The filter has two slots and `check` reads both, so an entry survives one rotation and vanishes on the second.

With the shipped config (`cache_min_ttl = 300`, refresh interval hardcoded to 60s) `bloom_rotation_cycles` works out to 5, so rotation runs every 300s. The consequence:

> any `(domain, qtype)` left unread for two rotation windows — **5 to 10 minutes** — becomes invisible to the cache while its record sits in the map with a perfectly valid TTL.

The optimistic refresh job could not save it either: `refresh_record` renewed `expires_at_secs`, `inserted_at_secs`, `ttl` and `data`, but never re-armed the bloom. So the background job kept records fresh while they stayed unreachable.

This mostly hid behind the thread-local L1 LRU, which is consulted *before* the bloom and absorbs bursts — but L1 only holds `IpAddresses`, so `HTTPS`/SVCB (`WireData`) was exposed on every idle gap.

## Fix

- **`rotate_bloom` is now a rebuild.** After rotating it walks the cache and re-seeds every live entry into the new active slot, skipping entries marked for deletion and expired ones past the stale window. Bloom membership now tracks what the cache holds rather than how recently a key was read. Returns the number of keys re-seeded.
- **`refresh_record` calls `bloom.set`**, so an entry renewed by the background job re-arms the gate immediately instead of waiting for the next rotation.
- **Rotation moved to `spawn_blocking`** now that it walks the map, matching the eviction and compaction passes already wrapped that way in the same maintenance cycle.
- Updated the two comments that documented the old semantics: the rotation cadence now only bounds how quickly bits left by removed keys are purged, not how long an entry stays visible.

## Tests

New `crates/infrastructure/tests/cache_bloom_rotation_test.rs`. All four use `CachedData::CanonicalName` on purpose — it never lands in the thread-local L1, so `get` genuinely exercises the bloom gate.

| Test | Pins |
|---|---|
| `unread_live_entry_survives_repeated_rotations` | 5 rotations with no read; a TTL-3600 record still hits. This is the case that failed before. |
| `refresh_record_rearms_the_bloom` | An entry renewed by the optimistic refresh job stays visible. |
| `rotation_does_not_reseed_expired_entries` | Only the live entry is re-seeded (`rotate_bloom() == 1`) and the expired one still misses — the fix does not turn the cache immortal. |
| `rotation_reseeds_permanent_entries` | Local-DNS records never age out of the filter. |

Verified against the original symptom before the fix: a record reporting `len=1 remaining_ttl=Some(3600)` returned `MISS` after two rotations, and still did after `refresh_record`.

## Cost

Rotation at full capacity (200k entries, `cache_shard_amount = 32`): **85ms in a debug build** — an upper bound, release is well under that. Runs on a blocking thread once every 300s, next to a compaction pass that already does a full `retain` (write lock per shard, heavier) every 600s. No effect on the query path.

`make ci` green: exit 0, 168 test suites.
