### PR TITLE
feat(cache): add a cache control page listing every cached entry

### DIFF
--- a/crates/api/src/dto/cache.rs
+++ b/crates/api/src/dto/cache.rs
@@ -36,3 +36,70 @@ pub struct CacheMetricsResponse {
     pub hit_rate: f64,
     pub transient_upstream_errors: u64,
 }
+
+#[derive(Deserialize, Debug, IntoParams)]
+pub struct CacheEntriesQuery {
+    #[serde(default = "default_entries_limit")]
+    pub limit: u32,
+    #[serde(default)]
+    pub offset: u32,
+    /// Case-insensitive substring match on the cached domain.
+    pub domain: Option<String>,
+    /// Record type name, e.g. `A`, `AAAA`, `CNAME`.
+    #[serde(rename = "type")]
+    pub record_type: Option<String>,
+    /// One of `hits`, `cached_at`, `expires_at`, `domain`, `type`.
+    /// Defaults to `cached_at`.
+    pub sort: Option<String>,
+    /// `asc` or `desc`. Defaults to `desc`.
+    pub order: Option<String>,
+}
+
+fn default_entries_limit() -> u32 {
+    25
+}
+
+#[derive(Deserialize, Debug, IntoParams)]
+pub struct DeleteCacheEntryQuery {
+    pub domain: String,
+    #[serde(rename = "type")]
+    pub record_type: String,
+}
+
+#[derive(Serialize, Debug, Clone, ToSchema)]
+pub struct CacheEntryResponse {
+    pub domain: String,
+    #[serde(rename = "type")]
+    #[schema(value_type = String)]
+    pub record_type: &'static str,
+    /// Addresses for A/AAAA entries; empty for every other record type.
+    pub answers: Vec<String>,
+    pub canonical_name: Option<String>,
+    #[schema(value_type = Option<String>)]
+    pub dnssec_status: Option<&'static str>,
+    pub ttl: u32,
+    /// Seconds left before expiry; `null` for permanent entries.
+    pub remaining_ttl: Option<u32>,
+    /// Unix epoch seconds when the entry was inserted.
+    pub cached_at: u64,
+    /// Unix epoch seconds when the entry expires; `null` for permanent entries.
+    pub expires_at: Option<u64>,
+    /// Hits served from the shared cache. Lookups absorbed by the per-thread
+    /// L1 cache are not counted here.
+    pub hits: u64,
+    pub last_access: u64,
+    pub permanent: bool,
+    /// Past its TTL but still served within the stale grace period.
+    pub stale: bool,
+}
+
+#[derive(Serialize, Debug, ToSchema)]
+pub struct PaginatedCacheEntries {
+    pub data: Vec<CacheEntryResponse>,
+    /// Entries matching the applied filters.
+    pub total: usize,
+    /// Entries in the cache, ignoring the filters.
+    pub records_total: usize,
+    pub limit: u32,
+    pub offset: u32,
+}

--- a/crates/api/src/dto/mod.rs
+++ b/crates/api/src/dto/mod.rs
@@ -44,7 +44,10 @@ pub use blocklist::{BlocklistQuery, BlocklistResponse, PaginatedBlocklist};
 pub use blocklist_source::{
     BlocklistSourceResponse, CreateBlocklistSourceRequest, UpdateBlocklistSourceRequest,
 };
-pub use cache::{CacheMetricsResponse, CacheStatsQuery, CacheStatsResponse};
+pub use cache::{
+    CacheEntriesQuery, CacheEntryResponse, CacheMetricsResponse, CacheStatsQuery,
+    CacheStatsResponse, DeleteCacheEntryQuery, PaginatedCacheEntries,
+};
 pub use client::{ClientResponse, ClientStatsResponse, ClientsQuery, UpdateClientRequest};
 pub use client_subnet::{
     ClientSubnetResponse, CreateClientSubnetRequest, CreateManualClientRequest,

--- a/crates/api/src/handlers/cache.rs
+++ b/crates/api/src/handlers/cache.rs
@@ -1,14 +1,23 @@
 use crate::{
-    dto::{CacheMetricsResponse, CacheStatsQuery, CacheStatsResponse},
+    dto::{
+        CacheEntriesQuery, CacheEntryResponse, CacheMetricsResponse, CacheStatsQuery,
+        CacheStatsResponse, DeleteCacheEntryQuery, PaginatedCacheEntries,
+    },
     errors::ApiError,
     state::AppState,
     utils::{parse_period, validate_period},
 };
 use axum::{
     extract::{Query, State},
+    http::StatusCode,
     Json,
 };
+use ferrous_dns_application::ports::{CacheEntryQuery, CacheEntrySnapshot};
+use ferrous_dns_domain::{DomainError, RecordType};
 use tracing::{debug, instrument};
+
+/// Upper bound on how many cache entries a single listing request may return.
+const MAX_CACHE_ENTRIES_LIMIT: u32 = 500;
 
 #[utoipa::path(
     get,
@@ -94,4 +103,119 @@ pub async fn get_cache_metrics(State(state): State<AppState>) -> Json<CacheMetri
         hit_rate: snapshot.hit_rate,
         transient_upstream_errors: snapshot.transient_upstream_errors,
     })
+}
+
+#[utoipa::path(
+    get,
+    path = "/cache/entries",
+    tag = "cache",
+    params(CacheEntriesQuery),
+    responses(
+        (status = 200, description = "Cached DNS entries", body = PaginatedCacheEntries),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
+#[instrument(skip(state), name = "api_get_cache_entries")]
+pub async fn get_cache_entries(
+    State(state): State<AppState>,
+    Query(params): Query<CacheEntriesQuery>,
+) -> Json<PaginatedCacheEntries> {
+    let limit = params.limit.clamp(1, MAX_CACHE_ENTRIES_LIMIT);
+
+    let query = CacheEntryQuery {
+        domain: params.domain.filter(|domain| !domain.is_empty()),
+        record_type: params
+            .record_type
+            .as_deref()
+            .and_then(|value| value.parse::<RecordType>().ok()),
+        sort: params
+            .sort
+            .as_deref()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or_default(),
+        order: params
+            .order
+            .as_deref()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or_default(),
+        limit: limit as usize,
+        offset: params.offset as usize,
+    };
+
+    let page = state.dns.cache.list_entries(&query);
+
+    debug!(
+        returned = page.entries.len(),
+        total = page.total,
+        records_total = page.records_total,
+        "Cache entries listed"
+    );
+
+    Json(PaginatedCacheEntries {
+        data: page.entries.iter().map(to_entry_response).collect(),
+        total: page.total,
+        records_total: page.records_total,
+        limit,
+        offset: params.offset,
+    })
+}
+
+#[utoipa::path(
+    delete,
+    path = "/cache/entries",
+    tag = "cache",
+    params(DeleteCacheEntryQuery),
+    responses(
+        (status = 204, description = "Cache entry removed"),
+        (status = 400, description = "Unknown record type"),
+        (status = 404, description = "Cache entry not found"),
+    ),
+    security(("session_cookie" = []), ("api_key" = [])),
+)]
+#[instrument(skip(state), name = "api_delete_cache_entry")]
+pub async fn delete_cache_entry(
+    State(state): State<AppState>,
+    Query(params): Query<DeleteCacheEntryQuery>,
+) -> Result<StatusCode, ApiError> {
+    let record_type = params.record_type.parse::<RecordType>().map_err(|_| {
+        DomainError::InvalidInput(format!("unknown record type: {}", params.record_type))
+    })?;
+
+    if !state.dns.cache.remove_record(&params.domain, &record_type) {
+        return Err(ApiError(DomainError::NotFound(format!(
+            "cache entry {} {}",
+            params.domain,
+            record_type.as_str()
+        ))));
+    }
+
+    debug!(domain = %params.domain, record_type = %record_type, "Cache entry removed");
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn to_entry_response(entry: &CacheEntrySnapshot) -> CacheEntryResponse {
+    CacheEntryResponse {
+        domain: entry.domain.clone(),
+        record_type: entry.record_type.as_str(),
+        answers: entry
+            .answers
+            .iter()
+            .map(|address| address.to_string())
+            .collect(),
+        canonical_name: entry.canonical_name.clone(),
+        dnssec_status: entry.dnssec_status.map(|status| status.as_str()),
+        ttl: entry.ttl,
+        remaining_ttl: entry.remaining_ttl,
+        cached_at: entry.cached_at_secs,
+        expires_at: if entry.is_permanent {
+            None
+        } else {
+            Some(entry.expires_at_secs)
+        },
+        hits: entry.hits,
+        last_access: entry.last_access_secs,
+        permanent: entry.is_permanent,
+        stale: entry.is_stale,
+    }
 }

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -148,6 +148,8 @@ impl Modify for SecurityAddon {
         // cache
         dto::CacheStatsResponse,
         dto::CacheMetricsResponse,
+        dto::CacheEntryResponse,
+        dto::PaginatedCacheEntries,
         // clients
         dto::ClientResponse,
         dto::ClientStatsResponse,

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -37,6 +37,10 @@ pub fn create_api_router_with_openapi(state: AppState) -> (Router, utoipa::opena
         .routes(routes!(handlers::cache::get_cache_stats))
         .routes(routes!(handlers::cache::get_cache_metrics))
         .routes(routes!(
+            handlers::cache::get_cache_entries,
+            handlers::cache::delete_cache_entry
+        ))
+        .routes(routes!(
             handlers::config::get::get_config,
             handlers::config::update::update_config
         ))

--- a/crates/api/tests/cache_entries_api_tests.rs
+++ b/crates/api/tests/cache_entries_api_tests.rs
@@ -1,0 +1,829 @@
+//! Tests for the `GET`/`DELETE /cache/entries` admin endpoints.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    Router,
+};
+use ferrous_dns_api::{
+    create_api_routes, AppState, BlockingUseCases, ClientUseCases, DnsUseCases, GroupUseCases,
+    QueryUseCases, SafeSearchUseCases, ScheduleUseCases, ServiceUseCases,
+};
+use ferrous_dns_application::{
+    ports::{
+        BlockFilterEnginePort, BlockedServiceRepository, ConfigRepository, FilterDecision,
+        SafeSearchConfigRepository, SafeSearchEnginePort, ServiceCatalogPort,
+    },
+    use_cases::{
+        AssignScheduleProfileUseCase, CreateLocalRecordUseCase, CreateScheduleProfileUseCase,
+        DeleteLocalRecordUseCase, DeleteSafeSearchConfigsUseCase, DeleteScheduleProfileUseCase,
+        GetBlockFilterStatsUseCase, GetBlocklistUseCase, GetClientsUseCase, GetQueryStatsUseCase,
+        GetRecentQueriesUseCase, GetSafeSearchConfigsUseCase, GetScheduleProfilesUseCase,
+        ManageTimeSlotsUseCase, ToggleSafeSearchUseCase, UpdateLocalRecordUseCase,
+        UpdateScheduleProfileUseCase,
+    },
+};
+use ferrous_dns_domain::{config::DatabaseConfig, Config, RecordType};
+use ferrous_dns_infrastructure::{
+    dns::cache::coarse_clock,
+    dns::{CachedAddresses, CachedData, DnsCache},
+    repositories::{
+        client_repository::SqliteClientRepository, query_log_repository::SqliteQueryLogRepository,
+        regex_filter_repository::SqliteRegexFilterRepository,
+    },
+};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use sqlx::sqlite::SqlitePoolOptions;
+use std::net::IpAddr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+mod helpers;
+
+struct NullBlockFilterEngine;
+
+#[async_trait::async_trait]
+impl BlockFilterEnginePort for NullBlockFilterEngine {
+    fn resolve_group(&self, _ip: std::net::IpAddr) -> i64 {
+        1
+    }
+    fn check(&self, _domain: &str, _group_id: i64) -> FilterDecision {
+        FilterDecision::Allow
+    }
+    async fn reload(&self) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+    async fn load_client_groups(&self) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+    fn compiled_domain_count(&self) -> usize {
+        0
+    }
+    fn store_cname_decision(&self, _domain: &str, _group_id: i64, _ttl_secs: u64) {}
+    fn is_blocking_enabled(&self) -> bool {
+        true
+    }
+    fn set_blocking_enabled(&self, _enabled: bool) {}
+}
+
+struct NullBlockedServiceRepository;
+
+#[async_trait::async_trait]
+impl BlockedServiceRepository for NullBlockedServiceRepository {
+    async fn block_service(
+        &self,
+        _service_id: &str,
+        _group_id: i64,
+    ) -> Result<ferrous_dns_domain::BlockedService, ferrous_dns_domain::DomainError> {
+        unimplemented!()
+    }
+    async fn unblock_service(
+        &self,
+        _service_id: &str,
+        _group_id: i64,
+    ) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+    async fn get_blocked_for_group(
+        &self,
+        _group_id: i64,
+    ) -> Result<Vec<ferrous_dns_domain::BlockedService>, ferrous_dns_domain::DomainError> {
+        Ok(vec![])
+    }
+    async fn get_all_blocked(
+        &self,
+    ) -> Result<Vec<ferrous_dns_domain::BlockedService>, ferrous_dns_domain::DomainError> {
+        Ok(vec![])
+    }
+    async fn delete_all_for_service(
+        &self,
+        _service_id: &str,
+    ) -> Result<u64, ferrous_dns_domain::DomainError> {
+        Ok(0)
+    }
+}
+
+struct NullCustomServiceRepository;
+
+#[async_trait::async_trait]
+impl ferrous_dns_application::ports::CustomServiceRepository for NullCustomServiceRepository {
+    async fn create(
+        &self,
+        _service_id: &str,
+        _name: &str,
+        _category_name: &str,
+        _domains: &[String],
+    ) -> Result<ferrous_dns_domain::CustomService, ferrous_dns_domain::DomainError> {
+        unimplemented!()
+    }
+    async fn get_by_service_id(
+        &self,
+        _service_id: &str,
+    ) -> Result<Option<ferrous_dns_domain::CustomService>, ferrous_dns_domain::DomainError> {
+        Ok(None)
+    }
+    async fn get_all(
+        &self,
+    ) -> Result<Vec<ferrous_dns_domain::CustomService>, ferrous_dns_domain::DomainError> {
+        Ok(vec![])
+    }
+    async fn update(
+        &self,
+        _service_id: &str,
+        _name: Option<String>,
+        _category_name: Option<String>,
+        _domains: Option<Vec<String>>,
+    ) -> Result<ferrous_dns_domain::CustomService, ferrous_dns_domain::DomainError> {
+        unimplemented!()
+    }
+    async fn delete(&self, _service_id: &str) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+}
+
+struct NullServiceCatalog;
+
+impl ServiceCatalogPort for NullServiceCatalog {
+    fn get_by_id(&self, _id: &str) -> Option<ferrous_dns_domain::ServiceDefinition> {
+        None
+    }
+    fn all(&self) -> Vec<ferrous_dns_domain::ServiceDefinition> {
+        vec![]
+    }
+    fn normalized_rules_for(&self, _service_id: &str) -> Vec<String> {
+        vec![]
+    }
+    fn reload_custom(&self, _custom: Vec<ferrous_dns_domain::ServiceDefinition>) {}
+}
+
+struct NullConfigRepository;
+
+#[async_trait::async_trait]
+impl ConfigRepository for NullConfigRepository {
+    async fn save_local_records(
+        &self,
+        _config: &Config,
+    ) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+}
+
+struct NullSafeSearchConfigRepository;
+
+#[async_trait::async_trait]
+impl SafeSearchConfigRepository for NullSafeSearchConfigRepository {
+    async fn get_all(
+        &self,
+    ) -> Result<Vec<ferrous_dns_domain::SafeSearchConfig>, ferrous_dns_domain::DomainError> {
+        Ok(vec![])
+    }
+    async fn get_by_group(
+        &self,
+        _group_id: i64,
+    ) -> Result<Vec<ferrous_dns_domain::SafeSearchConfig>, ferrous_dns_domain::DomainError> {
+        Ok(vec![])
+    }
+    async fn upsert(
+        &self,
+        _group_id: i64,
+        _engine: ferrous_dns_domain::SafeSearchEngine,
+        _enabled: bool,
+        _youtube_mode: ferrous_dns_domain::YouTubeMode,
+    ) -> Result<ferrous_dns_domain::SafeSearchConfig, ferrous_dns_domain::DomainError> {
+        unimplemented!()
+    }
+    async fn delete_by_group(&self, _group_id: i64) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+}
+
+struct NullSafeSearchEnginePort;
+
+#[async_trait::async_trait]
+impl SafeSearchEnginePort for NullSafeSearchEnginePort {
+    fn cname_for(&self, _domain: &str, _group_id: i64) -> Option<&'static str> {
+        None
+    }
+    async fn reload(&self) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+}
+
+struct NullScheduleProfileRepository;
+
+#[async_trait::async_trait]
+impl ferrous_dns_application::ports::ScheduleProfileRepository for NullScheduleProfileRepository {
+    async fn create(
+        &self,
+        _name: String,
+        _tz: String,
+        _comment: Option<String>,
+    ) -> Result<ferrous_dns_domain::ScheduleProfile, ferrous_dns_domain::DomainError> {
+        unimplemented!()
+    }
+    async fn get_by_id(
+        &self,
+        _id: i64,
+    ) -> Result<Option<ferrous_dns_domain::ScheduleProfile>, ferrous_dns_domain::DomainError> {
+        Ok(None)
+    }
+    async fn get_all(
+        &self,
+    ) -> Result<Vec<ferrous_dns_domain::ScheduleProfile>, ferrous_dns_domain::DomainError> {
+        Ok(vec![])
+    }
+    async fn update(
+        &self,
+        _id: i64,
+        _name: Option<String>,
+        _tz: Option<String>,
+        _comment: Option<String>,
+    ) -> Result<ferrous_dns_domain::ScheduleProfile, ferrous_dns_domain::DomainError> {
+        unimplemented!()
+    }
+    async fn delete(&self, _id: i64) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+    async fn get_slots(
+        &self,
+        _profile_id: i64,
+    ) -> Result<Vec<ferrous_dns_domain::TimeSlot>, ferrous_dns_domain::DomainError> {
+        Ok(vec![])
+    }
+    async fn add_slot(
+        &self,
+        _pid: i64,
+        _days: u8,
+        _start: String,
+        _end: String,
+        _action: ferrous_dns_domain::ScheduleAction,
+    ) -> Result<ferrous_dns_domain::TimeSlot, ferrous_dns_domain::DomainError> {
+        unimplemented!()
+    }
+    async fn delete_slot(&self, _slot_id: i64) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+    async fn assign_to_group(
+        &self,
+        _group_id: i64,
+        _profile_id: i64,
+    ) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+    async fn unassign_from_group(
+        &self,
+        _group_id: i64,
+    ) -> Result<(), ferrous_dns_domain::DomainError> {
+        Ok(())
+    }
+    async fn get_group_assignment(
+        &self,
+        _group_id: i64,
+    ) -> Result<Option<i64>, ferrous_dns_domain::DomainError> {
+        Ok(None)
+    }
+    async fn get_all_group_assignments(
+        &self,
+    ) -> Result<Vec<(i64, i64)>, ferrous_dns_domain::DomainError> {
+        Ok(vec![])
+    }
+}
+
+async fn create_test_db() -> sqlx::SqlitePool {
+    let pool = SqlitePoolOptions::new()
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+
+    sqlx::query(
+        r#"
+        CREATE TABLE groups (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            enabled BOOLEAN NOT NULL DEFAULT 1,
+            comment TEXT,
+            is_default BOOLEAN NOT NULL DEFAULT 0,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r#"
+        CREATE TABLE clients (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ip_address TEXT NOT NULL UNIQUE,
+            mac_address TEXT,
+            hostname TEXT,
+            first_seen DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            last_seen DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            query_count INTEGER NOT NULL DEFAULT 0,
+            last_mac_update DATETIME,
+            last_hostname_update DATETIME,
+            group_id INTEGER NOT NULL DEFAULT 1 REFERENCES groups(id) ON DELETE RESTRICT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r#"
+        CREATE TABLE query_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            domain TEXT NOT NULL,
+            record_type TEXT NOT NULL DEFAULT 'A',
+            client_ip TEXT NOT NULL DEFAULT '127.0.0.1',
+            blocked INTEGER NOT NULL DEFAULT 0,
+            response_time_ms INTEGER,
+            cache_hit INTEGER NOT NULL DEFAULT 0,
+            cache_refresh INTEGER NOT NULL DEFAULT 0,
+            dnssec_status TEXT,
+            dns64_synthesized INTEGER NOT NULL DEFAULT 0,
+            answers TEXT,
+            upstream_server TEXT,
+            upstream_pool TEXT,
+            response_status TEXT,
+            query_source TEXT NOT NULL DEFAULT 'client',
+            group_id INTEGER,
+            block_source TEXT,
+            created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    pool
+}
+
+/// Builds the API router together with the live cache behind it, so a test can
+/// seed entries and then assert on what the endpoints report.
+async fn create_test_app(pool: sqlx::SqlitePool) -> (Router, Arc<DnsCache>) {
+    let client_repo = Arc::new(SqliteClientRepository::new(
+        pool.clone(),
+        &DatabaseConfig::default(),
+    ));
+    let group_repo = Arc::new(
+        ferrous_dns_infrastructure::repositories::group_repository::SqliteGroupRepository::new(
+            pool.clone(),
+        ),
+    );
+    let regex_filter_repo = Arc::new(SqliteRegexFilterRepository::new(pool.clone()));
+    let query_log_repo = Arc::new(SqliteQueryLogRepository::new(
+        pool.clone(),
+        pool.clone(),
+        pool.clone(),
+        &DatabaseConfig::default(),
+    ));
+
+    let config = Arc::new(RwLock::new(Config::default()));
+    // `max_entries` must be non-zero: with 0 every insert immediately flags the
+    // cache for eviction and the seeded entries would not survive.
+    let cache = Arc::new(DnsCache::new(
+        ferrous_dns_infrastructure::dns::DnsCacheConfig {
+            max_entries: 1000,
+            eviction_strategy: ferrous_dns_infrastructure::dns::EvictionStrategy::LRU,
+            min_threshold: 0.0,
+            refresh_threshold: 0.0,
+            batch_eviction_percentage: 0.0,
+            adaptive_thresholds: false,
+            min_frequency: 0,
+            min_lfuk_score: 0.0,
+            shard_amount: 4,
+            access_window_secs: 7200,
+            eviction_sample_size: 8,
+            lfuk_k_value: 0.5,
+            refresh_sample_rate: 1.0,
+            min_ttl: 0,
+            max_ttl: 86_400,
+        },
+    ));
+
+    use ferrous_dns_domain::config::upstream::{UpstreamPool, UpstreamStrategy};
+    use ferrous_dns_infrastructure::dns::{PoolManager, QueryEventEmitter};
+
+    let event_emitter = QueryEventEmitter::new_disabled();
+    let test_pool = UpstreamPool {
+        name: "test".to_string(),
+        strategy: UpstreamStrategy::Parallel,
+        priority: 1,
+        servers: vec!["8.8.8.8:53".to_string()],
+        weight: None,
+    };
+    let pool_manager = Arc::new(
+        PoolManager::new(vec![test_pool], None, event_emitter)
+            .await
+            .expect("Failed to create PoolManager"),
+    );
+
+    let state = AppState {
+        query: QueryUseCases {
+            get_stats: Arc::new(GetQueryStatsUseCase::new(query_log_repo.clone(), client_repo.clone())),
+            get_queries: Arc::new(GetRecentQueriesUseCase::new(query_log_repo.clone())),
+            get_timeline: Arc::new(ferrous_dns_application::use_cases::GetTimelineUseCase::new(query_log_repo.clone())),
+            get_query_rate: Arc::new(ferrous_dns_application::use_cases::GetQueryRateUseCase::new(query_log_repo.clone())),
+            get_cache_stats: Arc::new(ferrous_dns_application::use_cases::GetCacheStatsUseCase::new(query_log_repo.clone())),
+            get_top_blocked_domains: Arc::new(ferrous_dns_application::use_cases::GetTopBlockedDomainsUseCase::new(query_log_repo.clone())),
+            get_top_clients: Arc::new(ferrous_dns_application::use_cases::GetTopClientsUseCase::new(query_log_repo.clone())),
+        },
+        dns: DnsUseCases {
+            cache: cache.clone() as Arc<dyn ferrous_dns_application::ports::DnsCachePort>,
+            create_local_record: Arc::new(CreateLocalRecordUseCase::new(config.clone(), Arc::new(NullConfigRepository))),
+            update_local_record: Arc::new(UpdateLocalRecordUseCase::new(config.clone(), Arc::new(NullConfigRepository))),
+            delete_local_record: Arc::new(DeleteLocalRecordUseCase::new(config.clone(), Arc::new(NullConfigRepository))),
+            dnssec_stats: Arc::new(ferrous_dns_infrastructure::dns::dnssec::DnssecStatsAdapter::disabled()),
+            upstream_health: Arc::new(ferrous_dns_infrastructure::dns::UpstreamHealthAdapter::new(
+                pool_manager.clone(),
+                None,
+            )),
+            reload_upstream: Arc::new(ferrous_dns_infrastructure::dns::UpstreamReloadAdapter::new(vec![pool_manager.clone(), pool_manager])),
+        },
+        groups: GroupUseCases {
+            get_groups: Arc::new(ferrous_dns_application::use_cases::GetGroupsUseCase::new(group_repo.clone())),
+            create_group: Arc::new(ferrous_dns_application::use_cases::CreateGroupUseCase::new(group_repo.clone())),
+            update_group: Arc::new(ferrous_dns_application::use_cases::UpdateGroupUseCase::new(group_repo.clone())),
+            delete_group: Arc::new(ferrous_dns_application::use_cases::DeleteGroupUseCase::new(group_repo.clone())),
+            assign_client_group: Arc::new(ferrous_dns_application::use_cases::AssignClientGroupUseCase::new(
+                client_repo.clone(),
+                group_repo.clone(),
+                Arc::new(NullBlockFilterEngine),
+            )),
+        },
+        clients: ClientUseCases {
+            get_clients: Arc::new(GetClientsUseCase::new(client_repo.clone())),
+            get_client_subnets: Arc::new(ferrous_dns_application::use_cases::GetClientSubnetsUseCase::new(Arc::new(
+                ferrous_dns_infrastructure::repositories::client_subnet_repository::SqliteClientSubnetRepository::new(pool.clone()),
+            ))),
+            create_client_subnet: Arc::new(ferrous_dns_application::use_cases::CreateClientSubnetUseCase::new(
+                Arc::new(ferrous_dns_infrastructure::repositories::client_subnet_repository::SqliteClientSubnetRepository::new(pool.clone())),
+                group_repo.clone(),
+                Arc::new(NullBlockFilterEngine),
+            )),
+            delete_client_subnet: Arc::new(ferrous_dns_application::use_cases::DeleteClientSubnetUseCase::new(
+                Arc::new(ferrous_dns_infrastructure::repositories::client_subnet_repository::SqliteClientSubnetRepository::new(pool.clone())),
+                Arc::new(NullBlockFilterEngine),
+            )),
+            create_manual_client: Arc::new(ferrous_dns_application::use_cases::CreateManualClientUseCase::new(
+                client_repo.clone(),
+                group_repo.clone(),
+            )),
+            update_client: Arc::new(ferrous_dns_application::use_cases::UpdateClientUseCase::new(client_repo.clone())),
+            delete_client: Arc::new(ferrous_dns_application::use_cases::DeleteClientUseCase::new(client_repo.clone())),
+            subnet_matcher: Arc::new(ferrous_dns_application::services::SubnetMatcherService::new(Arc::new(
+                ferrous_dns_infrastructure::repositories::client_subnet_repository::SqliteClientSubnetRepository::new(pool.clone()),
+            ))),
+        },
+        blocking: BlockingUseCases {
+            get_blocklist: Arc::new(GetBlocklistUseCase::new(Arc::new(
+                ferrous_dns_infrastructure::repositories::blocklist_repository::SqliteBlocklistRepository::new(pool.clone()),
+            ))),
+            get_blocklist_sources: Arc::new(ferrous_dns_application::use_cases::GetBlocklistSourcesUseCase::new(Arc::new(
+                ferrous_dns_infrastructure::repositories::blocklist_source_repository::SqliteBlocklistSourceRepository::new(pool.clone()),
+            ))),
+            create_blocklist_source: Arc::new(ferrous_dns_application::use_cases::CreateBlocklistSourceUseCase::new(
+                Arc::new(ferrous_dns_infrastructure::repositories::blocklist_source_repository::SqliteBlocklistSourceRepository::new(pool.clone())),
+                group_repo.clone(),
+            )),
+            update_blocklist_source: Arc::new(ferrous_dns_application::use_cases::UpdateBlocklistSourceUseCase::new(
+                Arc::new(ferrous_dns_infrastructure::repositories::blocklist_source_repository::SqliteBlocklistSourceRepository::new(pool.clone())),
+                group_repo.clone(),
+            )),
+            delete_blocklist_source: Arc::new(ferrous_dns_application::use_cases::DeleteBlocklistSourceUseCase::new(Arc::new(
+                ferrous_dns_infrastructure::repositories::blocklist_source_repository::SqliteBlocklistSourceRepository::new(pool.clone()),
+            ))),
+            get_whitelist: Arc::new(ferrous_dns_application::use_cases::GetWhitelistUseCase::new(Arc::new(
+                ferrous_dns_infrastructure::repositories::whitelist_repository::SqliteWhitelistRepository::new(pool.clone()),
+            ))),
+            get_whitelist_sources: Arc::new(ferrous_dns_application::use_cases::GetWhitelistSourcesUseCase::new(Arc::new(
+                ferrous_dns_infrastructure::repositories::whitelist_source_repository::SqliteWhitelistSourceRepository::new(pool.clone()),
+            ))),
+            create_whitelist_source: Arc::new(ferrous_dns_application::use_cases::CreateWhitelistSourceUseCase::new(
+                Arc::new(ferrous_dns_infrastructure::repositories::whitelist_source_repository::SqliteWhitelistSourceRepository::new(pool.clone())),
+                group_repo.clone(),
+            )),
+            update_whitelist_source: Arc::new(ferrous_dns_application::use_cases::UpdateWhitelistSourceUseCase::new(
+                Arc::new(ferrous_dns_infrastructure::repositories::whitelist_source_repository::SqliteWhitelistSourceRepository::new(pool.clone())),
+                group_repo.clone(),
+            )),
+            delete_whitelist_source: Arc::new(ferrous_dns_application::use_cases::DeleteWhitelistSourceUseCase::new(Arc::new(
+                ferrous_dns_infrastructure::repositories::whitelist_source_repository::SqliteWhitelistSourceRepository::new(pool.clone()),
+            ))),
+            get_managed_domains: Arc::new(ferrous_dns_application::use_cases::GetManagedDomainsUseCase::new(Arc::new(
+                ferrous_dns_infrastructure::repositories::managed_domain_repository::SqliteManagedDomainRepository::new(pool.clone()),
+            ))),
+            create_managed_domain: Arc::new(ferrous_dns_application::use_cases::CreateManagedDomainUseCase::new(
+                Arc::new(ferrous_dns_infrastructure::repositories::managed_domain_repository::SqliteManagedDomainRepository::new(pool.clone())),
+                group_repo.clone(),
+                Arc::new(NullBlockFilterEngine),
+            )),
+            update_managed_domain: Arc::new(ferrous_dns_application::use_cases::UpdateManagedDomainUseCase::new(
+                Arc::new(ferrous_dns_infrastructure::repositories::managed_domain_repository::SqliteManagedDomainRepository::new(pool.clone())),
+                group_repo.clone(),
+                Arc::new(NullBlockFilterEngine),
+            )),
+            delete_managed_domain: Arc::new(ferrous_dns_application::use_cases::DeleteManagedDomainUseCase::new(
+                Arc::new(ferrous_dns_infrastructure::repositories::managed_domain_repository::SqliteManagedDomainRepository::new(pool.clone())),
+                Arc::new(NullBlockFilterEngine),
+            )),
+            get_regex_filters: Arc::new(ferrous_dns_application::use_cases::GetRegexFiltersUseCase::new(
+                regex_filter_repo.clone(),
+            )),
+            create_regex_filter: Arc::new(ferrous_dns_application::use_cases::CreateRegexFilterUseCase::new(
+                regex_filter_repo.clone(),
+                group_repo.clone(),
+                Arc::new(NullBlockFilterEngine),
+            )),
+            update_regex_filter: Arc::new(ferrous_dns_application::use_cases::UpdateRegexFilterUseCase::new(
+                regex_filter_repo.clone(),
+                group_repo.clone(),
+                Arc::new(NullBlockFilterEngine),
+            )),
+            delete_regex_filter: Arc::new(ferrous_dns_application::use_cases::DeleteRegexFilterUseCase::new(
+                regex_filter_repo.clone(),
+                Arc::new(NullBlockFilterEngine),
+            )),
+            get_block_filter_stats: Arc::new(GetBlockFilterStatsUseCase::new(Arc::new(NullBlockFilterEngine))),
+            test_domain: Arc::new(ferrous_dns_application::use_cases::TestDomainUseCase::new(Arc::new(NullBlockFilterEngine))),
+            backtest: Arc::new(ferrous_dns_application::use_cases::BacktestBlocklistsUseCase::new(
+                Arc::new(NullBlockFilterEngine),
+                Arc::new(ferrous_dns_infrastructure::repositories::query_log_repository::SqliteQueryLogRepository::new(pool.clone(), pool.clone(), pool.clone(), &Default::default())),
+            )),
+        },
+        services: ServiceUseCases {
+            get_service_catalog: Arc::new(ferrous_dns_application::use_cases::GetServiceCatalogUseCase::new(Arc::new(NullServiceCatalog))),
+            get_blocked_services: Arc::new(ferrous_dns_application::use_cases::GetBlockedServicesUseCase::new(Arc::new(NullBlockedServiceRepository))),
+            block_service: Arc::new(ferrous_dns_application::use_cases::BlockServiceUseCase::new(
+                Arc::new(NullBlockedServiceRepository),
+                Arc::new(ferrous_dns_infrastructure::repositories::managed_domain_repository::SqliteManagedDomainRepository::new(pool.clone())),
+                group_repo.clone(),
+                Arc::new(NullBlockFilterEngine),
+                Arc::new(NullServiceCatalog),
+            )),
+            unblock_service: Arc::new(ferrous_dns_application::use_cases::UnblockServiceUseCase::new(
+                Arc::new(NullBlockedServiceRepository),
+                Arc::new(ferrous_dns_infrastructure::repositories::managed_domain_repository::SqliteManagedDomainRepository::new(pool.clone())),
+                Arc::new(NullBlockFilterEngine),
+            )),
+            create_custom_service: Arc::new(ferrous_dns_application::use_cases::CreateCustomServiceUseCase::new(Arc::new(NullCustomServiceRepository), Arc::new(NullServiceCatalog))),
+            get_custom_services: Arc::new(ferrous_dns_application::use_cases::GetCustomServicesUseCase::new(Arc::new(NullCustomServiceRepository))),
+            update_custom_service: Arc::new(ferrous_dns_application::use_cases::UpdateCustomServiceUseCase::new(Arc::new(NullCustomServiceRepository), Arc::new(NullServiceCatalog), Arc::new(ferrous_dns_infrastructure::repositories::managed_domain_repository::SqliteManagedDomainRepository::new(pool.clone())), Arc::new(NullBlockedServiceRepository), Arc::new(NullBlockFilterEngine))),
+            delete_custom_service: Arc::new(ferrous_dns_application::use_cases::DeleteCustomServiceUseCase::new(Arc::new(NullCustomServiceRepository), Arc::new(NullServiceCatalog), Arc::new(NullBlockedServiceRepository), Arc::new(ferrous_dns_infrastructure::repositories::managed_domain_repository::SqliteManagedDomainRepository::new(pool.clone())), Arc::new(NullBlockFilterEngine))),
+        },
+        safe_search: SafeSearchUseCases {
+            get_configs: Arc::new(GetSafeSearchConfigsUseCase::new(
+                Arc::new(NullSafeSearchConfigRepository),
+                group_repo.clone(),
+            )),
+            toggle: Arc::new(ToggleSafeSearchUseCase::new(
+                Arc::new(NullSafeSearchConfigRepository),
+                group_repo.clone(),
+                Arc::new(NullSafeSearchEnginePort),
+            )),
+            delete_configs: Arc::new(DeleteSafeSearchConfigsUseCase::new(
+                Arc::new(NullSafeSearchConfigRepository),
+                group_repo.clone(),
+                Arc::new(NullSafeSearchEnginePort),
+            )),
+        },
+        schedule: ScheduleUseCases {
+            get_profiles: Arc::new(GetScheduleProfilesUseCase::new(Arc::new(NullScheduleProfileRepository))),
+            create_profile: Arc::new(CreateScheduleProfileUseCase::new(Arc::new(NullScheduleProfileRepository))),
+            update_profile: Arc::new(UpdateScheduleProfileUseCase::new(Arc::new(NullScheduleProfileRepository))),
+            delete_profile: Arc::new(DeleteScheduleProfileUseCase::new(Arc::new(NullScheduleProfileRepository))),
+            manage_slots: Arc::new(ManageTimeSlotsUseCase::new(Arc::new(NullScheduleProfileRepository))),
+            assign_profile: Arc::new(AssignScheduleProfileUseCase::new(Arc::new(NullScheduleProfileRepository), group_repo.clone())),
+        },
+        auth: helpers::build_test_auth_use_cases(),
+        backup: helpers::build_test_backup_use_cases(config.clone()),
+        config: config.clone(),
+        config_file_persistence: Arc::new(ferrous_dns_infrastructure::repositories::TomlConfigFilePersistence),
+        config_path: None,
+        tls_cert: Arc::new(helpers::MockTlsCertificateService),
+        webauthn_configured: false,
+        tls_enabled: false,
+    };
+
+    (create_api_routes(state), cache)
+}
+
+fn make_ip_data(ip: &str) -> CachedData {
+    let addr: IpAddr = ip.parse().unwrap();
+    CachedData::IpAddresses(CachedAddresses {
+        addresses: Arc::new(vec![addr]),
+    })
+}
+
+fn seed(cache: &DnsCache, domains: &[&str]) {
+    coarse_clock::tick();
+    for domain in domains {
+        cache.insert(domain, RecordType::A, make_ip_data("1.2.3.4"), 300, None);
+    }
+}
+
+async fn get_json(app: Router, uri: &str) -> Value {
+    let response = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&body).unwrap()
+}
+
+async fn delete_status(app: Router, uri: &str) -> StatusCode {
+    app.oneshot(
+        Request::builder()
+            .method("DELETE")
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+    .status()
+}
+
+#[tokio::test]
+async fn test_get_cache_entries_returns_seeded_entries() {
+    let pool = create_test_db().await;
+    let (app, cache) = create_test_app(pool).await;
+    seed(&cache, &["a.test", "b.test"]);
+
+    let json = get_json(app, "/cache/entries").await;
+
+    assert_eq!(json["total"], 2);
+    assert_eq!(json["records_total"], 2);
+    assert_eq!(json["limit"], 25, "limit defaults to 25");
+    assert_eq!(json["offset"], 0);
+
+    let data = json["data"].as_array().unwrap();
+    assert_eq!(data.len(), 2);
+    assert_eq!(data[0]["type"], "A");
+    assert_eq!(data[0]["answers"][0], "1.2.3.4");
+    assert_eq!(data[0]["permanent"], false);
+    assert_eq!(data[0]["stale"], false);
+    assert!(data[0]["remaining_ttl"].is_number());
+}
+
+#[tokio::test]
+async fn test_get_cache_entries_paginates_with_offset() {
+    let pool = create_test_db().await;
+    let (app, cache) = create_test_app(pool).await;
+    seed(&cache, &["a.page", "b.page", "c.page"]);
+
+    let first = get_json(
+        app.clone(),
+        "/cache/entries?limit=2&offset=0&sort=domain&order=asc",
+    )
+    .await;
+    let first_domains: Vec<&str> = first["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["domain"].as_str().unwrap())
+        .collect();
+    assert_eq!(first_domains, vec!["a.page", "b.page"]);
+    assert_eq!(first["total"], 3);
+    assert_eq!(first["limit"], 2);
+
+    let second = get_json(app, "/cache/entries?limit=2&offset=2&sort=domain&order=asc").await;
+    let second_domains: Vec<&str> = second["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["domain"].as_str().unwrap())
+        .collect();
+    assert_eq!(second_domains, vec!["c.page"]);
+    assert_eq!(second["total"], 3);
+    assert_eq!(second["offset"], 2);
+}
+
+#[tokio::test]
+async fn test_get_cache_entries_filters_by_domain() {
+    let pool = create_test_db().await;
+    let (app, cache) = create_test_app(pool).await;
+    seed(
+        &cache,
+        &["shop.example.com", "api.example.org", "other.test"],
+    );
+
+    let json = get_json(app, "/cache/entries?domain=example").await;
+
+    assert_eq!(json["total"], 2, "total counts only filtered entries");
+    assert_eq!(
+        json["records_total"], 3,
+        "records_total ignores the domain filter"
+    );
+    assert_eq!(json["data"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn test_get_cache_entries_sorts_by_domain_in_both_directions() {
+    let pool = create_test_db().await;
+    let (app, cache) = create_test_app(pool).await;
+    seed(&cache, &["c.sorted", "a.sorted", "b.sorted"]);
+
+    let asc = get_json(app.clone(), "/cache/entries?sort=domain&order=asc").await;
+    let asc_domains: Vec<&str> = asc["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["domain"].as_str().unwrap())
+        .collect();
+    assert_eq!(asc_domains, vec!["a.sorted", "b.sorted", "c.sorted"]);
+
+    let desc = get_json(app, "/cache/entries?sort=domain&order=desc").await;
+    let desc_domains: Vec<&str> = desc["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["domain"].as_str().unwrap())
+        .collect();
+    assert_eq!(desc_domains, vec!["c.sorted", "b.sorted", "a.sorted"]);
+}
+
+#[tokio::test]
+async fn test_get_cache_entries_ignores_unknown_sort_and_order() {
+    let pool = create_test_db().await;
+    let (app, cache) = create_test_app(pool).await;
+    seed(&cache, &["a.fallback", "b.fallback"]);
+
+    let json = get_json(app, "/cache/entries?sort=bogus&order=sideways").await;
+
+    assert_eq!(
+        json["total"], 2,
+        "unparsable sort/order fall back to the defaults instead of failing"
+    );
+}
+
+#[tokio::test]
+async fn test_get_cache_entries_clamps_limit_to_maximum() {
+    let pool = create_test_db().await;
+    let (app, cache) = create_test_app(pool).await;
+    seed(&cache, &["a.limit"]);
+
+    let json = get_json(app, "/cache/entries?limit=99999").await;
+
+    assert_eq!(json["limit"], 500, "limit is clamped to 500");
+}
+
+#[tokio::test]
+async fn test_get_cache_entries_clamps_zero_limit_to_one() {
+    let pool = create_test_db().await;
+    let (app, cache) = create_test_app(pool).await;
+    seed(&cache, &["a.zero", "b.zero"]);
+
+    let json = get_json(app, "/cache/entries?limit=0").await;
+
+    assert_eq!(json["limit"], 1);
+    assert_eq!(json["data"].as_array().unwrap().len(), 1);
+    assert_eq!(json["total"], 2);
+}
+
+#[tokio::test]
+async fn test_delete_cache_entry_returns_no_content_and_removes_it() {
+    let pool = create_test_db().await;
+    let (app, cache) = create_test_app(pool).await;
+    seed(&cache, &["doomed.test", "kept.test"]);
+
+    let status = delete_status(app.clone(), "/cache/entries?domain=doomed.test&type=A").await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let json = get_json(app, "/cache/entries").await;
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["data"][0]["domain"], "kept.test");
+}
+
+#[tokio::test]
+async fn test_delete_cache_entry_returns_not_found_for_missing_entry() {
+    let pool = create_test_db().await;
+    let (app, cache) = create_test_app(pool).await;
+    seed(&cache, &["present.test"]);
+
+    let status = delete_status(app, "/cache/entries?domain=absent.test&type=A").await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_delete_cache_entry_returns_bad_request_for_unknown_type() {
+    let pool = create_test_db().await;
+    let (app, cache) = create_test_app(pool).await;
+    seed(&cache, &["present.test"]);
+
+    let status = delete_status(app, "/cache/entries?domain=present.test&type=NOPE").await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}

--- a/crates/application/src/ports/dns_cache_port.rs
+++ b/crates/application/src/ports/dns_cache_port.rs
@@ -1,5 +1,6 @@
-use ferrous_dns_domain::RecordType;
+use ferrous_dns_domain::{DnssecStatus, RecordType};
 use std::net::IpAddr;
+use std::str::FromStr;
 
 /// Snapshot of DNS cache metrics for API exposure.
 #[derive(Debug, Clone)]
@@ -21,6 +22,112 @@ pub struct CacheMetricsSnapshot {
     pub transient_upstream_errors: u64,
 }
 
+/// Snapshot of a single positive cache entry, as listed by the admin UI.
+#[derive(Debug, Clone)]
+pub struct CacheEntrySnapshot {
+    pub domain: String,
+    pub record_type: RecordType,
+    /// Addresses for A/AAAA entries; empty for every other record type.
+    pub answers: Vec<IpAddr>,
+    /// Target of a CNAME entry.
+    pub canonical_name: Option<String>,
+    /// `None` when the entry was cached without a DNSSEC determination.
+    pub dnssec_status: Option<DnssecStatus>,
+    pub ttl: u32,
+    /// Seconds left before expiry; `None` for permanent entries.
+    pub remaining_ttl: Option<u32>,
+    pub cached_at_secs: u64,
+    pub expires_at_secs: u64,
+    /// Hits served from the shared cache. Lookups absorbed by the per-thread
+    /// L1 cache are not counted here.
+    pub hits: u64,
+    pub last_access_secs: u64,
+    pub is_permanent: bool,
+    /// Past its TTL but still served within the stale grace period.
+    pub is_stale: bool,
+}
+
+/// Field the cache listing is ordered by.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CacheEntrySort {
+    Hits,
+    #[default]
+    CachedAt,
+    ExpiresAt,
+    Domain,
+    Type,
+}
+
+impl FromStr for CacheEntrySort {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "hits" => Ok(Self::Hits),
+            "cached_at" => Ok(Self::CachedAt),
+            "expires_at" => Ok(Self::ExpiresAt),
+            "domain" => Ok(Self::Domain),
+            "type" => Ok(Self::Type),
+            other => Err(format!("invalid cache entry sort: '{other}'")),
+        }
+    }
+}
+
+/// Direction the cache listing is ordered in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CacheEntryOrder {
+    Asc,
+    #[default]
+    Desc,
+}
+
+impl FromStr for CacheEntryOrder {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "asc" => Ok(Self::Asc),
+            "desc" => Ok(Self::Desc),
+            other => Err(format!("invalid cache entry order: '{other}'")),
+        }
+    }
+}
+
+/// Filtering, ordering and pagination for a cache listing.
+#[derive(Debug, Clone)]
+pub struct CacheEntryQuery {
+    /// Case-insensitive substring match on the cached domain.
+    pub domain: Option<String>,
+    pub record_type: Option<RecordType>,
+    pub sort: CacheEntrySort,
+    pub order: CacheEntryOrder,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+impl Default for CacheEntryQuery {
+    fn default() -> Self {
+        Self {
+            domain: None,
+            record_type: None,
+            sort: CacheEntrySort::default(),
+            order: CacheEntryOrder::default(),
+            limit: 25,
+            offset: 0,
+        }
+    }
+}
+
+/// One page of cache entries plus the counts needed by the UI.
+#[derive(Debug, Clone)]
+pub struct CacheEntryPage {
+    pub entries: Vec<CacheEntrySnapshot>,
+    /// Entries matching the filter, before pagination is applied.
+    pub total: usize,
+    /// Entries in the cache, ignoring the filter.
+    pub records_total: usize,
+}
+
 /// Port for DNS cache operations exposed to the API layer.
 pub trait DnsCachePort: Send + Sync {
     fn cache_size(&self) -> usize;
@@ -32,4 +139,5 @@ pub trait DnsCachePort: Send + Sync {
         addresses: Vec<IpAddr>,
     );
     fn remove_record(&self, domain: &str, record_type: &RecordType) -> bool;
+    fn list_entries(&self, query: &CacheEntryQuery) -> CacheEntryPage;
 }

--- a/crates/application/src/ports/mod.rs
+++ b/crates/application/src/ports/mod.rs
@@ -56,7 +56,10 @@ pub use config_file_port::ConfigFilePersistence;
 pub use config_repository::ConfigRepository;
 pub use custom_service_repository::CustomServiceRepository;
 pub use dga_flag_store::{DgaEvictionTarget, DgaFlagStore};
-pub use dns_cache_port::{CacheMetricsSnapshot, DnsCachePort};
+pub use dns_cache_port::{
+    CacheEntryOrder, CacheEntryPage, CacheEntryQuery, CacheEntrySnapshot, CacheEntrySort,
+    CacheMetricsSnapshot, DnsCachePort,
+};
 pub use dns_resolver::{DnsResolution, DnsResolver, EMPTY_CNAME_CHAIN};
 pub use dnssec_stats_port::{DnssecStatsPort, DnssecValidatorStats};
 pub use group_repository::GroupRepository;

--- a/crates/cli/src/server/web.rs
+++ b/crates/cli/src/server/web.rs
@@ -176,6 +176,8 @@ fn create_app(
         .route("/static/dashboard.js", get(dashboard_js_handler))
         .route("/static/queries.css", get(queries_css_handler))
         .route("/static/queries.js", get(queries_js_handler))
+        .route("/static/cache-control.css", get(cache_control_css_handler))
+        .route("/static/cache-control.js", get(cache_control_js_handler))
         .route("/static/dnssec.css", get(dnssec_css_handler))
         .route("/static/dnssec.js", get(dnssec_js_handler))
         .route("/static/clients.css", get(clients_css_handler))
@@ -205,6 +207,7 @@ fn create_app(
         .route("/login.html", get(login_handler))
         .route("/dashboard.html", get(dashboard_handler))
         .route("/queries.html", get(queries_handler))
+        .route("/cache-control.html", get(cache_control_handler))
         .route("/dnssec.html", get(dnssec_handler))
         .route("/clients.html", get(clients_handler))
         .route("/groups.html", get(groups_handler))
@@ -300,6 +303,10 @@ async fn queries_handler() -> Html<&'static str> {
     Html(include_str!("../../../../web/static/queries.html"))
 }
 
+async fn cache_control_handler() -> Html<&'static str> {
+    Html(include_str!("../../../../web/static/cache-control.html"))
+}
+
 async fn dnssec_handler() -> Html<&'static str> {
     Html(include_str!("../../../../web/static/dnssec.html"))
 }
@@ -362,6 +369,14 @@ css_handler!(
 js_handler!(dashboard_js_handler, "../../../../web/static/dashboard.js");
 css_handler!(queries_css_handler, "../../../../web/static/queries.css");
 js_handler!(queries_js_handler, "../../../../web/static/queries.js");
+css_handler!(
+    cache_control_css_handler,
+    "../../../../web/static/cache-control.css"
+);
+js_handler!(
+    cache_control_js_handler,
+    "../../../../web/static/cache-control.js"
+);
 css_handler!(dnssec_css_handler, "../../../../web/static/dnssec.css");
 js_handler!(dnssec_js_handler, "../../../../web/static/dnssec.js");
 css_handler!(clients_css_handler, "../../../../web/static/clients.css");

--- a/crates/infrastructure/src/dns/cache/listing.rs
+++ b/crates/infrastructure/src/dns/cache/listing.rs
@@ -1,0 +1,141 @@
+use super::coarse_clock::coarse_now_secs;
+use super::data::CachedDnssecStatus;
+use super::record::CachedRecord;
+use super::storage::DnsCache;
+use ferrous_dns_application::ports::{
+    CacheEntryOrder, CacheEntryPage, CacheEntryQuery, CacheEntrySnapshot, CacheEntrySort,
+};
+use ferrous_dns_domain::DnssecStatus;
+use std::cmp::Ordering;
+use std::sync::atomic::Ordering as AtomicOrdering;
+
+impl DnsCache {
+    /// Builds a filtered, ordered and paginated snapshot of the positive
+    /// cache for the admin UI. Entries still inside the stale grace period
+    /// are listed (the resolver still serves them) and flagged as stale;
+    /// entries marked for deletion, negative responses and fully expired
+    /// records are skipped.
+    pub fn list_entries(&self, query: &CacheEntryQuery) -> CacheEntryPage {
+        let now = coarse_now_secs();
+        let domain_filter = query.domain.as_deref().map(str::to_ascii_lowercase);
+
+        let mut matched: Vec<CacheEntrySnapshot> = Vec::new();
+
+        for entry in self.cache.iter() {
+            let record = entry.value();
+
+            if record.is_marked_for_deletion() {
+                continue;
+            }
+
+            if record.data.is_negative() {
+                continue;
+            }
+
+            if record.is_expired_at_secs(now) && !record.is_stale_usable_at_secs(now) {
+                continue;
+            }
+
+            let key = entry.key();
+
+            if let Some(needle) = domain_filter.as_deref() {
+                if !key.domain.as_str().contains(needle) {
+                    continue;
+                }
+            }
+
+            if let Some(record_type) = query.record_type {
+                if key.record_type != record_type {
+                    continue;
+                }
+            }
+
+            matched.push(snapshot_from(key.domain.as_str(), record, now));
+        }
+
+        let total = matched.len();
+        sort_entries(&mut matched, query.sort, query.order);
+
+        let entries = matched
+            .into_iter()
+            .skip(query.offset)
+            .take(query.limit)
+            .collect();
+
+        CacheEntryPage {
+            entries,
+            total,
+            records_total: self.size(),
+        }
+    }
+}
+
+fn snapshot_from(domain: &str, record: &CachedRecord, now_secs: u64) -> CacheEntrySnapshot {
+    let is_permanent = record.is_permanent();
+    let remaining_ttl = if is_permanent {
+        None
+    } else {
+        let remaining = record.expires_at_secs.saturating_sub(now_secs);
+        Some(remaining.min(u32::MAX as u64) as u32)
+    };
+
+    CacheEntrySnapshot {
+        domain: domain.to_string(),
+        record_type: record.record_type,
+        answers: record
+            .data
+            .as_ip_addresses()
+            .map(|addresses| addresses.as_ref().clone())
+            .unwrap_or_default(),
+        canonical_name: record.data.as_canonical_name().map(|name| name.to_string()),
+        dnssec_status: map_dnssec_status(record.dnssec_status),
+        ttl: record.ttl,
+        remaining_ttl,
+        cached_at_secs: record.inserted_at_secs,
+        expires_at_secs: record.expires_at_secs,
+        hits: record.counters.hit_count.load(AtomicOrdering::Relaxed),
+        last_access_secs: record.counters.last_access.load(AtomicOrdering::Relaxed),
+        is_permanent,
+        is_stale: record.is_stale_usable_at_secs(now_secs),
+    }
+}
+
+/// `CachedDnssecStatus::Unknown` means "no determination was recorded", which
+/// the domain enum expresses as the absence of a status.
+fn map_dnssec_status(status: CachedDnssecStatus) -> Option<DnssecStatus> {
+    match status {
+        CachedDnssecStatus::Unknown => None,
+        CachedDnssecStatus::Secure => Some(DnssecStatus::Secure),
+        CachedDnssecStatus::Insecure => Some(DnssecStatus::Insecure),
+        CachedDnssecStatus::Bogus => Some(DnssecStatus::Bogus),
+        CachedDnssecStatus::Indeterminate => Some(DnssecStatus::Indeterminate),
+    }
+}
+
+fn sort_entries(entries: &mut [CacheEntrySnapshot], sort: CacheEntrySort, order: CacheEntryOrder) {
+    entries.sort_by(|a, b| {
+        let primary = match sort {
+            CacheEntrySort::Hits => a.hits.cmp(&b.hits),
+            CacheEntrySort::CachedAt => a.cached_at_secs.cmp(&b.cached_at_secs),
+            CacheEntrySort::ExpiresAt => a.expires_at_secs.cmp(&b.expires_at_secs),
+            CacheEntrySort::Domain => a.domain.cmp(&b.domain),
+            CacheEntrySort::Type => a.record_type.to_u16().cmp(&b.record_type.to_u16()),
+        };
+
+        let primary = match order {
+            CacheEntryOrder::Asc => primary,
+            CacheEntryOrder::Desc => primary.reverse(),
+        };
+
+        primary.then_with(|| tie_break(a, b))
+    });
+}
+
+/// The `DashMap` has no stable iteration order, so equal sort keys are broken
+/// by `(domain, record type)` — always ascending, so paging is reproducible
+/// in both directions.
+fn tie_break(a: &CacheEntrySnapshot, b: &CacheEntrySnapshot) -> Ordering {
+    a.domain
+        .cmp(&b.domain)
+        .then_with(|| a.record_type.to_u16().cmp(&b.record_type.to_u16()))
+}

--- a/crates/infrastructure/src/dns/cache/mod.rs
+++ b/crates/infrastructure/src/dns/cache/mod.rs
@@ -5,6 +5,7 @@ pub mod data;
 pub mod eviction;
 pub mod key;
 pub mod l1;
+pub mod listing;
 pub mod metrics;
 pub mod negative_cache;
 pub mod negative_ttl;

--- a/crates/infrastructure/src/dns/cache/storage.rs
+++ b/crates/infrastructure/src/dns/cache/storage.rs
@@ -379,6 +379,9 @@ impl DnsCache {
         if self.cache.remove(&key).is_some() {
             self.permanent_keys.remove(&key);
             self.metrics.evictions.fetch_add(1, AtomicOrdering::Relaxed);
+            // The per-thread L1 keeps serving a removed record until it
+            // expires locally, so bump the generation like `clear()` does.
+            l1_clear();
             info!(domain = %domain, record_type = %record_type, "Removed record from cache");
             true
         } else {
@@ -733,6 +736,13 @@ impl ferrous_dns_application::ports::DnsCachePort for DnsCache {
 
     fn remove_record(&self, domain: &str, record_type: &ferrous_dns_domain::RecordType) -> bool {
         self.remove(domain, record_type)
+    }
+
+    fn list_entries(
+        &self,
+        query: &ferrous_dns_application::ports::CacheEntryQuery,
+    ) -> ferrous_dns_application::ports::CacheEntryPage {
+        DnsCache::list_entries(self, query)
     }
 }
 

--- a/crates/infrastructure/tests/cache_list_entries_test.rs
+++ b/crates/infrastructure/tests/cache_list_entries_test.rs
@@ -1,0 +1,565 @@
+use ferrous_dns_application::ports::{CacheEntryOrder, CacheEntryQuery, CacheEntrySort};
+use ferrous_dns_domain::{DnssecStatus, RecordType};
+use ferrous_dns_infrastructure::dns::cache::coarse_clock;
+use ferrous_dns_infrastructure::dns::{
+    CachedAddresses, CachedData, CachedDnssecStatus, DnsCache, DnsCacheConfig, EvictionStrategy,
+};
+use std::net::IpAddr;
+use std::sync::Arc;
+
+fn create_listing_cache() -> DnsCache {
+    DnsCache::new(DnsCacheConfig {
+        max_entries: 1000,
+        eviction_strategy: EvictionStrategy::HitRate,
+        min_threshold: 0.0,
+        refresh_threshold: 0.75,
+        batch_eviction_percentage: 0.2,
+        adaptive_thresholds: false,
+        min_frequency: 0,
+        min_lfuk_score: 0.0,
+        shard_amount: 4,
+        access_window_secs: 7200,
+        eviction_sample_size: 8,
+        lfuk_k_value: 0.5,
+        refresh_sample_rate: 1.0,
+        min_ttl: 0,
+        max_ttl: 86_400,
+    })
+}
+
+fn make_ip_data(ip: &str) -> CachedData {
+    let addr: IpAddr = ip.parse().unwrap();
+    CachedData::IpAddresses(CachedAddresses {
+        addresses: Arc::new(vec![addr]),
+    })
+}
+
+/// CNAME data never reaches the thread-local L1, so `cache.get()` always goes
+/// through L2 and increments `hit_count`.
+fn make_cname_data(name: &str) -> CachedData {
+    CachedData::CanonicalName(Arc::from(name))
+}
+
+fn query_all(sort: CacheEntrySort, order: CacheEntryOrder) -> CacheEntryQuery {
+    CacheEntryQuery {
+        limit: 100,
+        sort,
+        order,
+        ..Default::default()
+    }
+}
+
+fn domains(entries: &[ferrous_dns_application::ports::CacheEntrySnapshot]) -> Vec<&str> {
+    entries.iter().map(|entry| entry.domain.as_str()).collect()
+}
+
+#[test]
+fn test_list_entries_filters_by_domain_substring_case_insensitive() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    cache.insert(
+        "shop.example.com",
+        RecordType::A,
+        make_ip_data("1.1.1.1"),
+        300,
+        None,
+    );
+    cache.insert(
+        "api.example.org",
+        RecordType::A,
+        make_ip_data("2.2.2.2"),
+        300,
+        None,
+    );
+    cache.insert(
+        "other.test",
+        RecordType::A,
+        make_ip_data("3.3.3.3"),
+        300,
+        None,
+    );
+
+    let page = cache.list_entries(&CacheEntryQuery {
+        domain: Some("EXAMPLE".to_string()),
+        limit: 100,
+        sort: CacheEntrySort::Domain,
+        order: CacheEntryOrder::Asc,
+        ..Default::default()
+    });
+
+    assert_eq!(page.total, 2);
+    assert_eq!(page.records_total, 3);
+    assert_eq!(
+        domains(&page.entries),
+        vec!["api.example.org", "shop.example.com"]
+    );
+}
+
+#[test]
+fn test_list_entries_filters_by_record_type() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    cache.insert(
+        "dual.test",
+        RecordType::A,
+        make_ip_data("1.1.1.1"),
+        300,
+        None,
+    );
+    cache.insert(
+        "dual.test",
+        RecordType::AAAA,
+        make_ip_data("::1"),
+        300,
+        None,
+    );
+    cache.insert(
+        "dual.test",
+        RecordType::CNAME,
+        make_cname_data("target.test"),
+        300,
+        None,
+    );
+
+    let page = cache.list_entries(&CacheEntryQuery {
+        record_type: Some(RecordType::AAAA),
+        limit: 100,
+        ..Default::default()
+    });
+
+    assert_eq!(page.total, 1);
+    assert_eq!(page.records_total, 3);
+    assert_eq!(page.entries[0].record_type, RecordType::AAAA);
+}
+
+#[test]
+fn test_list_entries_sorts_by_hits_both_directions() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    for (domain, hits) in [("cold.hits", 0), ("warm.hits", 2), ("hot.hits", 5)] {
+        cache.insert(
+            domain,
+            RecordType::CNAME,
+            make_cname_data("alias.test"),
+            300,
+            None,
+        );
+        for _ in 0..hits {
+            assert!(cache.get(domain, &RecordType::CNAME).is_some());
+        }
+    }
+
+    let desc = cache.list_entries(&query_all(CacheEntrySort::Hits, CacheEntryOrder::Desc));
+    assert_eq!(
+        domains(&desc.entries),
+        vec!["hot.hits", "warm.hits", "cold.hits"]
+    );
+    assert_eq!(desc.entries[0].hits, 5);
+
+    let asc = cache.list_entries(&query_all(CacheEntrySort::Hits, CacheEntryOrder::Asc));
+    assert_eq!(
+        domains(&asc.entries),
+        vec!["cold.hits", "warm.hits", "hot.hits"]
+    );
+}
+
+#[test]
+fn test_list_entries_sorts_by_domain_both_directions() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    for domain in ["c.sortdomain", "a.sortdomain", "b.sortdomain"] {
+        cache.insert(domain, RecordType::A, make_ip_data("1.1.1.1"), 300, None);
+    }
+
+    let asc = cache.list_entries(&query_all(CacheEntrySort::Domain, CacheEntryOrder::Asc));
+    assert_eq!(
+        domains(&asc.entries),
+        vec!["a.sortdomain", "b.sortdomain", "c.sortdomain"]
+    );
+
+    let desc = cache.list_entries(&query_all(CacheEntrySort::Domain, CacheEntryOrder::Desc));
+    assert_eq!(
+        domains(&desc.entries),
+        vec!["c.sortdomain", "b.sortdomain", "a.sortdomain"]
+    );
+}
+
+#[test]
+fn test_list_entries_sorts_by_type_both_directions() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    // A = 1, CNAME = 5, AAAA = 28 (RFC record type codes).
+    cache.insert(
+        "types.test",
+        RecordType::AAAA,
+        make_ip_data("::1"),
+        300,
+        None,
+    );
+    cache.insert(
+        "types.test",
+        RecordType::A,
+        make_ip_data("1.1.1.1"),
+        300,
+        None,
+    );
+    cache.insert(
+        "types.test",
+        RecordType::CNAME,
+        make_cname_data("alias.test"),
+        300,
+        None,
+    );
+
+    let asc = cache.list_entries(&query_all(CacheEntrySort::Type, CacheEntryOrder::Asc));
+    let asc_types: Vec<RecordType> = asc.entries.iter().map(|e| e.record_type).collect();
+    assert_eq!(
+        asc_types,
+        vec![RecordType::A, RecordType::CNAME, RecordType::AAAA]
+    );
+
+    let desc = cache.list_entries(&query_all(CacheEntrySort::Type, CacheEntryOrder::Desc));
+    let desc_types: Vec<RecordType> = desc.entries.iter().map(|e| e.record_type).collect();
+    assert_eq!(
+        desc_types,
+        vec![RecordType::AAAA, RecordType::CNAME, RecordType::A]
+    );
+}
+
+#[test]
+fn test_list_entries_sorts_by_expires_at_both_directions() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    for (domain, ttl) in [("long.exp", 900), ("short.exp", 60), ("mid.exp", 300)] {
+        cache.insert(domain, RecordType::A, make_ip_data("1.1.1.1"), ttl, None);
+    }
+
+    let asc = cache.list_entries(&query_all(CacheEntrySort::ExpiresAt, CacheEntryOrder::Asc));
+    assert_eq!(
+        domains(&asc.entries),
+        vec!["short.exp", "mid.exp", "long.exp"]
+    );
+
+    let desc = cache.list_entries(&query_all(CacheEntrySort::ExpiresAt, CacheEntryOrder::Desc));
+    assert_eq!(
+        domains(&desc.entries),
+        vec!["long.exp", "mid.exp", "short.exp"]
+    );
+}
+
+#[test]
+fn test_list_entries_sorts_by_cached_at_both_directions() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    cache.insert(
+        "first.cached",
+        RecordType::A,
+        make_ip_data("1.1.1.1"),
+        300,
+        None,
+    );
+
+    // The coarse clock only advances on `tick()`, so both inserts would
+    // otherwise share the same `inserted_at_secs`.
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    coarse_clock::tick();
+
+    cache.insert(
+        "second.cached",
+        RecordType::A,
+        make_ip_data("2.2.2.2"),
+        300,
+        None,
+    );
+
+    let desc = cache.list_entries(&query_all(CacheEntrySort::CachedAt, CacheEntryOrder::Desc));
+    assert_eq!(
+        domains(&desc.entries),
+        vec!["second.cached", "first.cached"]
+    );
+    assert!(desc.entries[0].cached_at_secs > desc.entries[1].cached_at_secs);
+
+    let asc = cache.list_entries(&query_all(CacheEntrySort::CachedAt, CacheEntryOrder::Asc));
+    assert_eq!(domains(&asc.entries), vec!["first.cached", "second.cached"]);
+}
+
+#[test]
+fn test_list_entries_tie_break_is_deterministic_in_both_orders() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    // Same TTL and same insertion tick: every sort key below ties, so only the
+    // `(domain, record type)` tie-break decides the order.
+    for domain in ["b.tie", "a.tie", "c.tie"] {
+        cache.insert(domain, RecordType::AAAA, make_ip_data("::1"), 300, None);
+        cache.insert(domain, RecordType::A, make_ip_data("1.1.1.1"), 300, None);
+    }
+
+    let expected = vec![
+        ("a.tie", RecordType::A),
+        ("a.tie", RecordType::AAAA),
+        ("b.tie", RecordType::A),
+        ("b.tie", RecordType::AAAA),
+        ("c.tie", RecordType::A),
+        ("c.tie", RecordType::AAAA),
+    ];
+
+    for order in [CacheEntryOrder::Asc, CacheEntryOrder::Desc] {
+        let page = cache.list_entries(&query_all(CacheEntrySort::Hits, order));
+        let actual: Vec<(&str, RecordType)> = page
+            .entries
+            .iter()
+            .map(|entry| (entry.domain.as_str(), entry.record_type))
+            .collect();
+        assert_eq!(actual, expected, "tie-break must not depend on the order");
+    }
+}
+
+#[test]
+fn test_list_entries_permanent_entry_has_no_remaining_ttl() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    cache.insert_permanent(
+        "printer.lan",
+        RecordType::A,
+        make_ip_data("192.168.1.50"),
+        None,
+    );
+    cache.insert(
+        "regular.test",
+        RecordType::A,
+        make_ip_data("1.1.1.1"),
+        300,
+        None,
+    );
+
+    let page = cache.list_entries(&query_all(CacheEntrySort::Domain, CacheEntryOrder::Asc));
+
+    let permanent = page
+        .entries
+        .iter()
+        .find(|entry| entry.domain == "printer.lan")
+        .expect("permanent entry must be listed");
+    assert!(permanent.is_permanent);
+    assert_eq!(permanent.remaining_ttl, None);
+    assert!(!permanent.is_stale);
+
+    let regular = page
+        .entries
+        .iter()
+        .find(|entry| entry.domain == "regular.test")
+        .expect("regular entry must be listed");
+    assert!(!regular.is_permanent);
+    // The coarse clock is process-global, so a parallel test may tick it
+    // forward a few seconds between the insert and this listing.
+    let remaining = regular.remaining_ttl.expect("regular entry has a TTL");
+    assert!(
+        (250..=300).contains(&remaining),
+        "unexpected remaining TTL: {remaining}"
+    );
+}
+
+#[test]
+fn test_list_entries_maps_dnssec_status() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    cache.insert(
+        "secure.dnssec",
+        RecordType::A,
+        make_ip_data("1.1.1.1"),
+        300,
+        Some(CachedDnssecStatus::Secure),
+    );
+    cache.insert(
+        "unknown.dnssec",
+        RecordType::A,
+        make_ip_data("2.2.2.2"),
+        300,
+        Some(CachedDnssecStatus::Unknown),
+    );
+
+    let page = cache.list_entries(&query_all(CacheEntrySort::Domain, CacheEntryOrder::Asc));
+
+    assert_eq!(page.entries[0].domain, "secure.dnssec");
+    assert_eq!(page.entries[0].dnssec_status, Some(DnssecStatus::Secure));
+    assert_eq!(page.entries[1].domain, "unknown.dnssec");
+    assert_eq!(page.entries[1].dnssec_status, None);
+}
+
+#[test]
+fn test_list_entries_exposes_answers_and_canonical_name() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    cache.insert(
+        "addresses.test",
+        RecordType::A,
+        make_ip_data("203.0.113.7"),
+        300,
+        None,
+    );
+    cache.insert(
+        "alias.test",
+        RecordType::CNAME,
+        make_cname_data("canonical.test"),
+        300,
+        None,
+    );
+
+    let page = cache.list_entries(&query_all(CacheEntrySort::Domain, CacheEntryOrder::Asc));
+
+    let addresses = &page.entries[0];
+    assert_eq!(addresses.domain, "addresses.test");
+    assert_eq!(addresses.answers.len(), 1);
+    assert_eq!(addresses.answers[0].to_string(), "203.0.113.7");
+    assert_eq!(addresses.canonical_name, None);
+
+    let alias = &page.entries[1];
+    assert_eq!(alias.domain, "alias.test");
+    assert!(alias.answers.is_empty());
+    assert_eq!(alias.canonical_name, Some("canonical.test".to_string()));
+}
+
+#[test]
+fn test_list_entries_total_counts_filter_while_records_total_counts_cache() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    for domain in ["a.counted", "b.counted", "c.other"] {
+        cache.insert(domain, RecordType::A, make_ip_data("1.1.1.1"), 300, None);
+    }
+
+    let page = cache.list_entries(&CacheEntryQuery {
+        domain: Some("counted".to_string()),
+        limit: 1,
+        ..Default::default()
+    });
+
+    assert_eq!(page.entries.len(), 1, "limit caps the returned page");
+    assert_eq!(page.total, 2, "total counts every filtered entry");
+    assert_eq!(page.records_total, 3, "records_total ignores the filter");
+}
+
+#[test]
+fn test_list_entries_paginates_with_offset() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    for domain in ["a.page", "b.page", "c.page", "d.page", "e.page"] {
+        cache.insert(domain, RecordType::A, make_ip_data("1.1.1.1"), 300, None);
+    }
+
+    let first = cache.list_entries(&CacheEntryQuery {
+        sort: CacheEntrySort::Domain,
+        order: CacheEntryOrder::Asc,
+        limit: 2,
+        offset: 0,
+        ..Default::default()
+    });
+    assert_eq!(domains(&first.entries), vec!["a.page", "b.page"]);
+    assert_eq!(first.total, 5);
+
+    let second = cache.list_entries(&CacheEntryQuery {
+        sort: CacheEntrySort::Domain,
+        order: CacheEntryOrder::Asc,
+        limit: 2,
+        offset: 2,
+        ..Default::default()
+    });
+    assert_eq!(domains(&second.entries), vec!["c.page", "d.page"]);
+    assert_eq!(second.total, 5);
+
+    let last = cache.list_entries(&CacheEntryQuery {
+        sort: CacheEntrySort::Domain,
+        order: CacheEntryOrder::Asc,
+        limit: 2,
+        offset: 4,
+        ..Default::default()
+    });
+    assert_eq!(domains(&last.entries), vec!["e.page"]);
+
+    let past_end = cache.list_entries(&CacheEntryQuery {
+        sort: CacheEntrySort::Domain,
+        order: CacheEntryOrder::Asc,
+        limit: 2,
+        offset: 10,
+        ..Default::default()
+    });
+    assert!(past_end.entries.is_empty());
+    assert_eq!(past_end.total, 5, "total stays independent of the offset");
+}
+
+#[test]
+fn test_list_entries_omits_negative_responses() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    // Negative answers are routed to the separate negative cache, never to the
+    // positive map this listing walks.
+    cache.insert(
+        "nxdomain.test",
+        RecordType::A,
+        CachedData::NegativeResponse,
+        300,
+        None,
+    );
+    cache.insert(
+        "positive.test",
+        RecordType::A,
+        make_ip_data("1.1.1.1"),
+        300,
+        None,
+    );
+
+    let page = cache.list_entries(&query_all(CacheEntrySort::Domain, CacheEntryOrder::Asc));
+
+    assert_eq!(domains(&page.entries), vec!["positive.test"]);
+    assert_eq!(page.total, 1);
+    assert_eq!(page.records_total, 1);
+}
+
+#[test]
+fn test_list_entries_keeps_stale_and_drops_fully_expired() {
+    let cache = create_listing_cache();
+    coarse_clock::tick();
+
+    // Stale grace period is 2×TTL: after 4s the TTL=3 entry is expired but
+    // still served, while the TTL=1 entry is past its grace window.
+    cache.insert(
+        "stale.expiry",
+        RecordType::CNAME,
+        make_cname_data("alias.test"),
+        3,
+        None,
+    );
+    cache.insert(
+        "gone.expiry",
+        RecordType::CNAME,
+        make_cname_data("alias.test"),
+        1,
+        None,
+    );
+
+    std::thread::sleep(std::time::Duration::from_secs(4));
+    coarse_clock::tick();
+
+    let page = cache.list_entries(&query_all(CacheEntrySort::Domain, CacheEntryOrder::Asc));
+
+    assert_eq!(domains(&page.entries), vec!["stale.expiry"]);
+    assert_eq!(page.total, 1);
+    assert!(page.entries[0].is_stale, "stale entry must be flagged");
+    assert_eq!(page.entries[0].remaining_ttl, Some(0));
+    assert_eq!(
+        page.records_total, 2,
+        "records_total reflects the raw cache, including the expired entry"
+    );
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -534,6 +534,35 @@ GET /api/cache/metrics
 
 Returns detailed cache metrics: hits, misses, evictions, insertions, optimistic refreshes, lazy deletions, compactions, hit rate.
 
+### List Cache Entries
+
+```http
+GET /api/cache/entries?limit=25&offset=0&sort=cached_at&order=desc
+```
+
+Returns the entries currently held in the positive cache, with filtering, ordering, and pagination.
+
+| Parameter | Type | Description |
+|:----------|:-----|:------------|
+| `limit` | integer | Max results (default: 25, max: 500) |
+| `offset` | integer | Pagination offset |
+| `domain` | string | Case-insensitive substring match on the cached domain |
+| `type` | string | Record type name, e.g. `A`, `AAAA`, `CNAME` |
+| `sort` | string | `hits`, `cached_at`, `expires_at`, `domain`, or `type` (default: `cached_at`) |
+| `order` | string | `asc` or `desc` (default: `desc`) |
+
+The response is `{ "data": [...], "total": 0, "records_total": 0, "limit": 25, "offset": 0 }`, where `total` counts the entries matching the filters and `records_total` counts every entry in the cache. Each item carries `domain`, `type`, `answers`, `canonical_name`, `dnssec_status`, `ttl`, `remaining_ttl`, `cached_at`, `expires_at`, `hits`, `last_access`, `permanent`, and `stale`. Timestamps are UNIX epoch seconds; `remaining_ttl` and `expires_at` are `null` for permanent entries.
+
+`hits` counts only lookups served from the shared cache — queries absorbed by the per-thread L1 cache are not included, so hot A/AAAA records report fewer hits than they actually served.
+
+### Delete Cache Entry
+
+```http
+DELETE /api/cache/entries?domain=example.com&type=A
+```
+
+Removes a single cache entry. Returns `204 No Content` on success, `404` if the entry is not cached, and `400` if the record type is unknown.
+
 ---
 
 ## Upstream Health

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -80,6 +80,14 @@ Multi-tab filtering management:
 - Automatic PTR generation from A records
 - Conditional forwarding configuration
 
+### Cache Control
+
+- Lists the entries currently held in the DNS cache: insertion time, remaining TTL, domain (with DNSSEC validation status), record type, answer, and hit count
+- Search by domain substring
+- Sort by clicking any column header (repeat click reverses the direction)
+- Paginated listing with a configurable page size
+- **Remove** — drop an individual entry from the cache
+
 ### Settings
 
 - **System Status** — hostname, kernel, CPU load, memory usage, uptime

--- a/web/static/block-services.html
+++ b/web/static/block-services.html
@@ -52,6 +52,7 @@
         <div class="nav-section">
             <div class="nav-section-title">DNS CONTROL</div>
             <a href="/local-dns-settings.html" class="nav-item"><i data-lucide="server" class="nav-icon"></i><span>Local DNS</span></a>
+            <a href="/cache-control.html" class="nav-item"><i data-lucide="database" class="nav-icon"></i><span>Cache Control</span></a>
             <a href="/settings.html" class="nav-item"><i data-lucide="settings" class="nav-icon"></i><span>Settings</span></a>
         </div>
     </nav>

--- a/web/static/cache-control.css
+++ b/web/static/cache-control.css
@@ -1,0 +1,209 @@
+        .card {
+            padding: 16px
+        }
+
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 4px 12px;
+            border-radius: 9999px;
+            font-size: 12px;
+            font-weight: 600
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: fixed;
+            min-width: 560px
+        }
+
+        .col-time { width: 120px }
+        .col-ttl { width: 110px }
+        .col-hit { width: 70px }
+        .col-answer {
+            width: 150px;
+            font-family: monospace;
+            font-size: 12px;
+            line-height: 1.4
+        }
+
+        /* Count of the answers that did not fit in the two visible lines —
+           the full list lives in the cell's tooltip. */
+        .answer-more {
+            display: inline-block;
+            margin-top: 2px;
+            padding: 1px 6px;
+            border-radius: 9999px;
+            font-family: inherit;
+            font-size: 10px;
+            font-weight: 600;
+            background: rgba(107, 114, 128, 0.15);
+            color: var(--text-secondary)
+        }
+
+        /* Hover tooltip listing every answer, one per line — same treatment as
+           the DNSSEC icon below, but left-aligned to the cell. */
+        .answer-tip {
+            position: relative;
+            cursor: default
+        }
+
+        .answer-tip::after {
+            content: attr(data-tooltip);
+            position: absolute;
+            bottom: calc(100% + 7px);
+            left: 0;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 11px;
+            line-height: 1.5;
+            text-align: left;
+            white-space: pre;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.15s;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border-color);
+            color: var(--text-primary);
+            z-index: 10;
+        }
+
+        .answer-tip:hover::after {
+            opacity: 1
+        }
+
+        @media (max-width: 1100px) {
+            .col-hit { display: none }
+        }
+
+        @media (max-width: 900px) {
+            .col-answer { display: none }
+        }
+
+        @media (max-width: 820px) {
+            .col-type { display: none }
+        }
+
+        /* Phones: drop the table min-width and the TTL column, and shrink TIME
+           so the DOMAIN column keeps enough room to show the cached name
+           instead of collapsing to zero width. */
+        @media (max-width: 640px) {
+            table { min-width: 0 }
+            .col-ttl { display: none }
+            .col-time { width: 86px }
+            th, td { padding: 8px 6px }
+        }
+
+        th {
+            padding: 8px 10px;
+            text-align: left;
+            font-weight: 600;
+            font-size: 12px;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            border-bottom: 1px solid var(--border-color)
+        }
+
+        /* Sortable headers: the arrow marks the active column and its
+           direction; clicking the active one flips it. */
+        th.th-sort {
+            cursor: pointer;
+            user-select: none;
+            transition: color 0.15s
+        }
+
+        th.th-sort:hover {
+            color: var(--text-primary)
+        }
+
+        .sort-arrow {
+            font-size: 11px;
+            color: var(--color-primary)
+        }
+
+        td {
+            padding: 8px 10px;
+            border-bottom: 1px solid var(--border-color);
+            font-size: 14px
+        }
+
+        tr:hover {
+            opacity: 0.85
+        }
+
+        /* Past its TTL but still inside the grace period the resolver serves
+           from. */
+        .badge-stale {
+            display: inline-block;
+            margin-left: 4px;
+            padding: 1px 6px;
+            border-radius: 9999px;
+            font-size: 10px;
+            font-weight: 600;
+            background: rgba(245, 158, 11, 0.15);
+            color: var(--color-warning)
+        }
+
+        .dnssec-icon {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            cursor: default;
+        }
+
+        .dnssec-icon::after {
+            content: attr(data-tooltip);
+            position: absolute;
+            bottom: calc(100% + 7px);
+            left: 50%;
+            transform: translateX(-50%);
+            padding: 3px 8px;
+            border-radius: 4px;
+            font-size: 11px;
+            font-weight: 700;
+            font-family: monospace;
+            letter-spacing: 0.05em;
+            white-space: nowrap;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.15s;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border-color);
+            z-index: 10;
+        }
+
+        .dnssec-icon::before {
+            content: '';
+            position: absolute;
+            bottom: calc(100% + 2px);
+            left: 50%;
+            transform: translateX(-50%);
+            border: 4px solid transparent;
+            border-top-color: var(--border-color);
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.15s;
+            z-index: 10;
+        }
+
+        .dnssec-icon:hover::after,
+        .dnssec-icon:hover::before {
+            opacity: 1;
+        }
+
+        .dnssec-icon[data-tooltip="SECURE"]::after        { color: #22C55E; }
+        .dnssec-icon[data-tooltip="INSECURE"]::after      { color: #EAB308; }
+        .dnssec-icon[data-tooltip="BOGUS"]::after         { color: #EF4444; }
+        .dnssec-icon[data-tooltip="NOT VALIDATED"]::after { color: #9CA3AF; }
+
+        .col-action { text-align: center }
+        @media (max-width: 700px) {
+            .col-action { display: none }
+        }
+        .btn-action { padding: 4px 10px; border-radius: 6px; font-size: 11px; font-weight: 600; border: none; cursor: pointer; transition: background 0.15s }
+        .btn-action:disabled { opacity: 0.5; cursor: not-allowed }
+        .btn-action-remove { background: rgba(239, 68, 68, 0.15); color: #EF4444 }
+        .btn-action-remove:hover:not(:disabled) { background: rgba(239, 68, 68, 0.3) }

--- a/web/static/cache-control.html
+++ b/web/static/cache-control.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ferrous DNS - Query Log</title>
+    <title>Ferrous DNS - Cache Control</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.5/dist/cdn.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/lucide@0.469.0/dist/umd/lucide.min.js"></script>
@@ -11,7 +11,7 @@
     <script src="/ferrous-config.js"></script>
     <script src="/static/shared.js"></script>
     <link rel="icon" type="image/svg+xml" href="/static/logo.svg">
-    <link rel="stylesheet" href="/static/queries.css">
+    <link rel="stylesheet" href="/static/cache-control.css">
 </head>
 <body x-data="app()" x-init="init()">
 <div class="mobile-header">
@@ -44,7 +44,7 @@
         <div class="nav-section">
             <div class="nav-section-title">MAIN</div>
             <a href="/dashboard.html" class="nav-item"><i data-lucide="layout-dashboard" class="nav-icon"></i><span>Dashboard</span></a>
-            <a href="/queries.html" class="nav-item active"><i data-lucide="file-text" class="nav-icon"></i><span>Query Log</span></a>
+            <a href="/queries.html" class="nav-item"><i data-lucide="file-text" class="nav-icon"></i><span>Query Log</span></a>
             <a href="/dnssec.html" class="nav-item"><i data-lucide="shield-check" class="nav-icon"></i><span>DNSSEC</span></a>
         </div>
         <div class="nav-section">
@@ -69,9 +69,8 @@
         <div class="nav-section">
             <div class="nav-section-title">DNS CONTROL</div>
             <a href="/local-dns-settings.html" class="nav-item"><i data-lucide="server" class="nav-icon"></i><span>Local DNS</span></a>
-            <a href="/cache-control.html" class="nav-item"><i data-lucide="database" class="nav-icon"></i><span>Cache Control</span></a>
-            <a href="/settings.html" class="nav-item"><i data-lucide="settings"
-                                                         class="nav-icon"></i><span>Settings</span></a>
+            <a href="/cache-control.html" class="nav-item active"><i data-lucide="database" class="nav-icon"></i><span>Cache Control</span></a>
+            <a href="/settings.html" class="nav-item"><i data-lucide="settings" class="nav-icon"></i><span>Settings</span></a>
         </div>
     </nav>
     <div id="server-version" style="font-size:11px;color:var(--text-tertiary);padding:0 24px 4px"></div>
@@ -84,15 +83,17 @@
 <main style="padding:24px">
     <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:24px">
         <div>
-            <h2 style="font-size:24px;font-weight:700;color:var(--text-primary)">Query Log</h2>
-            <p style="font-size:14px;color:var(--text-secondary);margin-top:4px">DNS query history — last 24h</p>
+            <h2 style="font-size:24px;font-weight:700;color:var(--text-primary)">Cache Control</h2>
+            <p style="font-size:14px;color:var(--text-secondary);margin-top:4px">
+                Entries currently held in the DNS cache — <span x-text="recordsTotal"></span> total
+            </p>
         </div>
     </div>
     <div class="card" style="margin-bottom:24px">
         <div style="display:flex;align-items:center;gap:24px;flex-wrap:wrap">
             <div style="display:flex;align-items:center;gap:8px">
                 <label style="font-size:14px;font-weight:500;color:var(--text-secondary);white-space:nowrap">Show:</label>
-                <select x-model.number="pageSize" @change="currentPage=1;_cursors={};loadQueries()"
+                <select x-model.number="pageSize" @change="currentPage=1;loadEntries()"
                         style="padding:8px 12px;border:1px solid var(--border-color);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px">
                     <option value="10">10</option>
                     <option value="25">25</option>
@@ -102,32 +103,9 @@
             </div>
             <div style="display:flex;align-items:center;gap:8px">
                 <label style="font-size:14px;font-weight:500;color:var(--text-secondary);white-space:nowrap">Domain:</label>
-                <input type="text" x-model="searchDomain" @input.debounce.400ms="currentPage=1;_cursors={};loadQueries()"
+                <input type="text" x-model="searchDomain" @input.debounce.400ms="currentPage=1;loadEntries()"
                        placeholder="Search domain..."
                        style="padding:8px 12px;border:1px solid var(--border-color);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px;width:200px">
-            </div>
-            <div style="display:flex;align-items:center;gap:8px">
-                <label style="font-size:14px;font-weight:500;color:var(--text-secondary);white-space:nowrap">Client:</label>
-                <select x-model="searchClient" @change="currentPage=1;_cursors={};loadQueries()"
-                        style="padding:8px 12px;border:1px solid var(--border-color);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px;width:200px">
-                    <option value="">All Clients</option>
-                    <template x-for="client in clients" :key="client.ip_address">
-                        <option :value="client.ip_address" x-text="clientLabel(client)"></option>
-                    </template>
-                </select>
-            </div>
-            <div style="display:flex;align-items:center;gap:8px">
-                <label style="font-size:14px;font-weight:500;color:var(--text-secondary);white-space:nowrap">Category:</label>
-                <select x-model="category" @change="currentPage=1;_cursors={};loadQueries()"
-                        style="padding:8px 12px;border:1px solid var(--border-color);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px">
-                    <option value="">All Queries</option>
-                    <option value="allowed">Allowed</option>
-                    <option value="blocked">Blocked</option>
-                    <option value="cache">Cache Hits</option>
-                    <option value="upstream">Upstream</option>
-                    <option value="rate-limited">Rate Limited</option>
-                    <option value="malware">Malware Detection</option>
-                </select>
             </div>
             <div style="margin-left:auto">
                 <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
@@ -142,99 +120,97 @@
         <table>
             <thead>
             <tr>
-                <th class="col-time">TIME</th>
-                <th>DOMAIN</th>
-                <th class="col-type" style="width:70px">TYPE</th>
-                <th class="col-client">CLIENT</th>
-                <th class="col-source">SOURCE</th>
+                <th class="col-time th-sort" @click="sortBy('cached_at')" title="Sort by insertion time">TIME<span
+                        class="sort-arrow" x-text="sortArrow('cached_at')"></span></th>
+                <th class="th-sort" @click="sortBy('domain')" title="Sort by domain">DOMAIN<span class="sort-arrow"
+                        x-text="sortArrow('domain')"></span></th>
+                <th class="col-type th-sort" style="width:70px" @click="sortBy('type')" title="Sort by record type">TYPE<span
+                        class="sort-arrow" x-text="sortArrow('type')"></span></th>
                 <th class="col-answer">ANSWER</th>
-                <th class="col-rt" style="width:110px">RESPONSE TIME</th>
-                <th class="col-action" style="width:80px">ACTION</th>
+                <th class="col-ttl th-sort" @click="sortBy('expires_at')" title="Sort by remaining TTL">TTL<span
+                        class="sort-arrow" x-text="sortArrow('expires_at')"></span></th>
+                <th class="col-hit th-sort" @click="sortBy('hits')"
+                    title="Hits served from the shared cache. Lookups absorbed by the per-thread L1 cache are not counted.">
+                    HIT<span class="sort-arrow" x-text="sortArrow('hits')"></span></th>
+                <th class="col-action" style="width:90px">ACTION</th>
             </tr>
             </thead>
             <tbody>
-            <template x-for="query in paginatedQueries" :key="query.id||Math.random()">
-                <tr :class="(query.block_source === 'dns_tunneling' || query.block_source === 'dns_rebinding' || query.block_source === 'nxdomain_hijack' || query.block_source === 'response_ip_filter' || query.block_source === 'dga_detection') ? 'row-malware' : (query.response_status === 'RATE_LIMITED' || query.response_status === 'RATE_LIMITED_TC') ? 'row-rate-limited' : query.blocked ? 'row-blocked' : 'row-allowed'">
-                    <td style="font-size:12px" x-text="formatTime(query.timestamp)"></td>
+            <template x-for="entry in entries" :key="entry.domain + '|' + entry.type">
+                <tr>
+                    <td style="font-size:12px" x-text="formatCachedAt(entry.cached_at)"></td>
                     <td style="font-family:monospace;font-size:14px;max-width:0;overflow:hidden">
                         <div style="display:flex;align-items:center;gap:5px;overflow:hidden">
-                            <template x-if="query.dnssec_status === 'Secure'">
+                            <template x-if="entry.dnssec_status === 'Secure'">
                                 <span class="dnssec-icon" data-tooltip="SECURE">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
                                 </span>
                             </template>
-                            <template x-if="query.dnssec_status === 'Insecure'">
+                            <template x-if="entry.dnssec_status === 'Insecure'">
                                 <span class="dnssec-icon" data-tooltip="INSECURE">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#EAB308" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
                                 </span>
                             </template>
-                            <template x-if="query.dnssec_status === 'Bogus'">
+                            <template x-if="entry.dnssec_status === 'Bogus'">
                                 <span class="dnssec-icon" data-tooltip="BOGUS">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#EF4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
                                 </span>
                             </template>
-                            <template x-if="!['Secure','Insecure','Bogus'].includes(query.dnssec_status)">
+                            <template x-if="!['Secure','Insecure','Bogus'].includes(entry.dnssec_status)">
                                 <span class="dnssec-icon" data-tooltip="NOT VALIDATED">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#6B7280" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 9.9-1"/></svg>
                                 </span>
                             </template>
-                            <span x-text="query.domain" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap" :title="query.domain"></span>
+                            <span x-text="entry.domain" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap" :title="entry.domain"></span>
                         </div>
                     </td>
                     <td class="col-type"><span class="badge" style="background:rgba(59,130,246,0.1);color:#3B82F6"
-                              x-text="query.type"></span></td>
-                    <td class="col-client" style="font-size:13px"
-                        x-text="query.client_hostname ? query.client_hostname + ' (' + query.client + ')' : query.client"></td>
-                    <td style="max-width:0;overflow:hidden">
-                        <span class="badge" style="max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"
-                              :style="query.cache_hit
-                                ? 'background:rgba(168,85,247,0.1);color:#A855F7'
-                                : (query.block_source === 'dns_tunneling' || query.block_source === 'dns_rebinding' || query.block_source === 'nxdomain_hijack' || query.block_source === 'response_ip_filter' || query.block_source === 'dga_detection')
-                                  ? 'background:rgba(245,158,11,0.1);color:#F59E0B'
-                                  : query.block_source === 'blocklist'
-                                    ? 'background:rgba(239,68,68,0.1);color:#ef4444'
-                                    : query.block_source === 'managed_domain'
-                                      ? 'background:rgba(249,115,22,0.1);color:#f97316'
-                                      : query.block_source === 'regex_filter'
-                                        ? 'background:rgba(139,92,246,0.1);color:#8b5cf6'
-                                        : query.response_status === 'LOCAL_DNS'
-                                          ? 'background:rgba(34,197,94,0.1);color:#22C55E'
-                                          : 'background:rgba(59,130,246,0.1);color:#3B82F6'"
-                              x-html="formatSource(query)"
-                              :title="query.upstream_pool && query.upstream_server
-                                ? query.upstream_pool + ':' + query.upstream_server
-                                : ''"></span>
-                    </td>
+                              x-text="entry.type"></span></td>
                     <td class="col-answer">
-                        <template x-if="!query.answers || !query.answers.length">
-                            <span style="color:var(--text-secondary)">—</span>
-                        </template>
-                        <template x-if="query.answers && query.answers.length">
-                            <div class="answer-tip" :data-tooltip="query.answers.join('\n')">
-                                <template x-for="(ip, i) in query.answers.slice(0, 2)" :key="i">
+                        <template x-if="entry.answers && entry.answers.length">
+                            <div class="answer-tip" :data-tooltip="entry.answers.join('\n')">
+                                <template x-for="(ip, i) in entry.answers.slice(0, 2)" :key="i">
                                     <div x-text="ip" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap"></div>
                                 </template>
-                                <template x-if="query.answers.length > 2">
-                                    <span class="answer-more" x-text="'+' + (query.answers.length - 2)"></span>
+                                <template x-if="entry.answers.length > 2">
+                                    <span class="answer-more" x-text="'+' + (entry.answers.length - 2)"></span>
                                 </template>
                             </div>
                         </template>
+                        <template x-if="(!entry.answers || !entry.answers.length) && entry.canonical_name">
+                            <div x-text="entry.canonical_name" :title="entry.canonical_name"
+                                 style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap"></div>
+                        </template>
+                        <template x-if="(!entry.answers || !entry.answers.length) && !entry.canonical_name">
+                            <span style="color:var(--text-secondary)">—</span>
+                        </template>
                     </td>
-                    <td class="col-rt" style="font-size:13px" x-text="formatResponseTime(query)"></td>
+                    <td class="col-ttl" style="font-size:13px">
+                        <span x-text="formatTtl(entry)"></span>
+                        <template x-if="entry.stale">
+                            <span class="badge-stale">stale</span>
+                        </template>
+                    </td>
+                    <td class="col-hit" style="font-size:13px" x-text="entry.hits"></td>
                     <td class="col-action">
-                        <button type="button" class="btn-action"
-                            :class="query.blocked ? 'btn-action-allow' : 'btn-action-block'"
-                            @click="handleDomainAction(query)"
-                            x-text="query.blocked ? 'Allow' : 'Block'">
+                        <button type="button" class="btn-action btn-action-remove"
+                            :disabled="removing === entry.domain + '|' + entry.type"
+                            @click="removeEntry(entry)">Remove
                         </button>
                     </td>
+                </tr>
+            </template>
+            <template x-if="entries.length === 0">
+                <tr>
+                    <td colspan="7" style="text-align:center;color:var(--text-secondary);padding:32px 0"
+                        x-text="searchDomain ? 'No cached entries match this domain.' : 'No entries in the cache yet.'"></td>
                 </tr>
             </template>
             </tbody>
         </table>
         <div style="display:flex;align-items:center;justify-content:space-between;padding:16px 0;margin-top:16px;border-top:1px solid var(--border-color)">
             <div style="font-size:14px;color:var(--text-secondary)">
-                Showing <span x-text="(currentPage-1)*pageSize+1"></span> to <span
+                Showing <span x-text="total === 0 ? 0 : (currentPage-1)*pageSize+1"></span> to <span
                     x-text="Math.min(currentPage*pageSize,total)"></span> of <span
                     x-text="total"></span>
             </div>
@@ -243,14 +219,14 @@
                         style="padding:8px 16px;border-radius:6px;border:1px solid var(--border-color);background:var(--bg-secondary);color:var(--text-primary);cursor:pointer;font-size:14px"
                         :style="currentPage===1?'opacity:0.5;cursor:not-allowed':''">Previous
                 </button>
-                <button @click="changePage(1)" :disabled="!_hasMore"
+                <button @click="changePage(1)" :disabled="!hasMore"
                         style="padding:8px 16px;border-radius:6px;border:1px solid var(--border-color);background:var(--bg-secondary);color:var(--text-primary);cursor:pointer;font-size:14px"
-                        :style="!_hasMore?'opacity:0.5;cursor:not-allowed':''">Next
+                        :style="!hasMore?'opacity:0.5;cursor:not-allowed':''">Next
                 </button>
             </div>
         </div>
     </div>
 </main>
-<script src="/static/queries.js"></script>
+<script src="/static/cache-control.js"></script>
 </body>
 </html>

--- a/web/static/cache-control.js
+++ b/web/static/cache-control.js
@@ -1,0 +1,161 @@
+    function app() {
+        return {
+            theme: 'light',
+            queryRate: {queries: 0, rate: '0 q/s'},
+            entries: [],
+            total: 0,
+            recordsTotal: 0,
+            pageSize: 25,
+            currentPage: 1,
+            searchDomain: '',
+            sortField: 'cached_at',
+            sortOrder: 'desc',
+            autoRefresh: false,
+            removing: null,
+            stats: {queries_total: 0},
+            _ctrl: {},
+            _pollId: null,
+
+            async init() {
+                this.theme = localStorage.getItem('theme') || 'light';
+                document.documentElement.classList.toggle('dark', this.theme === 'dark');
+                await checkAuth();
+                startRatePolling(rate => { this.queryRate = rate; });
+                await Promise.all([this.loadEntries(), this.loadStats()]);
+                scheduleLucide(100);
+                this.startPolling();
+                document.addEventListener('visibilitychange', () => {
+                    if (document.hidden) this.stopPolling();
+                    else this.startPolling();
+                });
+            },
+
+            toggleTheme() {
+                this.theme = this.theme === 'light' ? 'dark' : 'light';
+                localStorage.setItem('theme', this.theme);
+                document.documentElement.classList.toggle('dark', this.theme === 'dark');
+                scheduleLucide();
+            },
+
+            async loadEntries() {
+                this._ctrl.entries?.abort();
+                this._ctrl.entries = new AbortController();
+                try {
+                    const offset = (this.currentPage - 1) * this.pageSize;
+                    const domainParam = this.searchDomain
+                        ? `&domain=${encodeURIComponent(this.searchDomain)}`
+                        : '';
+                    const res = await apiFetch(
+                        `${API_BASE}/cache/entries?limit=${this.pageSize}&offset=${offset}`
+                        + `&sort=${this.sortField}&order=${this.sortOrder}${domainParam}`,
+                        {signal: this._ctrl.entries.signal}
+                    );
+                    if (res.ok) {
+                        const result = await res.json();
+                        this.entries = result.data || [];
+                        this.total = result.total ?? this.entries.length;
+                        this.recordsTotal = result.records_total ?? this.total;
+                    }
+                } catch (e) {
+                    if (e.name !== 'AbortError') console.error('Error loading cache entries:', e);
+                }
+            },
+
+            async loadStats() {
+                this._ctrl.stats?.abort();
+                this._ctrl.stats = new AbortController();
+                try {
+                    const res = await fetch(`${API_BASE}/stats`, {signal: this._ctrl.stats.signal});
+                    if (res.ok) {
+                        const stats = await res.json();
+                        this.stats.queries_total = stats.queries_total || 0;
+                    }
+                } catch (e) {
+                    if (e.name !== 'AbortError') console.error('Failed to load stats:', e);
+                }
+            },
+
+            get hasMore() {
+                return this.currentPage * this.pageSize < this.total;
+            },
+
+            async changePage(delta) {
+                const next = this.currentPage + delta;
+                if (next < 1) return;
+                if (delta > 0 && !this.hasMore) return;
+                this.currentPage = next;
+                await this.loadEntries();
+            },
+
+            // Clicking the active column flips the direction; a new column
+            // starts on `desc`, which is the useful end for every field here.
+            async sortBy(field) {
+                if (this.sortField === field) {
+                    this.sortOrder = this.sortOrder === 'desc' ? 'asc' : 'desc';
+                } else {
+                    this.sortField = field;
+                    this.sortOrder = 'desc';
+                }
+                this.currentPage = 1;
+                await this.loadEntries();
+            },
+
+            sortArrow(field) {
+                if (this.sortField !== field) return '';
+                return this.sortOrder === 'desc' ? ' ↓' : ' ↑';
+            },
+
+            startPolling() {
+                this.stopPolling();
+                this._pollId = setInterval(() => {
+                    if (this.autoRefresh) {
+                        this.loadEntries();
+                        this.loadStats();
+                    }
+                }, 1000);
+            },
+
+            stopPolling() {
+                clearInterval(this._pollId);
+                this._pollId = null;
+                stopRatePolling();
+            },
+
+            formatCachedAt(cachedAt) {
+                if (!cachedAt) return '-';
+                return new Date(cachedAt * 1000).toLocaleTimeString();
+            },
+
+            // Permanent entries never expire; stale ones already hit zero and
+            // are flagged separately by the badge next to this value.
+            formatTtl(entry) {
+                if (entry.permanent) return '—';
+                const secs = entry.remaining_ttl ?? 0;
+                if (secs < 60) return `${secs}s`;
+                if (secs < 3600) return `${Math.floor(secs / 60)}m ${secs % 60}s`;
+                return `${Math.floor(secs / 3600)}h ${Math.floor((secs % 3600) / 60)}m`;
+            },
+
+            async removeEntry(entry) {
+                const marker = entry.domain + '|' + entry.type;
+                this.removing = marker;
+                try {
+                    const res = await apiFetch(
+                        `${API_BASE}/cache/entries?domain=${encodeURIComponent(entry.domain)}`
+                        + `&type=${encodeURIComponent(entry.type)}`,
+                        {method: 'DELETE'}
+                    );
+                    if (res.ok || res.status === 404) {
+                        await this.loadEntries();
+                    } else {
+                        console.error('Failed to remove cache entry:', await res.text());
+                        alert(`Failed to remove "${entry.domain}" (${entry.type}).`);
+                    }
+                } catch (e) {
+                    alert(`Network error: ${e.message}`);
+                } finally {
+                    this.removing = null;
+                }
+            }
+        };
+    }

--- a/web/static/clients.html
+++ b/web/static/clients.html
@@ -90,6 +90,10 @@
                 <i data-lucide="server" class="nav-icon"></i>
                 <span>Local DNS</span>
             </a>
+            <a href="/cache-control.html" class="nav-item">
+                <i data-lucide="database" class="nav-icon"></i>
+                <span>Cache Control</span>
+            </a>
             <a href="/settings.html" class="nav-item">
                 <i data-lucide="settings" class="nav-icon"></i>
                 <span>Settings</span>

--- a/web/static/dashboard.html
+++ b/web/static/dashboard.html
@@ -75,6 +75,7 @@
         <div class="nav-section">
             <div class="nav-section-title">DNS CONTROL</div>
             <a href="/local-dns-settings.html" class="nav-item"><i data-lucide="server" class="nav-icon"></i><span>Local DNS</span></a>
+            <a href="/cache-control.html" class="nav-item"><i data-lucide="database" class="nav-icon"></i><span>Cache Control</span></a>
             <a href="/settings.html" class="nav-item"><i data-lucide="settings"
                                                          class="nav-icon"></i><span>Settings</span></a>
         </div>

--- a/web/static/dns-filter.html
+++ b/web/static/dns-filter.html
@@ -75,6 +75,7 @@
         <div class="nav-section">
             <div class="nav-section-title">DNS CONTROL</div>
             <a href="/local-dns-settings.html" class="nav-item"><i data-lucide="server" class="nav-icon"></i><span>Local DNS</span></a>
+            <a href="/cache-control.html" class="nav-item"><i data-lucide="database" class="nav-icon"></i><span>Cache Control</span></a>
             <a href="/settings.html" class="nav-item"><i data-lucide="settings" class="nav-icon"></i><span>Settings</span></a>
         </div>
     </nav>

--- a/web/static/dnssec.html
+++ b/web/static/dnssec.html
@@ -70,6 +70,7 @@
         <div class="nav-section">
             <div class="nav-section-title">DNS CONTROL</div>
             <a href="/local-dns-settings.html" class="nav-item"><i data-lucide="server" class="nav-icon"></i><span>Local DNS</span></a>
+            <a href="/cache-control.html" class="nav-item"><i data-lucide="database" class="nav-icon"></i><span>Cache Control</span></a>
             <a href="/settings.html" class="nav-item"><i data-lucide="settings"
                                                          class="nav-icon"></i><span>Settings</span></a>
         </div>

--- a/web/static/groups.html
+++ b/web/static/groups.html
@@ -75,6 +75,8 @@
             <div class="nav-section-title">DNS CONTROL</div>
             <a href="/local-dns-settings.html" class="nav-item"><i data-lucide="server"
                                                                    class="nav-icon"></i><span>Local DNS</span></a>
+            <a href="/cache-control.html" class="nav-item"><i data-lucide="database"
+                                                              class="nav-icon"></i><span>Cache Control</span></a>
             <a href="/settings.html" class="nav-item"><i data-lucide="settings"
                                                          class="nav-icon"></i><span>Settings</span></a>
         </div>

--- a/web/static/local-dns-settings.html
+++ b/web/static/local-dns-settings.html
@@ -74,6 +74,10 @@
                 <i data-lucide="server" class="nav-icon"></i>
                 <span>Local DNS</span>
             </a>
+            <a href="/cache-control.html" class="nav-item">
+                <i data-lucide="database" class="nav-icon"></i>
+                <span>Cache Control</span>
+            </a>
             <a href="/settings.html" class="nav-item">
                 <i data-lucide="settings" class="nav-icon"></i>
                 <span>Settings</span>

--- a/web/static/settings.html
+++ b/web/static/settings.html
@@ -71,6 +71,7 @@
         <div class="nav-section">
             <div class="nav-section-title">DNS CONTROL</div>
             <a href="/local-dns-settings.html" class="nav-item"><i data-lucide="server" class="nav-icon"></i><span>Local DNS</span></a>
+            <a href="/cache-control.html" class="nav-item"><i data-lucide="database" class="nav-icon"></i><span>Cache Control</span></a>
             <a href="/settings.html" class="nav-item active"><i data-lucide="settings" class="nav-icon"></i><span>Settings</span></a>
         </div>
     </nav>


### PR DESCRIPTION
## Summary

The admin UI had no way to see what the resolver is actually holding in memory — the only cache control available was a full flush. This adds a **Cache Control** page backed by a new listing endpoint, so an operator can inspect the live cache and drop individual entries.

### Infrastructure

`DnsCache::list_entries` builds a filtered, ordered and paginated snapshot of the positive cache. Entries inside the stale grace period are listed and flagged as stale, since the resolver still serves them; negative responses, records marked for deletion and fully expired records are skipped. `DashMap` has no stable iteration order, so equal sort keys are broken by `(domain, record type)` — always ascending — to keep paging reproducible in both directions.

### API

`GET /api/cache/entries` exposes the snapshot with `domain` and `type` filters, five sort keys (`cached_at`, `expires_at`, `hits`, `domain`, `type`), and an offset/limit window. The response carries both a filtered `total` and the raw `records_total`; the two differ whenever the map still holds entries the listing excludes, such as a record that expired past its grace period but has not been compacted yet.

### Web

The page polls the endpoint with an optional live-update toggle. Two details worth calling out in review:

- The TTL column shows the **remaining** TTL, not the original one from the upstream response. Both are in the payload; the remaining value is what an operator needs.
- The HIT column undercounts A and AAAA on purpose, and the column tooltip says so. Those types are promoted to the per-thread L1 cache, and an L1 hit returns before reaching the shared counter. Measured on a live server: five identical queries produced `hits=4` for a TXT record and `hits=1` for an A record of the same domain.

This is also why the default sort is insertion time rather than hit count — sorting by hits would put TXT and MX records on top and bury the hottest A records.

## Test plan

- [x] `make ci` green (fmt-check + clippy `-D warnings` + full test suite).
- [x] Doc tests, and `scripts/check-docs-version.sh` clean.
- [x] New tests: `crates/infrastructure/tests/cache_list_entries_test.rs` (filtering, ordering, stale flagging, paging) and `crates/api/tests/cache_entries_api_tests.rs` (query params, validation, response shape).
- [x] Manual: ran the resolver against real upstreams, populated the cache with ~25 entries across A, AAAA, TXT and MX, and verified the page against the API payload — remaining TTL counting down, stale badge appearing at the grace period, permanent local records showing an em dash, and per-entry deletion removing exactly one record from the map.

## Known follow-ups / out of scope

- `cargo audit` was not run locally: `cargo-audit` is not installed on this machine. CI still covers it.
- The TIME column shows the last insertion, which the proactive refresh job rewrites (`storage.rs:500`), so a batch of entries renewed in the same cycle shares a timestamp. That is faithful to what the cache stores, but it means the column cannot tell you how long a domain has been known. `last_access` is already in the API payload and unused by the table — exposing it would cover that, and is deliberately left out of this PR.
- Below 900px the responsive rules hide ANSWER while keeping TTL, so the narrow layout reads TIME · DOMAIN · TTL. Functional, but the breakpoint order is worth a second opinion.
