### PR TITLE
fix(docker): stop the restart loop when the config bind mount is a directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,18 @@ services:
       - NET_BIND_SERVICE
 
     # Must stay writable (not `:ro`): the first-run setup wizard, POST /config from
-    # the dashboard, and backup restore all persist changes back to this file
-    # (TomlConfigFilePersistence writes directly to the path in FERROUS_CONFIG).
+    # The entrypoint bootstraps the bundled default ferrous-dns.toml into
+    # /data/config/ inside this volume on first run, so no host file is required.
+    # To keep the config on the host instead, create ./ferrous-dns.toml FIRST and
+    # chown it to 1000:1000, then uncomment the bind mount below — Docker creates a
+    # root-owned *directory* at any bind-mount source that does not exist yet, which
+    # the non-root container then cannot write. It must also stay writable (no
+    # `:ro`): the setup wizard, POST /config from the dashboard, and backup restore
+    # all persist changes back to this file (TomlConfigFilePersistence writes
+    # directly to the path in FERROUS_CONFIG).
     volumes:
       - ferrous-data:/data
-      - ./ferrous-dns.toml:/data/config/ferrous-dns.toml
+      # - ./ferrous-dns.toml:/data/config/ferrous-dns.toml
 
     environment:
       - FERROUS_CONFIG=/data/config/ferrous-dns.toml

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,19 +6,45 @@
 set -e
 
 SHARE_DIR="/usr/local/share/ferrous-dns"
+CONFIG_PATH="/data/config/ferrous-dns.toml"
+RUN_AS="uid $(id -u), gid $(id -g)"
+
+# Docker creates the source of a bind mount as a root-owned *directory* when the
+# host path does not exist yet, so the config path can be a directory that only
+# looks like a missing file. Copying into it would land the default at
+# .../ferrous-dns.toml/ferrous-dns.toml, or fail outright as the non-root user.
+if [ -d "$CONFIG_PATH" ]; then
+    echo "ERROR: $CONFIG_PATH is a directory, not a file." >&2
+    echo "       Docker created it because the host path of a bind mount did not exist." >&2
+    echo "       On the host: stop the container, remove that directory, and either drop the" >&2
+    echo "       -v <host-path>:$CONFIG_PATH mount (the image bootstraps its own default into" >&2
+    echo "       the /data volume) or create the file first and chown it to 1000:1000." >&2
+    exit 1
+fi
 
 # Bootstrap default config if not present (first run or fresh volume)
-if [ ! -f "/data/config/ferrous-dns.toml" ]; then
-    echo "No config found at /data/config/ferrous-dns.toml — copying default..."
-    mkdir -p /data/config
-    cp "$SHARE_DIR/ferrous-dns.toml" /data/config/ferrous-dns.toml
+if [ ! -f "$CONFIG_PATH" ]; then
+    echo "No config found at $CONFIG_PATH — copying default..."
+    if ! mkdir -p /data/config || ! cp "$SHARE_DIR/ferrous-dns.toml" "$CONFIG_PATH"; then
+        echo "ERROR: could not write $CONFIG_PATH as $RUN_AS." >&2
+        echo "       /data and any mounted config path must be writable by that user;" >&2
+        echo "       chown 1000:1000 them on the host." >&2
+        exit 1
+    fi
+elif [ ! -w "$CONFIG_PATH" ]; then
+    echo "WARNING: $CONFIG_PATH is not writable as $RUN_AS — the setup wizard," >&2
+    echo "         POST /config and backup restore will fail to persist changes." >&2
 fi
 
 # Bootstrap migrations if not present (first run or fresh volume)
 # The app resolves ./migrations relative to WORKDIR (/data)
 if [ ! -d "/data/migrations" ]; then
     echo "No migrations found at /data/migrations — copying bundled migrations..."
-    cp -r "$SHARE_DIR/migrations" /data/migrations
+    if ! cp -r "$SHARE_DIR/migrations" /data/migrations; then
+        echo "ERROR: could not create /data/migrations as $RUN_AS." >&2
+        echo "       The /data volume must be writable by that user." >&2
+        exit 1
+    fi
 fi
 
 # Initialize args array

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,14 +18,13 @@ docker run -d \
   --user 1000:1000 \
   -e TZ=America/Sao_Paulo \
   -e FERROUS_CONFIG=/data/config/ferrous-dns.toml \
-  -v /path/to/ferrous-dns.toml:/data/config/ferrous-dns.toml \
   -v ferrous-data:/data/ \
   --dns 10.0.0.1 \
   --cap-add NET_BIND_SERVICE \
   ferrousnetworking/ferrous-dns:latest
 ```
 
-Ports, bind address, database path, and log level are all set inside the mounted `ferrous-dns.toml`, and can be overridden with the `FERROUS_*` environment variables below — the Docker image's entrypoint script translates them into the matching CLI flags at startup. The bind mount must stay writable (no `:ro`): the first-run setup wizard, `POST /config` from the dashboard, and backup restore all persist changes back to this file.
+No host config file is needed to start: on first run the entrypoint copies the bundled default `ferrous-dns.toml` into `/data/config/` inside the `ferrous-data` volume. Ports, bind address, database path, and log level are all set inside that file, and can be overridden with the `FERROUS_*` environment variables below — the Docker image's entrypoint script translates them into the matching CLI flags at startup.
 
 #### Environment Variables
 
@@ -42,6 +41,25 @@ Access the dashboard at `http://localhost:8080`
 
 !!! note "Network mode"
     `--network host` is required so Ferrous DNS can bind to port 53 and detect client IPs/MACs correctly. It is also required for **mDNS device discovery** (`mdns_enabled`): multicast on UDP 5353 does not traverse Docker bridge port mapping, so the listener only works in host mode. On macOS, host networking is not available in Docker Desktop — use a Linux VM or Docker Compose with explicit port mappings.
+
+#### Keeping the config file on the host (optional)
+
+Editing `ferrous-dns.toml` by hand is easier when the file lives on the host rather than inside the volume. Bind-mounting it takes two extra steps, both mandatory:
+
+```bash
+curl -fsSL -o ferrous-dns.toml \
+  https://raw.githubusercontent.com/ferrous-networking/ferrous-dns/main/ferrous-dns.toml
+chown 1000:1000 ferrous-dns.toml
+```
+
+Only then add the mount:
+
+```bash
+  -v "$PWD/ferrous-dns.toml:/data/config/ferrous-dns.toml" \
+```
+
+!!! warning "Create the file before mounting it"
+    Docker creates the source of a bind mount as a **root-owned directory** when the host path does not exist. Mounting a path you have not created yet therefore puts a directory at `/data/config/ferrous-dns.toml`, and the container — which runs as uid 1000 — cannot write it, so it exits and `--restart always` turns that into a restart loop. Keep the mount writable too (no `:ro`): the first-run setup wizard, `POST /config` from the dashboard, and backup restore all persist changes back to this file.
 
 ---
 
@@ -65,12 +83,13 @@ services:
     cap_add:
       - NET_BIND_SERVICE
     volumes:
-      - ./ferrous-dns.toml:/data/config/ferrous-dns.toml
       - ferrous-data:/data/
 
 volumes:
   ferrous-data:
 ```
+
+To keep the config on the host, follow [Keeping the config file on the host](#keeping-the-config-file-on-the-host-optional) first, then add `- ./ferrous-dns.toml:/data/config/ferrous-dns.toml` to `volumes:`.
 
 Then start it:
 
@@ -150,7 +169,6 @@ Docker Desktop — use explicit port mappings instead of `--network host`:
 docker run -d --name ferrous-dns --restart always \
   -p 53:53/udp -p 53:53/tcp -p 8080:8080 \
   -e FERROUS_CONFIG=/data/config/ferrous-dns.toml \
-  -v /path/to/ferrous-dns.toml:/data/config/ferrous-dns.toml \
   -v ferrous-data:/data/ \
   ferrousnetworking/ferrous-dns:latest
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -290,6 +290,42 @@ UDP DNS is not affected — PROXY Protocol only applies to TCP and DoT listeners
 
 ---
 
+## Docker Container Restart Loop on Startup
+
+### Symptom
+
+The container never finishes booting and `docker logs` repeats:
+
+```text
+No config found at /data/config/ferrous-dns.toml — copying default...
+cp: can't create '/data/config/ferrous-dns.toml/ferrous-dns.toml': Permission denied
+```
+
+### Cause
+
+The doubled path is the tell: `/data/config/ferrous-dns.toml` is a **directory**, so `cp` wrote *into* it. Docker creates the source of a bind mount as a root-owned directory whenever the host path does not exist yet, so a mount like `-v ./ferrous-dns.toml:/data/config/ferrous-dns.toml` pointing at a file you never created produces a directory the container cannot write — it runs as uid 1000. The entrypoint exits, and `restart: always` turns that into a loop.
+
+### Solution
+
+Stop the container, remove the directory Docker created, and drop the bind mount — the image bootstraps its own default config into the `/data` volume:
+
+```bash
+docker compose down          # or: docker rm -f ferrous-dns
+rm -rf ./ferrous-dns.toml    # the directory Docker created, not a real config
+```
+
+To keep the config on the host instead, create the file and give it to uid 1000 **before** starting the container:
+
+```bash
+curl -fsSL -o ferrous-dns.toml \
+  https://raw.githubusercontent.com/ferrous-networking/ferrous-dns/main/ferrous-dns.toml
+chown 1000:1000 ferrous-dns.toml
+```
+
+The same applies to a config that is owned by another user: the mount must be writable by uid 1000 (and not `:ro`), or the setup wizard, `POST /config` and backup restore cannot persist changes.
+
+---
+
 ## Docker Networking Issues
 
 ### Host network mode (recommended)


### PR DESCRIPTION
Closes #195

## Summary

Fixes the boot loop reported in #195, where the container repeats:

```text
No config found at /data/config/ferrous-dns.toml — copying default...
cp: can't create '/data/config/ferrous-dns.toml/ferrous-dns.toml': Permission denied
```

The doubled path is the tell: `/data/config/ferrous-dns.toml` is a **directory**. Docker creates the source of a bind mount as a root-owned directory when the host path does not exist, and the installation docs told users to mount `-v /path/to/ferrous-dns.toml:/data/config/ferrous-dns.toml` without ever telling them to create that file first. The entrypoint's `-f` test then read the directory as a missing file, `cp` wrote *into* it, and the non-root `ferrous` user (uid 1000) could not create there — `set -e` killed the entrypoint and `restart: always` did the rest.

It was latent until 9fb3d26 switched the documented examples from `--user root` to `--user 1000:1000`: as root the same `cp` succeeded, silently produced the nested file, and the server started on defaults, so nobody saw it.

- **`docker/entrypoint.sh`** — rejects a directory at the config path with an actionable message instead of dying on `Permission denied`; both bootstrap copies now check their own result rather than relying on `set -e`, and report the actual uid/gid; an existing but non-writable config raises a warning, since that is what breaks the setup wizard and `POST /config` later.
- **`docker-compose.yml`** — the `./ferrous-dns.toml` bind mount is commented out of the default path. The `ferrous-data:/data` volume is enough: the entrypoint bootstraps the bundled default with the right owner.
- **`docs/getting-started/installation.md`** — the docker run, Compose and WSL2 examples no longer mount a file the user has not created. The bind mount becomes an optional section with the mandatory `curl` + `chown 1000:1000` steps.
- **`docs/troubleshooting.md`** — new entry for the exact error, its cause and the workaround.

No Rust code is touched.

## Test plan

Ran the patched entrypoint in an `alpine:3.22` container as `--user 1000:1000` against a faked `/data` and share dir:

- [x] Directory at the config path (reproduces #195) → clear error, exit 1, no doubled path
- [x] Fresh empty volume → config and migrations bootstrapped as 1000:1000, reaches `exec`
- [x] Config present but mode 444 → warning, startup continues
- [x] `/data` not writable → explicit error naming the uid/gid, exit 1
- [x] `sh -n docker/entrypoint.sh` clean
- [x] `docker compose config` valid
