### PR TITLE
fix(web): key Local DNS records by id so hosts with both A and AAAA render

### DIFF
--- a/web/static/local-dns-settings.html
+++ b/web/static/local-dns-settings.html
@@ -164,7 +164,7 @@
                 </tr>
                 </thead>
                 <tbody>
-                <template x-for="record in records" :key="record.fqdn">
+                <template x-for="record in records" :key="record.id">
                     <tr>
                         <td>
                             <span style="font-family:monospace;font-size:13px;color:var(--text-primary)" x-text="record.fqdn"></span>


### PR DESCRIPTION
## What

Change the Alpine `x-for` key on the Local DNS records table from `record.fqdn` to `record.id`.

## Why

`x-for` keys must be unique. A host with both an A and an AAAA record produces two rows with the same `fqdn`. Alpine throws on the duplicate key and the whole records table renders empty, even though the records exist and the API returns them.

## How

`record.id` is unique per row, since `LocalRecordDto::from_config` assigns the list index as the id. The same template already uses it in `deleteRecord(record.id)`, so the field is always present in the payload.

## Testing

Add two records for the same hostname, one A and one AAAA, then open the Local DNS page. Before this change the table is empty; with it both rows render. I have run this fix as a build-time patch on a production instance since June 2026.
