### PR TITLE
fix(dnssec): trust both root KSKs so the 2026-10-11 rollover is a no-op

### DIFF
--- a/crates/cli/src/wiring/dns/resolver.rs
+++ b/crates/cli/src/wiring/dns/resolver.rs
@@ -1,7 +1,9 @@
+use anyhow::Context;
 use ferrous_dns_domain::Config;
+use ferrous_dns_infrastructure::dns::dnssec::TrustAnchorStore;
 use ferrous_dns_infrastructure::dns::{HickoryDnsResolver, PoolManager};
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::wiring::Repositories;
 
@@ -30,7 +32,11 @@ pub(super) fn build_resolver(
     .with_local_dns_server(config.dns.local_dns_server.clone());
 
     if dnssec_validates {
-        resolver = resolver.with_dnssec_pool_manager(pool_manager_for_dnssec);
+        resolver = resolver
+            .with_dnssec_pool_manager(pool_manager_for_dnssec)
+            .with_trust_anchors(load_trust_anchors(config)?);
+    } else if config.dns.dnssec_trust_anchor_file.is_some() {
+        debug!("DNSSEC validation is off — dnssec_trust_anchor_file is ignored");
     }
 
     // DNS64 (RFC 6147) — fail-soft: a malformed / non-/96 prefix disables the
@@ -59,4 +65,38 @@ pub(super) fn build_resolver(
     );
 
     Ok(resolver)
+}
+
+/// Loads the DNSSEC trust anchors: the operator's file when one is configured,
+/// the IANA root anchors embedded in the binary otherwise.
+///
+/// A configured file that cannot be read or parsed aborts startup instead of
+/// falling back to the embedded set — silently keeping the old trust root would
+/// leave the operator believing they had replaced it.
+fn load_trust_anchors(config: &Config) -> anyhow::Result<TrustAnchorStore> {
+    let configured_path = config.dns.dnssec_trust_anchor_file.as_deref();
+
+    let store = match configured_path {
+        Some(path) => TrustAnchorStore::from_file(path)
+            .with_context(|| format!("failed to load DNSSEC trust anchors from {path}"))?,
+        None => TrustAnchorStore::new(),
+    };
+
+    info!(
+        count = store.len(),
+        source = configured_path.unwrap_or("embedded"),
+        "DNSSEC trust anchors loaded"
+    );
+
+    for anchor in store.iter() {
+        debug!(
+            zone = %anchor.domain,
+            key_tag = anchor.key_tag(),
+            algorithm = anchor.algorithm(),
+            description = %anchor.description,
+            "DNSSEC trust anchor"
+        );
+    }
+
+    Ok(store)
 }

--- a/crates/domain/src/config/dns.rs
+++ b/crates/domain/src/config/dns.rs
@@ -37,6 +37,13 @@ pub struct DnsConfig {
     #[serde(default)]
     pub dnssec_enabled: Option<bool>,
 
+    /// Path to a DNSSEC trust anchor file in DNS presentation format (DS and/or
+    /// DNSKEY records), replacing the IANA root anchors embedded in the binary.
+    /// Read once at startup — deliberately not exposed through the API, since it
+    /// names a host path and only takes effect on restart.
+    #[serde(default)]
+    pub dnssec_trust_anchor_file: Option<String>,
+
     #[serde(default)]
     pub default_strategy: UpstreamStrategy,
 
@@ -159,6 +166,7 @@ impl Default for DnsConfig {
             cache_ttl: default_cache_ttl(),
             dnssec_mode: None,
             dnssec_enabled: None,
+            dnssec_trust_anchor_file: None,
             default_strategy: UpstreamStrategy::Parallel,
             pools: vec![],
             health_check: HealthCheckConfig::default(),

--- a/crates/infrastructure/src/dns/dnssec/mod.rs
+++ b/crates/infrastructure/src/dns/dnssec/mod.rs
@@ -8,7 +8,7 @@ pub mod validator_pool;
 
 pub use cache::{CacheStatsSnapshot, DnssecCache};
 pub use crypto::SignatureVerifier;
-pub use trust_anchor::{TrustAnchor, TrustAnchorStore};
+pub use trust_anchor::{TrustAnchor, TrustAnchorKey, TrustAnchorStore};
 pub use types::{DnskeyRecord, DsRecord, RrsigRecord};
 pub use validation::{ChainVerifier, ValidationResult};
 pub use validator::{DnssecValidator, ValidatedResponse, ValidatorStats};

--- a/crates/infrastructure/src/dns/dnssec/trust_anchor.rs
+++ b/crates/infrastructure/src/dns/dnssec/trust_anchor.rs
@@ -1,34 +1,78 @@
-use super::types::DnskeyRecord;
+use super::crypto::SignatureVerifier;
+use super::types::{DnskeyRecord, DsRecord};
 use base64::{engine::general_purpose::STANDARD, Engine};
+use data_encoding::HEXLOWER_PERMISSIVE;
+use ferrous_dns_domain::DomainError;
+use std::path::Path;
+use std::str::FromStr;
+
+/// DNSKEY REVOKE bit (RFC 5011 §2.1). A revoked key hashes to a different key
+/// tag, so it can never match an anchor — flagging it as "unanchored" would be
+/// pure noise.
+const REVOKE_FLAG: u16 = 0x0080;
+
+/// What a trust anchor pins: the full DNSKEY, or the DS digest of it.
+///
+/// IANA publishes the root anchors as DS records
+/// (<https://data.iana.org/root-anchors/root-anchors.xml>), so that is the form
+/// the embedded set uses. An operator-supplied file may carry either, since
+/// both appear in the wild: `unbound-anchor -a` writes DNSKEY, the
+/// `dns-root-data` package ships DNSKEY (`root.key`) and DS (`root.ds`).
+#[derive(Debug, Clone)]
+pub enum TrustAnchorKey {
+    Dnskey(DnskeyRecord),
+
+    Ds(DsRecord),
+}
 
 #[derive(Debug, Clone)]
 pub struct TrustAnchor {
     pub domain: String,
 
-    pub dnskey: DnskeyRecord,
+    pub key: TrustAnchorKey,
 
     pub description: String,
 }
 
 impl TrustAnchor {
-    pub fn new(domain: String, dnskey: DnskeyRecord, description: String) -> Self {
+    pub fn new(domain: &str, key: TrustAnchorKey, description: String) -> Self {
         Self {
-            domain,
-            dnskey,
+            domain: normalize_domain(domain),
+            key,
             description,
         }
     }
 
+    pub fn key_tag(&self) -> u16 {
+        match &self.key {
+            TrustAnchorKey::Dnskey(dnskey) => dnskey.calculate_key_tag(),
+            TrustAnchorKey::Ds(ds) => ds.key_tag,
+        }
+    }
+
+    pub fn algorithm(&self) -> u8 {
+        match &self.key {
+            TrustAnchorKey::Dnskey(dnskey) => dnskey.algorithm,
+            TrustAnchorKey::Ds(ds) => ds.algorithm,
+        }
+    }
+
+    /// Whether `dnskey` is the key this anchor pins.
+    ///
+    /// A DS anchor recomputes the digest over the candidate key (RFC 4034
+    /// §5.1.4) via the same verifier the delegation walk uses; a digest we
+    /// cannot compute (unsupported type) simply does not match.
     pub fn matches(&self, dnskey: &DnskeyRecord) -> bool {
-        if self.dnskey.calculate_key_tag() != dnskey.calculate_key_tag() {
-            return false;
+        match &self.key {
+            TrustAnchorKey::Dnskey(anchor_key) => {
+                anchor_key.algorithm == dnskey.algorithm
+                    && anchor_key.public_key == dnskey.public_key
+                    && anchor_key.calculate_key_tag() == dnskey.calculate_key_tag()
+            }
+            TrustAnchorKey::Ds(ds) => SignatureVerifier
+                .verify_ds(ds, dnskey, &self.domain)
+                .unwrap_or(false),
         }
-
-        if self.dnskey.algorithm != dnskey.algorithm {
-            return false;
-        }
-
-        self.dnskey.public_key == dnskey.public_key
     }
 }
 
@@ -50,69 +94,102 @@ impl TrustAnchorStore {
         }
     }
 
+    pub fn from_anchors(anchors: Vec<TrustAnchor>) -> Self {
+        Self { anchors }
+    }
+
+    /// Loads anchors from a file in DNS presentation format, replacing (not
+    /// extending) the embedded set — an operator must be able to *remove* an
+    /// anchor, not only add one.
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, DomainError> {
+        let path = path.as_ref();
+        let text = std::fs::read_to_string(path).map_err(|e| {
+            DomainError::ConfigError(format!(
+                "failed to read trust anchor file {}: {e}",
+                path.display()
+            ))
+        })?;
+
+        text.parse()
+    }
+
+    /// The IANA root trust anchors, in DS form exactly as published in
+    /// `root-anchors.xml`.
+    ///
+    /// Both currently-valid anchors ship. KSK-2017 signs the root today;
+    /// KSK-2024 is already published and is scheduled to take over signing on
+    /// 2026-10-11, after which only it can authenticate the root DNSKEY RRset.
+    /// Carrying both means the switchover needs no operator action. The retired
+    /// KSK-2010 (key tag 19036) is deliberately omitted — its `validUntil`
+    /// passed in 2019.
     pub fn default_root_anchors() -> Vec<TrustAnchor> {
-        vec![TrustAnchor::new(
-            ".".to_string(),
-            Self::root_ksk_20326(),
-            "Root KSK-2017 (20326)".to_string(),
-        )]
+        vec![
+            embedded_root_anchor(
+                20326,
+                "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D",
+                "Root KSK-2017 (20326)",
+            ),
+            embedded_root_anchor(
+                38696,
+                "683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16",
+                "Root KSK-2024 (38696)",
+            ),
+        ]
     }
 
-    fn root_ksk_20326() -> DnskeyRecord {
-        let public_key_b64 = concat!(
-            "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3",
-            "+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kv",
-            "ArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF",
-            "0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+e",
-            "oZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfd",
-            "RUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwN",
-            "R1AkUTV74bU="
-        );
-
-        let public_key = STANDARD
-            .decode(public_key_b64)
-            .expect("Failed to decode root KSK public key");
-
-        DnskeyRecord {
-            flags: 257,
-            protocol: 3,
-            algorithm: 8,
-            public_key,
-        }
+    pub fn len(&self) -> usize {
+        self.anchors.len()
     }
 
-    pub fn add_anchor(&mut self, anchor: TrustAnchor) {
-        self.anchors.push(anchor);
+    pub fn is_empty(&self) -> bool {
+        self.anchors.is_empty()
     }
 
-    pub fn is_trusted(&self, dnskey: &DnskeyRecord, domain: &str) -> bool {
-        let normalized_domain = if domain.ends_with('.') {
-            domain.to_string()
-        } else if domain.is_empty() || domain == "." {
-            ".".to_string()
-        } else {
-            format!("{}.", domain)
-        };
+    pub fn iter(&self) -> impl Iterator<Item = &TrustAnchor> {
+        self.anchors.iter()
+    }
 
+    pub fn has_anchor_for(&self, domain: &str) -> bool {
+        let domain = normalize_domain(domain);
+        self.anchors.iter().any(|anchor| anchor.domain == domain)
+    }
+
+    /// The keys of `keys` that some anchor for `domain` pins.
+    ///
+    /// Returns every match rather than the first: during a KSK rollover the zone
+    /// publishes the outgoing and incoming keys side by side for months, and
+    /// either may be the one that actually signed the DNSKEY RRset.
+    pub fn anchor_keys_present<'a>(
+        &self,
+        domain: &str,
+        keys: &'a [DnskeyRecord],
+    ) -> Vec<&'a DnskeyRecord> {
+        let domain = normalize_domain(domain);
+        keys.iter()
+            .filter(|key| self.matches_any(&domain, key))
+            .collect()
+    }
+
+    /// The live key-signing keys of `domain` that no anchor pins — i.e. keys we
+    /// would be unable to validate with if the zone started signing with them.
+    /// Drives the rollover early warning.
+    pub fn unanchored_ksks<'a>(
+        &self,
+        domain: &str,
+        keys: &'a [DnskeyRecord],
+    ) -> Vec<&'a DnskeyRecord> {
+        let domain = normalize_domain(domain);
+        keys.iter()
+            .filter(|key| {
+                key.is_ksk() && key.flags & REVOKE_FLAG == 0 && !self.matches_any(&domain, key)
+            })
+            .collect()
+    }
+
+    fn matches_any(&self, normalized_domain: &str, key: &DnskeyRecord) -> bool {
         self.anchors
             .iter()
-            .any(|anchor| anchor.domain == normalized_domain && anchor.matches(dnskey))
-    }
-
-    pub fn get_anchor(&self, domain: &str) -> Option<&TrustAnchor> {
-        let normalized_domain = if domain.ends_with('.') {
-            domain.to_string()
-        } else {
-            format!("{}.", domain)
-        };
-
-        self.anchors
-            .iter()
-            .find(|anchor| anchor.domain == normalized_domain)
-    }
-
-    pub fn get_all_anchors(&self) -> &[TrustAnchor] {
-        &self.anchors
+            .any(|anchor| anchor.domain == normalized_domain && anchor.matches(key))
     }
 }
 
@@ -120,4 +197,176 @@ impl Default for TrustAnchorStore {
     fn default() -> Self {
         Self::new()
     }
+}
+
+impl FromStr for TrustAnchorStore {
+    type Err = DomainError;
+
+    /// Parses trust anchors in DNS presentation format — the shape written by
+    /// `unbound-anchor -a` and shipped by the `dns-root-data` package. Blank
+    /// lines and `;` comments are ignored; every other line must be a complete
+    /// single-line DS or DNSKEY record.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut anchors = Vec::new();
+
+        for (index, raw_line) in s.lines().enumerate() {
+            let line = raw_line.split(';').next().unwrap_or("").trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let anchor = parse_anchor_line(line).map_err(|e| {
+                DomainError::ConfigError(format!("trust anchor line {}: {e}", index + 1))
+            })?;
+            anchors.push(anchor);
+        }
+
+        if anchors.is_empty() {
+            return Err(DomainError::ConfigError(
+                "trust anchor file contains no DS or DNSKEY record".into(),
+            ));
+        }
+
+        Ok(Self { anchors })
+    }
+}
+
+fn normalize_domain(domain: &str) -> String {
+    let domain = domain.trim();
+
+    if domain.is_empty() || domain == "." {
+        return ".".to_string();
+    }
+
+    if domain.ends_with('.') {
+        domain.to_string()
+    } else {
+        format!("{domain}.")
+    }
+}
+
+fn embedded_root_anchor(key_tag: u16, digest_hex: &str, description: &str) -> TrustAnchor {
+    const ALGORITHM_RSASHA256: u8 = 8;
+    const DIGEST_SHA256: u8 = 2;
+
+    let digest = HEXLOWER_PERMISSIVE
+        .decode(digest_hex.as_bytes())
+        .expect("embedded root trust anchor digest must be valid hex");
+
+    let ds = ds_from_parts(key_tag, ALGORITHM_RSASHA256, DIGEST_SHA256, digest)
+        .expect("embedded root trust anchor must be a valid DS record");
+
+    TrustAnchor::new(".", TrustAnchorKey::Ds(ds), description.to_string())
+}
+
+fn parse_anchor_line(line: &str) -> Result<TrustAnchor, String> {
+    let tokens: Vec<&str> = line
+        .split_whitespace()
+        .filter(|token| *token != "(" && *token != ")")
+        .collect();
+
+    // Everything between the owner name and the type token is an optional TTL
+    // and class, in either order — so locate the type instead of counting.
+    let type_index = tokens
+        .iter()
+        .skip(1)
+        .position(|token| token.eq_ignore_ascii_case("DS") || token.eq_ignore_ascii_case("DNSKEY"))
+        .map(|index| index + 1)
+        .ok_or_else(|| "expected a DS or DNSKEY record".to_string())?;
+
+    let owner = tokens[0];
+    let record_type = tokens[type_index];
+    let rdata = &tokens[type_index + 1..];
+
+    if record_type.eq_ignore_ascii_case("DS") {
+        let (key_tag, algorithm, digest_type) = parse_leading_fields(rdata, "DS")?;
+        let digest = HEXLOWER_PERMISSIVE
+            .decode(rdata[3..].concat().as_bytes())
+            .map_err(|e| format!("invalid DS digest: {e}"))?;
+
+        let ds = ds_from_parts(key_tag, algorithm, digest_type, digest).map_err(record_error)?;
+        let description = format!("{owner} DS {key_tag}");
+
+        Ok(TrustAnchor::new(owner, TrustAnchorKey::Ds(ds), description))
+    } else {
+        let (flags, protocol, algorithm) = parse_leading_fields(rdata, "DNSKEY")?;
+        let public_key = STANDARD
+            .decode(rdata[3..].concat())
+            .map_err(|e| format!("invalid DNSKEY public key: {e}"))?;
+
+        let dnskey =
+            dnskey_from_parts(flags, protocol, algorithm, public_key).map_err(record_error)?;
+        let description = format!("{owner} DNSKEY {}", dnskey.calculate_key_tag());
+
+        Ok(TrustAnchor::new(
+            owner,
+            TrustAnchorKey::Dnskey(dnskey),
+            description,
+        ))
+    }
+}
+
+/// Unwraps the record parser's own message, so a malformed file is not reported
+/// to the operator as an "Invalid DNS response".
+fn record_error(error: DomainError) -> String {
+    match error {
+        DomainError::InvalidDnsResponse(message) => message,
+        other => other.to_string(),
+    }
+}
+
+/// Both record types start with a `u16` followed by two `u8`s (DS: key tag,
+/// algorithm, digest type — DNSKEY: flags, protocol, algorithm), then a single
+/// encoded blob that presentation format may split across whitespace.
+fn parse_leading_fields(rdata: &[&str], record_type: &str) -> Result<(u16, u8, u8), String> {
+    if rdata.len() < 4 {
+        return Err(format!(
+            "{record_type} record has {} fields, expected at least 4",
+            rdata.len()
+        ));
+    }
+
+    let first = rdata[0]
+        .parse::<u16>()
+        .map_err(|e| format!("invalid {record_type} field 1: {e}"))?;
+    let second = rdata[1]
+        .parse::<u8>()
+        .map_err(|e| format!("invalid {record_type} field 2: {e}"))?;
+    let third = rdata[2]
+        .parse::<u8>()
+        .map_err(|e| format!("invalid {record_type} field 3: {e}"))?;
+
+    Ok((first, second, third))
+}
+
+/// Assembles wire-format RDATA and hands it to the record parser, so a
+/// file-sourced anchor gets exactly the validation an on-the-wire record does.
+fn ds_from_parts(
+    key_tag: u16,
+    algorithm: u8,
+    digest_type: u8,
+    digest: Vec<u8>,
+) -> Result<DsRecord, DomainError> {
+    let mut rdata = Vec::with_capacity(4 + digest.len());
+    rdata.extend_from_slice(&key_tag.to_be_bytes());
+    rdata.push(algorithm);
+    rdata.push(digest_type);
+    rdata.extend_from_slice(&digest);
+
+    DsRecord::parse(&rdata)
+}
+
+fn dnskey_from_parts(
+    flags: u16,
+    protocol: u8,
+    algorithm: u8,
+    public_key: Vec<u8>,
+) -> Result<DnskeyRecord, DomainError> {
+    let mut rdata = Vec::with_capacity(4 + public_key.len());
+    rdata.extend_from_slice(&flags.to_be_bytes());
+    rdata.push(protocol);
+    rdata.push(algorithm);
+    rdata.extend_from_slice(&public_key);
+
+    DnskeyRecord::parse(&rdata)
 }

--- a/crates/infrastructure/src/dns/dnssec/validation/chain.rs
+++ b/crates/infrastructure/src/dns/dnssec/validation/chain.rs
@@ -119,6 +119,10 @@ impl ChainVerifier {
         }
     }
 
+    pub fn trust_anchor_count(&self) -> usize {
+        self.trust_store.len()
+    }
+
     pub async fn verify_chain(
         &mut self,
         domain: &str,
@@ -130,7 +134,7 @@ impl ChainVerifier {
             "Starting DNSSEC chain verification"
         );
 
-        if self.trust_store.get_anchor(".").is_none() {
+        if !self.trust_store.has_anchor_for(".") {
             warn!("No root trust anchor configured");
             return Ok(ValidationResult::Indeterminate);
         }
@@ -138,7 +142,7 @@ impl ChainVerifier {
         let labels = Self::split_domain(domain);
         debug!(labels = ?labels, "Domain labels");
 
-        // Turn the configured KSK trust anchor into the full validated root
+        // Turn the configured KSK trust anchors into the full validated root
         // DNSKEY RRset (KSK + ZSK). The bare anchor KSK is not enough: the DS
         // RRset of each TLD is signed by the root *ZSK*, so without the ZSK the
         // first delegation's DS could not be authenticated. Done on every walk —
@@ -668,22 +672,23 @@ impl ChainVerifier {
     }
 
     /// Establishes the validated root DNSKEY RRset (KSK + ZSK) from the
-    /// configured KSK trust anchor, storing it as the keys of the `.` zone.
+    /// configured KSK trust anchors, storing it as the keys of the `.` zone.
     ///
-    /// The trust anchor only pins the root KSK, but the DS RRset of every TLD is
+    /// A trust anchor only pins a root KSK, but the DS RRset of every TLD is
     /// signed by the root *ZSK*. So we fetch the live root DNSKEY RRset, confirm
-    /// it contains the anchor KSK, verify the RRset's self-signature against that
-    /// KSK (RFC 4035 §5.2), and only then trust the whole set — which now
-    /// includes the ZSK needed to authenticate TLD DS records.
+    /// it contains at least one anchored KSK, verify the RRset's self-signature
+    /// against one of them (RFC 4035 §5.2), and only then trust the whole set —
+    /// which now includes the ZSK needed to authenticate TLD DS records.
+    ///
+    /// Every anchored key is tried, not just the first: across a root KSK
+    /// rollover the outgoing and incoming keys are published side by side for
+    /// months, and only one of them signs the RRset at any given moment.
     async fn bootstrap_root_keys(&mut self) -> Result<(), DomainError> {
-        let anchor = match self.trust_store.get_anchor(".") {
-            Some(a) => a.clone(),
-            None => {
-                return Err(DomainError::InvalidDnsResponse(
-                    "No root trust anchor configured".into(),
-                ))
-            }
-        };
+        if !self.trust_store.has_anchor_for(".") {
+            return Err(DomainError::InvalidDnsResponse(
+                "No root trust anchor configured".into(),
+            ));
+        }
 
         let dnskey_result = Self::fetch_dnskey(&self.dnssec_cache, &self.pool_manager, ".").await?;
 
@@ -693,24 +698,27 @@ impl ChainVerifier {
             ));
         }
 
-        // A cache hit was already validated against the anchor on first fetch.
+        // A cache hit was already validated against the anchors on first fetch.
         if dnskey_result.from_cache {
             self.validated_keys
                 .insert(".".to_string(), dnskey_result.keys);
             return Ok(());
         }
 
-        // The configured anchor KSK must be present in the live root RRset.
-        let Some(anchor_key) = dnskey_result
-            .keys
-            .iter()
-            .find(|k| anchor.matches(k))
+        // At least one configured anchor must be present in the live root RRset.
+        let anchor_keys: Vec<DnskeyRecord> = self
+            .trust_store
+            .anchor_keys_present(".", &dnskey_result.keys)
+            .into_iter()
             .cloned()
-        else {
-            return Err(DomainError::InvalidDnsResponse(
-                "Root DNSKEY RRset does not contain the trust anchor".into(),
-            ));
-        };
+            .collect();
+
+        if anchor_keys.is_empty() {
+            return Err(DomainError::InvalidDnsResponse(format!(
+                "Root DNSKEY RRset contains none of the {} configured trust anchors",
+                self.trust_store.len()
+            )));
+        }
 
         if dnskey_result.rrsigs.is_empty() || dnskey_result.raw_records.is_empty() {
             return Err(DomainError::InvalidDnsResponse(
@@ -720,38 +728,63 @@ impl ChainVerifier {
 
         let now = now_secs();
         let mut rrsig_ok = false;
-        for rrsig in &dnskey_result.rrsigs {
-            match self.crypto_verifier.verify_rrsig(
-                rrsig,
-                &anchor_key,
-                ".",
-                &dnskey_result.raw_records,
-                now,
-            ) {
-                Ok(true) => {
-                    rrsig_ok = true;
-                    break;
-                }
-                Ok(false) => {}
-                Err(e) => {
-                    warn!(error = %e, "Root DNSKEY RRSIG verification error");
+        'anchors: for anchor_key in &anchor_keys {
+            for rrsig in &dnskey_result.rrsigs {
+                match self.crypto_verifier.verify_rrsig(
+                    rrsig,
+                    anchor_key,
+                    ".",
+                    &dnskey_result.raw_records,
+                    now,
+                ) {
+                    Ok(true) => {
+                        rrsig_ok = true;
+                        break 'anchors;
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        warn!(error = %e, "Root DNSKEY RRSIG verification error");
+                    }
                 }
             }
         }
 
         if !rrsig_ok {
-            return Err(DomainError::InvalidDnsResponse(
-                "Root DNSKEY self-signature verification failed".into(),
-            ));
+            return Err(DomainError::InvalidDnsResponse(format!(
+                "Root DNSKEY self-signature verification failed against {} anchored key(s)",
+                anchor_keys.len()
+            )));
         }
+
+        self.warn_on_unanchored_root_ksks(&dnskey_result.keys);
 
         self.dnssec_cache
             .cache_dnskey(".", dnskey_result.keys.to_vec(), dnskey_result.ttl);
         self.validated_keys
             .insert(".".to_string(), dnskey_result.keys);
 
-        debug!("Root DNSKEY RRset bootstrapped from trust anchor");
+        debug!(
+            anchored_keys = anchor_keys.len(),
+            "Root DNSKEY RRset bootstrapped from trust anchors"
+        );
         Ok(())
+    }
+
+    /// Early warning for the next root KSK rollover. The root publishes an
+    /// incoming KSK months before it starts signing with it, so a KSK that no
+    /// configured anchor pins is harmless today and fatal the day the root
+    /// switches over. Say so while there is still time to act.
+    ///
+    /// Runs only on a cache miss, so at most once per root DNSKEY TTL (~2 days).
+    fn warn_on_unanchored_root_ksks(&self, keys: &[DnskeyRecord]) {
+        for key in self.trust_store.unanchored_ksks(".", keys) {
+            warn!(
+                key_tag = key.calculate_key_tag(),
+                algorithm = key.algorithm,
+                "Root zone publishes a KSK that no configured trust anchor covers; \
+                 DNSSEC validation will break once the root signs with it — update the trust anchors"
+            );
+        }
     }
 
     pub fn get_zone_keys(&self, zone: &str) -> Option<&Arc<[DnskeyRecord]>> {

--- a/crates/infrastructure/src/dns/dnssec/validator.rs
+++ b/crates/infrastructure/src/dns/dnssec/validator.rs
@@ -272,7 +272,7 @@ impl DnssecValidator {
     pub fn stats(&self) -> ValidatorStats {
         ValidatorStats {
             timeout_ms: self.timeout_ms,
-            trust_anchors_count: 1,
+            trust_anchors_count: self.chain_verifier.trust_anchor_count(),
         }
     }
 

--- a/crates/infrastructure/src/dns/dnssec/validator_pool.rs
+++ b/crates/infrastructure/src/dns/dnssec/validator_pool.rs
@@ -1,4 +1,5 @@
 use super::cache::DnssecCache;
+use super::trust_anchor::TrustAnchorStore;
 use super::validator::{DnssecValidator, ValidatedResponse};
 use crate::dns::load_balancer::PoolManager;
 use ferrous_dns_domain::{DomainError, RecordType};
@@ -13,18 +14,31 @@ pub struct DnssecValidatorPool {
 }
 
 impl DnssecValidatorPool {
-    pub fn new(pool_manager: Arc<PoolManager>, timeout_ms: u64, size: usize) -> Self {
+    pub fn new(
+        pool_manager: Arc<PoolManager>,
+        timeout_ms: u64,
+        size: usize,
+        trust_store: TrustAnchorStore,
+    ) -> Self {
         let cache = Arc::new(DnssecCache::new());
         let validators = (0..size)
             .map(|_| {
                 Mutex::new(
-                    DnssecValidator::with_cache(pool_manager.clone(), cache.clone())
-                        .with_timeout(timeout_ms),
+                    DnssecValidator::with_trust_store_and_cache(
+                        pool_manager.clone(),
+                        trust_store.clone(),
+                        cache.clone(),
+                    )
+                    .with_timeout(timeout_ms),
                 )
             })
             .collect();
 
-        debug!(pool_size = size, "DNSSEC validator pool created");
+        debug!(
+            pool_size = size,
+            trust_anchors = trust_store.len(),
+            "DNSSEC validator pool created"
+        );
 
         Self {
             validators,

--- a/crates/infrastructure/src/dns/resolver/builder.rs
+++ b/crates/infrastructure/src/dns/resolver/builder.rs
@@ -1,4 +1,5 @@
 use super::super::cache::{DnsCache, NegativeQueryTracker};
+use super::super::dnssec::TrustAnchorStore;
 use super::super::load_balancer::PoolManager;
 use super::cache_layer::CachedResolver;
 use super::config::ResolverConfig;
@@ -16,6 +17,7 @@ use tracing::info;
 pub struct ResolverBuilder {
     pool_manager: Arc<PoolManager>,
     dnssec_pool_manager: Option<Arc<PoolManager>>,
+    trust_anchors: Option<TrustAnchorStore>,
     config: ResolverConfig,
     cache: Option<Arc<DnsCache>>,
     local_domain: Option<String>,
@@ -30,6 +32,7 @@ impl ResolverBuilder {
         Self {
             pool_manager,
             dnssec_pool_manager: None,
+            trust_anchors: None,
             config: ResolverConfig::default(),
             cache: None,
             local_domain: None,
@@ -42,6 +45,13 @@ impl ResolverBuilder {
 
     pub fn with_dnssec_pool_manager(mut self, pool_manager: Arc<PoolManager>) -> Self {
         self.dnssec_pool_manager = Some(pool_manager);
+        self
+    }
+
+    /// Overrides the DNSSEC trust anchors. Without this the validator uses the
+    /// IANA root anchors embedded in the binary.
+    pub fn with_trust_anchors(mut self, trust_anchors: TrustAnchorStore) -> Self {
+        self.trust_anchors = Some(trust_anchors);
         self
     }
 
@@ -118,6 +128,7 @@ impl ResolverBuilder {
                 resolver,
                 dnssec_pm,
                 self.config.query_timeout_ms,
+                self.trust_anchors.unwrap_or_default(),
             ));
         }
 

--- a/crates/infrastructure/src/dns/resolver/dnssec_layer.rs
+++ b/crates/infrastructure/src/dns/resolver/dnssec_layer.rs
@@ -1,4 +1,5 @@
 use super::super::dnssec::DnssecValidatorPool;
+use super::super::dnssec::TrustAnchorStore;
 use super::super::load_balancer::PoolManager;
 use async_trait::async_trait;
 use ferrous_dns_application::ports::{DnsResolution, DnsResolver};
@@ -17,6 +18,7 @@ impl DnssecResolver {
         inner: Arc<dyn DnsResolver>,
         pool_manager: Arc<PoolManager>,
         query_timeout_ms: u64,
+        trust_store: TrustAnchorStore,
     ) -> Self {
         let pool_size = std::thread::available_parallelism()
             .map(|n| n.get())
@@ -30,6 +32,7 @@ impl DnssecResolver {
                 pool_manager,
                 query_timeout_ms,
                 pool_size,
+                trust_store,
             )),
         }
     }

--- a/crates/infrastructure/src/dns/resolver/legacy.rs
+++ b/crates/infrastructure/src/dns/resolver/legacy.rs
@@ -1,4 +1,5 @@
 use super::super::cache::DnsCache;
+use super::super::dnssec::TrustAnchorStore;
 use super::super::load_balancer::PoolManager;
 use super::builder::ResolverBuilder;
 use super::config::ResolverConfig;
@@ -20,6 +21,7 @@ pub struct HickoryDnsResolver {
 struct BuilderState {
     pool_manager: Arc<PoolManager>,
     dnssec_pool_manager: Option<Arc<PoolManager>>,
+    trust_anchors: Option<TrustAnchorStore>,
     config: ResolverConfig,
     cache: Option<Arc<DnsCache>>,
     cache_ttl: u32,
@@ -46,6 +48,7 @@ impl HickoryDnsResolver {
         let builder_state = BuilderState {
             pool_manager: pool_manager.clone(),
             dnssec_pool_manager: None,
+            trust_anchors: None,
             config: config.clone(),
             cache: None,
             cache_ttl: DEFAULT_CACHE_TTL,
@@ -68,6 +71,12 @@ impl HickoryDnsResolver {
 
     pub fn with_dnssec_pool_manager(mut self, pool_manager: Arc<PoolManager>) -> Self {
         self.builder_state.dnssec_pool_manager = Some(pool_manager);
+        self.rebuild();
+        self
+    }
+
+    pub fn with_trust_anchors(mut self, trust_anchors: TrustAnchorStore) -> Self {
+        self.builder_state.trust_anchors = Some(trust_anchors);
         self.rebuild();
         self
     }
@@ -133,6 +142,10 @@ impl HickoryDnsResolver {
 
         if let Some(dnssec_pm) = &self.builder_state.dnssec_pool_manager {
             builder = builder.with_dnssec_pool_manager(dnssec_pm.clone());
+        }
+
+        if let Some(trust_anchors) = &self.builder_state.trust_anchors {
+            builder = builder.with_trust_anchors(trust_anchors.clone());
         }
 
         if let Some(cache) = &self.builder_state.cache {

--- a/crates/infrastructure/tests/dnssec_trust_anchor_test.rs
+++ b/crates/infrastructure/tests/dnssec_trust_anchor_test.rs
@@ -1,0 +1,304 @@
+//! Trust anchor parsing, DS matching, and root KSK rollover behaviour.
+//!
+//! The key blobs and digests below are the IANA root anchors verbatim from
+//! <https://data.iana.org/root-anchors/root-anchors.xml>: KSK-2017 (20326),
+//! which signs the root today, and KSK-2024 (38696), which takes over on
+//! 2026-10-11.
+
+use base64::{engine::general_purpose::STANDARD, Engine};
+use ferrous_dns_domain::{RecordType, UpstreamPool, UpstreamStrategy};
+use ferrous_dns_infrastructure::dns::dnssec::{
+    ChainVerifier, DnskeyRecord, DnssecCache, TrustAnchorKey, TrustAnchorStore, ValidationResult,
+};
+use ferrous_dns_infrastructure::dns::{PoolManager, QueryEventEmitter};
+use std::str::FromStr;
+use std::sync::Arc;
+
+const KSK_2017_B64: &str = "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU=";
+const KSK_2024_B64: &str = "AwEAAa96jeuknZlaeSrvyAJj6ZHv28hhOKkx3rLGXVaC6rXTsDc449/cidltpkyGwCJNnOAlFNKF2jBosZBU5eeHspaQWOmOElZsjICMQMC3aeHbGiShvZsx4wMYSjH8e7Vrhbu6irwCzVBApESjbUdpWWmEnhathWu1jo+siFUiRAAxm9qyJNg/wOZqqzL/dL/q8PkcRU5oUKEpUge71M3ej2/7CPqpdVwuMoTvoB+ZOT4YeGyxMvHmbrxlFzGOHOijtzN+u1TQNatX2XBuzZNQ1K+s2CXkPIZo7s6JgZyvaBevYtxPvYLw4z9mR7K2vaF18UYH9Z9GNUUeayffKC73PYc=";
+
+const KSK_2017_DS: &str = "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D";
+const KSK_2024_DS: &str = "683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16";
+
+fn dnskey(flags: u16, key_b64: &str) -> DnskeyRecord {
+    DnskeyRecord {
+        flags,
+        protocol: 3,
+        algorithm: 8,
+        public_key: STANDARD.decode(key_b64).expect("valid base64 key"),
+    }
+}
+
+fn ksk_2017() -> DnskeyRecord {
+    dnskey(257, KSK_2017_B64)
+}
+
+fn ksk_2024() -> DnskeyRecord {
+    dnskey(257, KSK_2024_B64)
+}
+
+/// A root ZSK stand-in: right shape, key material no anchor pins.
+fn root_zsk() -> DnskeyRecord {
+    DnskeyRecord {
+        flags: 256,
+        protocol: 3,
+        algorithm: 8,
+        public_key: vec![0x03, 0x01, 0x00, 0x01, 0xAB, 0xCD],
+    }
+}
+
+fn ds_anchor_store(anchors: &[(u16, &str)]) -> TrustAnchorStore {
+    let text: String = anchors
+        .iter()
+        .map(|(key_tag, digest)| format!(". IN DS {key_tag} 8 2 {digest}\n"))
+        .collect();
+
+    TrustAnchorStore::from_str(&text).expect("valid anchor file")
+}
+
+fn key_tags(keys: &[&DnskeyRecord]) -> Vec<u16> {
+    keys.iter().map(|key| key.calculate_key_tag()).collect()
+}
+
+#[test]
+fn embedded_set_carries_both_current_root_anchors() {
+    let store = TrustAnchorStore::new();
+
+    assert_eq!(store.len(), 2);
+    assert_eq!(
+        store.iter().map(|a| a.key_tag()).collect::<Vec<_>>(),
+        vec![20326, 38696]
+    );
+    assert!(store
+        .iter()
+        .all(|anchor| matches!(anchor.key, TrustAnchorKey::Ds(_))));
+    assert!(store.has_anchor_for("."));
+    assert!(store.has_anchor_for(""));
+}
+
+#[test]
+fn embedded_ds_anchors_match_their_published_keys() {
+    let store = TrustAnchorStore::new();
+    let keys = [ksk_2017(), root_zsk(), ksk_2024()];
+
+    assert_eq!(
+        key_tags(&store.anchor_keys_present(".", &keys)),
+        vec![20326, 38696]
+    );
+}
+
+#[test]
+fn anchors_do_not_cover_a_zone_they_were_not_issued_for() {
+    let store = TrustAnchorStore::new();
+
+    assert!(!store.has_anchor_for("com."));
+    assert!(store.anchor_keys_present("com.", &[ksk_2024()]).is_empty());
+}
+
+/// The failure this whole change exists to prevent: with only the outgoing
+/// anchor configured, the incoming KSK is invisible, so the root DNSKEY RRset
+/// stops being verifiable the moment the root signs with it.
+#[test]
+fn a_single_anchor_covers_only_its_own_key() {
+    let store = ds_anchor_store(&[(20326, KSK_2017_DS)]);
+    let keys = [ksk_2017(), ksk_2024()];
+
+    let matched = store.anchor_keys_present(".", &keys);
+    assert_eq!(key_tags(&matched), vec![20326]);
+}
+
+#[test]
+fn two_anchors_cover_both_keys_across_a_rollover() {
+    let store = ds_anchor_store(&[(20326, KSK_2017_DS), (38696, KSK_2024_DS)]);
+    let keys = [ksk_2017(), root_zsk(), ksk_2024()];
+
+    let matched = store.anchor_keys_present(".", &keys);
+    assert_eq!(key_tags(&matched), vec![20326, 38696]);
+}
+
+#[test]
+fn unanchored_ksks_flags_the_incoming_key_only() {
+    let store = ds_anchor_store(&[(20326, KSK_2017_DS)]);
+    let keys = [ksk_2017(), root_zsk(), ksk_2024()];
+
+    let unanchored = store.unanchored_ksks(".", &keys);
+    assert_eq!(
+        key_tags(&unanchored),
+        vec![38696],
+        "the ZSK must not be reported — only key-signing keys can be anchored"
+    );
+}
+
+#[test]
+fn unanchored_ksks_is_quiet_when_every_ksk_is_anchored() {
+    let store = TrustAnchorStore::new();
+
+    assert!(store
+        .unanchored_ksks(".", &[ksk_2017(), root_zsk(), ksk_2024()])
+        .is_empty());
+}
+
+#[test]
+fn a_revoked_key_is_not_reported_as_unanchored() {
+    let store = ds_anchor_store(&[(38696, KSK_2024_DS)]);
+    let revoked_ksk_2017 = dnskey(257 | 0x0080, KSK_2017_B64);
+
+    assert!(store
+        .unanchored_ksks(".", &[revoked_ksk_2017, ksk_2024()])
+        .is_empty());
+}
+
+#[test]
+fn parses_a_ds_line() {
+    let store =
+        TrustAnchorStore::from_str(&format!(".\t172800\tIN\tDS\t20326 8 2 {KSK_2017_DS}\n"))
+            .unwrap();
+
+    assert_eq!(store.len(), 1);
+    let anchor = store.iter().next().unwrap();
+    assert_eq!(anchor.key_tag(), 20326);
+    assert_eq!(anchor.algorithm(), 8);
+    assert!(anchor.matches(&ksk_2017()));
+    assert!(!anchor.matches(&ksk_2024()));
+}
+
+#[test]
+fn parses_a_dnskey_line_with_a_trailing_comment() {
+    let line = format!(
+        ".\t172800\tIN\tDNSKEY\t257 3 8 {KSK_2017_B64}  ;{{id = 20326 (ksk), size = 2048b}}\n"
+    );
+
+    let store = TrustAnchorStore::from_str(&line).unwrap();
+    let anchor = store.iter().next().unwrap();
+    assert!(matches!(anchor.key, TrustAnchorKey::Dnskey(_)));
+    assert_eq!(anchor.key_tag(), 20326);
+    assert!(anchor.matches(&ksk_2017()));
+    assert!(!anchor.matches(&ksk_2024()));
+}
+
+#[test]
+fn joins_rdata_split_across_whitespace() {
+    let (head, tail) = KSK_2024_DS.split_at(32);
+
+    let store = TrustAnchorStore::from_str(&format!(". IN DS 38696 8 2 {head} {tail}\n")).unwrap();
+    assert!(store.iter().next().unwrap().matches(&ksk_2024()));
+}
+
+#[test]
+fn accepts_a_file_mixing_both_forms_and_ignores_noise() {
+    let text = format!(
+        "; IANA root trust anchors\n\
+         \n\
+         . 172800 IN DS 20326 8 2 {KSK_2017_DS}\n\
+         ; the incoming key, published but not yet signing\n\
+         .\tIN\tDNSKEY\t257 3 8 {KSK_2024_B64}\n"
+    );
+
+    let store = TrustAnchorStore::from_str(&text).unwrap();
+    assert_eq!(store.len(), 2);
+    assert_eq!(
+        key_tags(&store.anchor_keys_present(".", &[ksk_2017(), ksk_2024()])),
+        vec![20326, 38696]
+    );
+}
+
+#[test]
+fn rejects_a_file_without_anchors() {
+    assert!(TrustAnchorStore::from_str("; only a comment\n\n").is_err());
+    assert!(TrustAnchorStore::from_str("").is_err());
+}
+
+#[test]
+fn rejects_a_digest_of_the_wrong_length() {
+    let err = TrustAnchorStore::from_str(". IN DS 20326 8 2 DEADBEEF\n").unwrap_err();
+
+    assert!(
+        err.to_string().contains("line 1"),
+        "the error should name the offending line: {err}"
+    );
+}
+
+#[test]
+fn rejects_an_unsupported_record_type() {
+    assert!(TrustAnchorStore::from_str(". IN A 192.0.2.1\n").is_err());
+}
+
+#[test]
+fn rejects_a_truncated_record() {
+    assert!(TrustAnchorStore::from_str(". IN DS 20326 8\n").is_err());
+}
+
+#[test]
+fn loads_anchors_from_a_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("root.ds");
+    std::fs::write(&path, format!(". IN DS 38696 8 2 {KSK_2024_DS}\n")).unwrap();
+
+    let store = TrustAnchorStore::from_file(&path).unwrap();
+    assert_eq!(store.len(), 1);
+    assert!(store.iter().next().unwrap().matches(&ksk_2024()));
+}
+
+#[test]
+fn reports_a_missing_file_by_path() {
+    let err = TrustAnchorStore::from_file("/nonexistent/ferrous-dns-root.key").unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("/nonexistent/ferrous-dns-root.key"));
+}
+
+async fn live_root_chain_verifier() -> ChainVerifier {
+    let pool = UpstreamPool {
+        name: "live".into(),
+        strategy: UpstreamStrategy::Parallel,
+        priority: 1,
+        servers: vec!["udp://1.1.1.1:53".into()],
+        weight: None,
+    };
+
+    let pool_manager = Arc::new(
+        PoolManager::new(vec![pool], None, QueryEventEmitter::new_disabled())
+            .await
+            .unwrap(),
+    );
+
+    ChainVerifier::new(
+        pool_manager,
+        TrustAnchorStore::new(),
+        Arc::new(DnssecCache::new()),
+    )
+}
+
+/// The real check on the embedded digests: bootstrap the root from them against
+/// the live root DNSKEY RRset. Validating `.` alone stops right after the
+/// bootstrap, so a failure here is about the anchors and nothing else.
+#[tokio::test]
+#[ignore = "live network: hits 1.1.1.1 and the root zone; run with --ignored"]
+async fn live_embedded_anchors_bootstrap_the_root() {
+    let mut verifier = live_root_chain_verifier().await;
+
+    let result = verifier
+        .verify_chain(".", RecordType::DNSKEY)
+        .await
+        .unwrap();
+    assert_eq!(result, ValidationResult::Secure);
+
+    let root_keys = verifier
+        .get_zone_keys(".")
+        .expect("root DNSKEY RRset bootstrapped")
+        .clone();
+
+    // KSK-2024 is published now and takes over signing on 2026-10-11, so its
+    // digest must match a live key or what we ship is wrong. KSK-2017 is
+    // deliberately not asserted — it leaves the RRset once the rollover ends.
+    let ksk_2024_anchor = TrustAnchorStore::default_root_anchors()
+        .into_iter()
+        .find(|anchor| anchor.key_tag() == 38696)
+        .expect("KSK-2024 anchor is embedded");
+
+    assert!(
+        root_keys.iter().any(|key| ksk_2024_anchor.matches(key)),
+        "the embedded KSK-2024 digest matches no live root DNSKEY"
+    );
+}

--- a/docs/configuration/dns.md
+++ b/docs/configuration/dns.md
@@ -25,6 +25,7 @@ local_dns_server = "10.0.0.1:53"
 | `query_timeout` | `3` | Seconds to wait for an upstream response |
 | `default_strategy` | `"Parallel"` | Default strategy for `upstream_servers`: `"Parallel"`, `"Balanced"`, or `"Failover"` |
 | `dnssec_mode` | `"Permissive"` | DNSSEC enforcement: `"Off"`, `"Permissive"`, or `"Strict"` (see [DNSSEC](#dnssec)) |
+| `dnssec_trust_anchor_file` | — | Path to a trust anchor file replacing the embedded IANA root anchors (see [Trust anchors](#trust-anchors)) |
 | `block_private_ptr` | `true` | Block PTR lookups for private/RFC-1918 IP ranges |
 | `block_non_fqdn` | `false` | Block queries for non-fully-qualified domain names |
 | `local_domain` | — | Local domain suffix appended to short hostnames |
@@ -199,6 +200,43 @@ dnssec_mode = "Strict"   # SERVFAIL on Bogus; "Permissive" validates without rej
 
 !!! tip "Backward compatibility"
     The legacy `dnssec_enabled = true/false` flag is still accepted (mapping to `Permissive`/`Off`) when `dnssec_mode` is absent, but `dnssec_mode` is the source of truth.
+
+### Trust anchors {#trust-anchors}
+
+Validation starts from the root key-signing key. Ferrous DNS embeds the IANA root trust anchors (`root-anchors.xml`) in the binary — **both** that are currently valid: KSK-2017 (key tag 20326), which signs the root today, and KSK-2024 (key tag 38696), scheduled to take over signing on **2026-10-11**. Shipping both means the rollover needs no action from you.
+
+To pin your own set instead, point `dnssec_trust_anchor_file` at a file in DNS presentation format:
+
+```toml title="ferrous-dns.toml"
+[dns]
+dnssec_trust_anchor_file = "/etc/ferrous-dns/root.key"
+```
+
+The file takes `DS` and `DNSKEY` records, one per line, with `;` comments — the format written by `unbound-anchor -a /etc/ferrous-dns/root.key` and shipped by the `dns-root-data` package as `root.key` / `root.ds`:
+
+```
+; the two current IANA root anchors, in DS form
+. IN DS 20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D
+. IN DS 38696 8 2 683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16
+```
+
+Behaviour worth knowing:
+
+- The file **replaces** the embedded anchors rather than adding to them, so you can retire an anchor and not only introduce one. List every anchor you want trusted.
+- A configured file that cannot be read or parsed **aborts startup**. Falling back to the embedded set would leave you believing you had replaced the trust root when you had not.
+- The path is read once at startup. It is deliberately not exposed through the REST API or the web UI, and is not part of a configuration backup, since it names a host path.
+- Startup logs the count and the source: `DNSSEC trust anchors loaded count=2 source=embedded`.
+
+!!! warning "Rollover early warning"
+    On every root DNSKEY refresh, Ferrous DNS compares the live root key-signing keys against your anchors and warns about any KSK no anchor covers:
+
+    ```
+    WARN Root zone publishes a KSK that no configured trust anchor covers;
+         DNSSEC validation will break once the root signs with it —
+         update the trust anchors key_tag=38696 algorithm=8
+    ```
+
+    Treat it as urgent: validation keeps working until the root starts signing with that key, and then fails for every signed zone. Automatic RFC 5011 anchor rollover is not implemented yet, so the update is manual — or arrives with a release that refreshes the embedded set.
 
 ---
 

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -64,6 +64,7 @@ upstream_servers = []                   # Fallback upstream DNS servers (used wh
 query_timeout = 3                       # Seconds to wait for an upstream response before timing out
 default_strategy = "Parallel"           # Resolution strategy: "Parallel" (fastest wins) or "Sequential"
 dnssec_mode = "Permissive"              # DNSSEC enforcement: "Off" (no validation), "Permissive" (validate + tag, no SERVFAIL), "Strict" (SERVFAIL on Bogus). Default: Permissive
+# dnssec_trust_anchor_file = "/etc/ferrous-dns/root.key"   # Replaces the embedded IANA root anchors (DS/DNSKEY presentation format). Read at startup; an unreadable file aborts boot
 block_private_ptr = true                # Block PTR lookups for private/RFC-1918 IP ranges
 block_non_fqdn = true                   # Block queries for names that are not fully qualified domain names
 rebinding_protection_enabled = true     # Block responses where a public domain resolves to a private/RFC-1918 IP (DNS rebinding)


### PR DESCRIPTION
## Summary

The embedded DNSSEC trust anchor set was a single hardcoded KSK-2017 DNSKEY (key tag 20326). IANA schedules **2026-10-11** as the day root KSK-2024 (key tag 38696) starts signing and KSK-2017 stops.

`bootstrap_root_keys` requires an RRSIG over the root DNSKEY RRset that verifies against an *anchored* key, so on that date the bootstrap fails and every signed zone becomes `Bogus`. In the default `Permissive` mode that is silent — answers keep flowing with the AD bit clear, DNSSEC quietly stops protecting anything. In `Strict` it is a SERVFAIL for the whole signed internet. There was no override path either, so the only remedy would have been a new release plus an upgrade on every self-hosted install.

### Trust anchors

`TrustAnchor` is now an enum over `Ds` and `Dnskey`, and the embedded set carries **both** currently valid IANA anchors in DS form, matching `root-anchors.xml`. DS matching reuses the existing `SignatureVerifier::verify_ds`, so this adds no new crypto path. The digests were cross-checked against the published `PublicKey` blobs before being embedded.

### Resolver

`bootstrap_root_keys` collects every live root key covered by any anchor and accepts any (key × RRSIG) pair that verifies, instead of binding to the first anchor. That is what makes the rollover a no-op: during the overlap both keys are published and only one of them signs at a time.

`warn_on_unanchored_root_ksks` warns — at most once per root DNSKEY TTL, on cache miss — about a published root KSK that no configured anchor covers. It is the early warning for the rollover *after* this one, since RFC 5011 is not implemented. It fires today on any install still pinned to KSK-2017 alone.

### Configuration

New `[dns] dnssec_trust_anchor_file`: a path to anchors in DNS presentation format (DS and DNSKEY lines, `;` comments, RDATA split across whitespace) — the shape `unbound-anchor -a` writes and `dns-root-data` ships.

- It **replaces** the embedded set rather than merging, so an operator can retire an anchor and not only add one.
- A file that cannot be read or parsed **aborts startup**. Falling back to the embedded set would leave the operator believing they had swapped the trust root when they had not.
- Deliberately boot-only: parsed into `DnsConfig` but absent from the API DTOs, the curated TOML writer and the backup snapshot, since it names a host path and only takes effect on restart. `save_config_to_file` edits in place, so the key survives a `POST /config`.

`ValidatorStats::trust_anchors_count` was the literal `1`; it now reports the real count.

## Related issues

None filed — found while reviewing the DNSSEC validator.

## Test plan

- [x] `make ci` green (fmt-check + clippy `-D warnings` + full test suite), verified by exit code.
- [x] New tests: `crates/infrastructure/tests/dnssec_trust_anchor_test.rs` — 18 unit tests over the parser, DS matching and the rollover cases, plus one `#[ignore]`d live test that bootstraps the real root from the embedded digests (`cargo test -p ferrous-dns-infrastructure --test dnssec_trust_anchor_test -- --ignored`).
- [x] Manual: ran the binary against the live root on a high `-d` port, one run per anchor set.

| Anchor set | Result |
|---|---|
| embedded (both) | Secure, AD bit set — `count=2 source=embedded` |
| file with both anchors | Secure — `count=2 source=<path>` |
| file, KSK-2024 only | **Bogus** — the root does not sign with it yet |
| file, KSK-2017 only | Secure, plus the unanchored-KSK warning naming `key_tag=38696` |
| bogus digest | Bogus in `Permissive`, **SERVFAIL** in `Strict` |
| unparseable file | exit 1: `trust anchor line 1: expected a DS or DNSKEY record` |

The KSK-2024-only row reproduces the October failure today: an anchor set that excludes the key currently signing the root cannot validate — exactly what an unpatched install hits on 2026-10-11. It is correct behaviour per RFC 4035 §5.2, not a regression.

## Known follow-ups / out of scope

- **RFC 5011 automatic rollover** (30-day hold-down, persisted key state, REVOKE handling) is not implemented. The embedded pair plus the warning buys until the KSK after 2024.
- The proposed **RSA→ECDSA root algorithm rollover** (new KSK ~2027, RSA retired ~2029) needs no crypto work here — algorithms 13/14 already verify — only a refreshed anchor set.
- Documentation: new *Trust anchors* section in `docs/configuration/dns.md`, and a commented example in the shipped `ferrous-dns.toml`.
