### PR TITLE
fix(dns): answer UDP queries on dual-stack and IPv6 binds

### DIFF
--- a/crates/cli/src/server/dns/mod.rs
+++ b/crates/cli/src/server/dns/mod.rs
@@ -25,12 +25,19 @@ pub async fn start_dns_server(
     core_ids: Vec<core_affinity::CoreId>,
     tcp_conn_limiter: ConnectionLimiter,
 ) -> anyhow::Result<()> {
-    let socket_addr: SocketAddr = bind_addr.parse()?;
-    let domain = if socket_addr.is_ipv4() {
-        Domain::IPV4
-    } else {
-        Domain::IPV6
+    let parsed: SocketAddr = bind_addr.parse()?;
+    // Unify the UDP/TCP path on a dual-stack AF_INET6 socket. IPv4 binds are
+    // mapped to `::ffff:a.b.c.d` so the pktinfo plumbing can always assume
+    // sockaddr_in6 / in6_pktinfo; `set_only_v6(false)` (in create_*_socket) lets
+    // a `[::]` bind answer both families. A mapped IPv4 bind preserves v4-only
+    // behaviour for that single address.
+    let socket_addr: SocketAddr = match parsed {
+        SocketAddr::V4(v4) => {
+            SocketAddr::new(std::net::IpAddr::V6(v4.ip().to_ipv6_mapped()), v4.port())
+        }
+        SocketAddr::V6(_) => parsed,
     };
+    let domain = Domain::IPV6;
 
     info!(bind_address = %socket_addr, num_workers, "Starting DNS server with SO_REUSEPORT");
 

--- a/crates/cli/src/server/dns/pktinfo.rs
+++ b/crates/cli/src/server/dns/pktinfo.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use socket2::Socket;
@@ -13,7 +13,11 @@ const RECV_BUF_SIZE: usize = 512;
 #[cfg(target_os = "linux")]
 const CMSG_BUF_SIZE: usize = 128;
 
-// ── IP_PKTINFO setup ─────────────────────────────────────────────────────────
+// ── IPV6_PKTINFO setup ───────────────────────────────────────────────────────
+//
+// The UDP path is unified on AF_INET6 dual-stack sockets (see mod.rs): IPv4
+// clients arrive as v4-mapped addresses (`::ffff:a.b.c.d`) and the kernel
+// delivers their destination via IPV6_PKTINFO, so only the IPv6 option is set.
 
 pub fn enable_pktinfo(socket: &Socket) {
     let fd = socket.as_raw_fd();
@@ -22,8 +26,8 @@ pub fn enable_pktinfo(socket: &Socket) {
     unsafe {
         libc::setsockopt(
             fd,
-            libc::IPPROTO_IP,
-            libc::IP_PKTINFO,
+            libc::IPPROTO_IPV6,
+            libc::IPV6_RECVPKTINFO,
             &val as *const libc::c_int as *const libc::c_void,
             std::mem::size_of::<libc::c_int>() as libc::socklen_t,
         );
@@ -77,7 +81,7 @@ pub(super) struct RecvBatch {
     recv_bufs: Vec<u8>,
     /// Contiguous cmsg buffers: slot i occupies [i*CMSG_BUF_SIZE .. (i+1)*CMSG_BUF_SIZE].
     cmsg_bufs: Vec<u8>,
-    src_addrs: Vec<libc::sockaddr_in>,
+    src_addrs: Vec<libc::sockaddr_in6>,
     iovecs: Vec<libc::iovec>,
     /// The mmsghdr array passed directly to recvmmsg.
     pub hdrs: Vec<libc::mmsghdr>,
@@ -97,7 +101,7 @@ impl RecvBatch {
         let mut b = Self {
             recv_bufs: vec![0u8; batch_size * RECV_BUF_SIZE],
             cmsg_bufs: vec![0u8; batch_size * CMSG_BUF_SIZE],
-            // SAFETY: sockaddr_in / iovec / mmsghdr are C structs; zero-init is correct.
+            // SAFETY: sockaddr_in6 / iovec / mmsghdr are C structs; zero-init is correct.
             src_addrs: (0..batch_size)
                 .map(|_| unsafe { std::mem::zeroed() })
                 .collect(),
@@ -132,8 +136,8 @@ impl RecvBatch {
 
             let cmsg_ptr = self.cmsg_bufs.as_mut_ptr().add(i * CMSG_BUF_SIZE);
             let hdr = &mut self.hdrs[i].msg_hdr;
-            hdr.msg_name = &mut self.src_addrs[i] as *mut libc::sockaddr_in as *mut libc::c_void;
-            hdr.msg_namelen = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+            hdr.msg_name = &mut self.src_addrs[i] as *mut libc::sockaddr_in6 as *mut libc::c_void;
+            hdr.msg_namelen = std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
             hdr.msg_iov = &mut self.iovecs[i];
             hdr.msg_iovlen = 1;
             hdr.msg_control = cmsg_ptr as *mut libc::c_void;
@@ -155,7 +159,7 @@ impl RecvBatch {
     pub(super) fn get_msg(&self, i: usize) -> ReceivedMsg<'_> {
         let n = self.hdrs[i].msg_len as usize;
         let data = &self.recv_bufs[i * RECV_BUF_SIZE..i * RECV_BUF_SIZE + n];
-        let src = sockaddr_in_to_socket_addr(&self.src_addrs[i]);
+        let src = sockaddr_in6_to_socket_addr(&self.src_addrs[i]);
         let cmsg_slice = &self.cmsg_bufs[i * CMSG_BUF_SIZE..i * CMSG_BUF_SIZE + CMSG_BUF_SIZE];
         #[allow(clippy::unnecessary_cast)]
         let controllen = self.hdrs[i].msg_hdr.msg_controllen as usize;
@@ -169,9 +173,9 @@ impl RecvBatch {
 pub(super) struct ReceivedMsg<'a> {
     /// Raw wire bytes of the DNS query.
     pub data: &'a [u8],
-    /// Source address of the client.
+    /// Source address of the client (v4-mapped clients normalised to `IpAddr::V4`).
     pub src: SocketAddr,
-    /// Destination IP (our interface) extracted from IP_PKTINFO.
+    /// Destination IP (our interface) extracted from IPV6_PKTINFO.
     pub dst_ip: IpAddr,
 }
 
@@ -212,7 +216,7 @@ pub(super) struct PendingWireResponse {
 pub(super) struct SendBatch {
     /// Contiguous cmsg buffers: slot i occupies [i*cmsg_space .. (i+1)*cmsg_space].
     cmsg_bufs: Vec<u8>,
-    dst_addrs: Vec<libc::sockaddr_in>,
+    dst_addrs: Vec<libc::sockaddr_in6>,
     iovecs: Vec<libc::iovec>,
     /// The mmsghdr array passed directly to sendmmsg.
     pub hdrs: Vec<libc::mmsghdr>,
@@ -231,11 +235,11 @@ impl SendBatch {
     pub(super) fn new(batch_size: usize) -> Self {
         // SAFETY: CMSG_SPACE is a pure size computation; no pointer dereference.
         let cmsg_space =
-            unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::in_pktinfo>() as u32) as usize };
+            unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::in6_pktinfo>() as u32) as usize };
 
         let mut b = Self {
             cmsg_bufs: vec![0u8; batch_size * cmsg_space],
-            // SAFETY: sockaddr_in / iovec / mmsghdr are C structs; zero-init is correct.
+            // SAFETY: sockaddr_in6 / iovec / mmsghdr are C structs; zero-init is correct.
             dst_addrs: (0..batch_size)
                 .map(|_| unsafe { std::mem::zeroed() })
                 .collect(),
@@ -263,8 +267,8 @@ impl SendBatch {
     unsafe fn rewire(&mut self, batch_size: usize) {
         for i in 0..batch_size {
             let hdr = &mut self.hdrs[i].msg_hdr;
-            hdr.msg_name = &mut self.dst_addrs[i] as *mut libc::sockaddr_in as *mut libc::c_void;
-            hdr.msg_namelen = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+            hdr.msg_name = &mut self.dst_addrs[i] as *mut libc::sockaddr_in6 as *mut libc::c_void;
+            hdr.msg_namelen = std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
             hdr.msg_iov = &mut self.iovecs[i];
             hdr.msg_iovlen = 1;
             hdr.msg_control =
@@ -282,7 +286,7 @@ impl SendBatch {
         }
 
         for (i, r) in responses.iter().enumerate() {
-            self.dst_addrs[i] = socket_addr_to_sockaddr_in(r.to);
+            self.dst_addrs[i] = socket_addr_to_sockaddr_in6(r.to);
 
             self.iovecs[i] = libc::iovec {
                 iov_base: r.wire.as_ptr() as *mut libc::c_void,
@@ -295,16 +299,16 @@ impl SendBatch {
 
             let hdr = &mut self.hdrs[i].msg_hdr;
             // msg_name, msg_iov, msg_control already wired in rewire().
-            hdr.msg_namelen = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+            hdr.msg_namelen = std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
             hdr.msg_iovlen = 1;
 
-            if let IpAddr::V4(src_v4) = r.src_ip {
-                let pktinfo = libc::in_pktinfo {
-                    ipi_ifindex: 0,
-                    ipi_spec_dst: libc::in_addr {
-                        s_addr: u32::from_ne_bytes(src_v4.octets()),
-                    },
-                    ipi_addr: libc::in_addr { s_addr: 0 },
+            if is_unspecified(r.src_ip) {
+                // No captured destination: let the kernel pick the source address.
+                hdr.msg_controllen = 0;
+            } else {
+                let pktinfo = libc::in6_pktinfo {
+                    ipi6_addr: ip_to_in6_addr(r.src_ip),
+                    ipi6_ifindex: dest_scope_id(r.to),
                 };
                 hdr.msg_controllen = self.cmsg_space as _;
 
@@ -313,17 +317,14 @@ impl SendBatch {
                 unsafe {
                     let cmsg = libc::CMSG_FIRSTHDR(hdr as *const _);
                     if !cmsg.is_null() {
-                        (*cmsg).cmsg_level = libc::IPPROTO_IP;
-                        (*cmsg).cmsg_type = libc::IP_PKTINFO;
+                        (*cmsg).cmsg_level = libc::IPPROTO_IPV6;
+                        (*cmsg).cmsg_type = libc::IPV6_PKTINFO;
                         (*cmsg).cmsg_len =
-                            libc::CMSG_LEN(std::mem::size_of::<libc::in_pktinfo>() as u32) as _;
-                        let data = libc::CMSG_DATA(cmsg) as *mut libc::in_pktinfo;
+                            libc::CMSG_LEN(std::mem::size_of::<libc::in6_pktinfo>() as u32) as _;
+                        let data = libc::CMSG_DATA(cmsg) as *mut libc::in6_pktinfo;
                         data.write(pktinfo);
                     }
                 }
-            } else {
-                // IPv6 src: no pktinfo ancillary data; kernel picks source address.
-                hdr.msg_controllen = 0;
             }
         }
 
@@ -361,7 +362,7 @@ impl SendBatch {
 /// lifetime.
 #[cfg(target_os = "linux")]
 pub(super) fn recv_batch(fd: RawFd, batch: &mut RecvBatch) -> io::Result<usize> {
-    // Restore msg_controllen so the kernel can write IP_PKTINFO again.
+    // Restore msg_controllen so the kernel can write IPV6_PKTINFO again.
     batch.reset_controllen(BATCH_SIZE);
 
     // SAFETY: fd is a valid non-blocking UDP socket owned by the caller.
@@ -397,12 +398,12 @@ pub(super) fn try_recv_with_pktinfo(
         iov_base: buf.as_mut_ptr() as *mut libc::c_void,
         iov_len: buf.len(),
     };
-    // SAFETY: sockaddr_in and msghdr are C structs; zeroing is the correct way to initialize them.
-    let mut src_addr: libc::sockaddr_in = unsafe { std::mem::zeroed() };
+    // SAFETY: sockaddr_in6 and msghdr are C structs; zeroing is the correct way to initialize them.
+    let mut src_addr: libc::sockaddr_in6 = unsafe { std::mem::zeroed() };
     let mut cmsg_buf = [0u8; 128];
     let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
-    msg.msg_name = &mut src_addr as *mut libc::sockaddr_in as *mut libc::c_void;
-    msg.msg_namelen = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+    msg.msg_name = &mut src_addr as *mut libc::sockaddr_in6 as *mut libc::c_void;
+    msg.msg_namelen = std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
     msg.msg_iov = &mut iov;
     msg.msg_iovlen = 1;
     msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
@@ -414,7 +415,7 @@ pub(super) fn try_recv_with_pktinfo(
         return Err(io::Error::last_os_error());
     }
 
-    let from = sockaddr_in_to_socket_addr(&src_addr);
+    let from = sockaddr_in6_to_socket_addr(&src_addr);
     let controllen: usize = msg.msg_controllen as _;
     let dst = extract_pktinfo_dst(&cmsg_buf, controllen);
 
@@ -427,24 +428,21 @@ pub(super) fn try_send_with_src_ip(
     to: SocketAddr,
     src: IpAddr,
 ) -> io::Result<()> {
-    let IpAddr::V4(src_v4) = src else {
+    if is_unspecified(src) {
         return socket_send_fallback(socket, buf, to);
-    };
+    }
 
     let fd = socket.as_raw_fd();
-    let dst_addr = socket_addr_to_sockaddr_in(to);
+    let dst_addr = socket_addr_to_sockaddr_in6(to);
 
-    let pktinfo = libc::in_pktinfo {
-        ipi_ifindex: 0,
-        ipi_spec_dst: libc::in_addr {
-            s_addr: u32::from_ne_bytes(src_v4.octets()),
-        },
-        ipi_addr: libc::in_addr { s_addr: 0 },
+    let pktinfo = libc::in6_pktinfo {
+        ipi6_addr: ip_to_in6_addr(src),
+        ipi6_ifindex: dest_scope_id(to),
     };
 
     // SAFETY: CMSG_SPACE is a pure size computation; no pointer dereference.
     let cmsg_space =
-        unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::in_pktinfo>() as u32) } as usize;
+        unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::in6_pktinfo>() as u32) } as usize;
     let mut cmsg_buf = [0u8; 64];
 
     let iov = libc::iovec {
@@ -453,8 +451,8 @@ pub(super) fn try_send_with_src_ip(
     };
     // SAFETY: msghdr is a C struct; zeroing is the correct initialization before setting fields.
     let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
-    msg.msg_name = &dst_addr as *const libc::sockaddr_in as *mut libc::c_void;
-    msg.msg_namelen = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+    msg.msg_name = &dst_addr as *const libc::sockaddr_in6 as *mut libc::c_void;
+    msg.msg_namelen = std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
     msg.msg_iov = &iov as *const libc::iovec as *mut libc::iovec;
     msg.msg_iovlen = 1;
     msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
@@ -466,10 +464,10 @@ pub(super) fn try_send_with_src_ip(
         if cmsg.is_null() {
             return socket_send_fallback(socket, buf, to);
         }
-        (*cmsg).cmsg_level = libc::IPPROTO_IP;
-        (*cmsg).cmsg_type = libc::IP_PKTINFO;
-        (*cmsg).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<libc::in_pktinfo>() as u32) as _;
-        let data = libc::CMSG_DATA(cmsg) as *mut libc::in_pktinfo;
+        (*cmsg).cmsg_level = libc::IPPROTO_IPV6;
+        (*cmsg).cmsg_type = libc::IPV6_PKTINFO;
+        (*cmsg).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<libc::in6_pktinfo>() as u32) as _;
+        let data = libc::CMSG_DATA(cmsg) as *mut libc::in6_pktinfo;
         data.write(pktinfo);
     }
 
@@ -486,21 +484,21 @@ pub(super) fn try_send_with_src_ip(
 
 fn extract_pktinfo_dst(cmsg_buf: &[u8], controllen: usize) -> IpAddr {
     let mut ptr = cmsg_buf.as_ptr() as *const libc::cmsghdr;
-    // SAFETY: controllen is bounded by cmsg_buf.len() as set in try_recv_with_pktinfo.
+    // SAFETY: controllen is bounded by cmsg_buf.len() as set by the caller.
     let end = unsafe { cmsg_buf.as_ptr().add(controllen) };
 
     while !ptr.is_null() && (ptr as *const u8) < end {
         // SAFETY: ptr is within [cmsg_buf, end) which is valid memory from the kernel recvmsg call.
         let cmsg = unsafe { &*ptr };
-        if cmsg.cmsg_level == libc::IPPROTO_IP && cmsg.cmsg_type == libc::IP_PKTINFO {
-            // SAFETY: CMSG_LEN(0) is the standard offset to the data payload; in_pktinfo is aligned.
+        if cmsg.cmsg_level == libc::IPPROTO_IPV6 && cmsg.cmsg_type == libc::IPV6_PKTINFO {
+            // SAFETY: CMSG_LEN(0) is the standard offset to the data payload; in6_pktinfo is aligned.
             let pktinfo_ptr = unsafe {
-                (ptr as *const u8).add(libc::CMSG_LEN(0) as usize) as *const libc::in_pktinfo
+                (ptr as *const u8).add(libc::CMSG_LEN(0) as usize) as *const libc::in6_pktinfo
             };
-            // SAFETY: kernel wrote a valid in_pktinfo at this location when IP_PKTINFO is set.
+            // SAFETY: kernel wrote a valid in6_pktinfo at this location when IPV6_PKTINFO is set.
             let pktinfo = unsafe { &*pktinfo_ptr };
-            let addr = Ipv4Addr::from(u32::from_be(pktinfo.ipi_addr.s_addr));
-            return IpAddr::V4(addr);
+            let v6 = Ipv6Addr::from(pktinfo.ipi6_addr.s6_addr);
+            return unmap_v4(v6);
         }
         // SAFETY: CMSG_SPACE returns the aligned size; advancing by it keeps ptr within the buffer.
         let next_len = unsafe { libc::CMSG_SPACE(cmsg.cmsg_len as u32 - libc::CMSG_LEN(0)) };
@@ -510,7 +508,7 @@ fn extract_pktinfo_dst(cmsg_buf: &[u8], controllen: usize) -> IpAddr {
         ptr = unsafe { (ptr as *const u8).add(next_len as usize) as *const libc::cmsghdr };
     }
 
-    IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+    IpAddr::V6(Ipv6Addr::UNSPECIFIED)
 }
 
 fn socket_send_fallback(
@@ -519,15 +517,15 @@ fn socket_send_fallback(
     to: SocketAddr,
 ) -> io::Result<()> {
     let fd = socket.as_raw_fd();
-    let dst_addr = socket_addr_to_sockaddr_in(to);
+    let dst_addr = socket_addr_to_sockaddr_in6(to);
     let iov = libc::iovec {
         iov_base: buf.as_ptr() as *mut libc::c_void,
         iov_len: buf.len(),
     };
     // SAFETY: msghdr is a C struct; zeroing is the correct initialization before setting fields.
     let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
-    msg.msg_name = &dst_addr as *const libc::sockaddr_in as *mut libc::c_void;
-    msg.msg_namelen = std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+    msg.msg_name = &dst_addr as *const libc::sockaddr_in6 as *mut libc::c_void;
+    msg.msg_namelen = std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
     msg.msg_iov = &iov as *const libc::iovec as *mut libc::iovec;
     msg.msg_iovlen = 1;
     // SAFETY: fd is valid; msg points to properly initialized iov on the stack.
@@ -538,19 +536,148 @@ fn socket_send_fallback(
     Ok(())
 }
 
-pub(super) fn sockaddr_in_to_socket_addr(addr: &libc::sockaddr_in) -> SocketAddr {
-    let ip = Ipv4Addr::from(u32::from_be(addr.sin_addr.s_addr));
-    let port = u16::from_be(addr.sin_port);
-    SocketAddr::new(IpAddr::V4(ip), port)
+/// Normalises a (possibly v4-mapped) IPv6 address back to a real `IpAddr::V4`
+/// so the application's client-IP / blocking logic still sees genuine IPv4.
+fn unmap_v4(v6: Ipv6Addr) -> IpAddr {
+    match v6.to_ipv4_mapped() {
+        Some(v4) => IpAddr::V4(v4),
+        None => IpAddr::V6(v6),
+    }
 }
 
-pub(super) fn socket_addr_to_sockaddr_in(addr: SocketAddr) -> libc::sockaddr_in {
-    // SAFETY: sockaddr_in is a C struct; zeroing is the correct initialization before setting fields.
-    let mut sa: libc::sockaddr_in = unsafe { std::mem::zeroed() };
-    sa.sin_family = libc::AF_INET as libc::sa_family_t;
-    if let IpAddr::V4(v4) = addr.ip() {
-        sa.sin_addr.s_addr = u32::from_be_bytes(v4.octets()).to_be();
+/// Converts an `IpAddr` to an `in6_addr`, mapping IPv4 to `::ffff:a.b.c.d` so it
+/// can be used with the dual-stack AF_INET6 socket.
+fn ip_to_in6_addr(ip: IpAddr) -> libc::in6_addr {
+    let v6 = match ip {
+        IpAddr::V4(v4) => v4.to_ipv6_mapped(),
+        IpAddr::V6(v6) => v6,
+    };
+    libc::in6_addr {
+        s6_addr: v6.octets(),
     }
-    sa.sin_port = addr.port().to_be();
+}
+
+fn is_unspecified(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_unspecified(),
+        IpAddr::V6(v6) => v6.is_unspecified(),
+    }
+}
+
+/// Scope id of a destination address, used as the reply's outgoing interface
+/// so link-local clients are answered on the link the query came from.
+fn dest_scope_id(addr: SocketAddr) -> u32 {
+    match addr {
+        SocketAddr::V6(v6) => v6.scope_id(),
+        SocketAddr::V4(_) => 0,
+    }
+}
+
+/// Normalises a v4-mapped socket address (`::ffff:a.b.c.d`) back to plain IPv4.
+/// The dual-stack listeners report IPv4 peers in mapped form; client-facing
+/// logic (groups, limits, logs) expects real IPv4.
+pub(super) fn unmap_socket_addr(addr: SocketAddr) -> SocketAddr {
+    match addr.ip() {
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => SocketAddr::new(IpAddr::V4(v4), addr.port()),
+            None => addr,
+        },
+        IpAddr::V4(_) => addr,
+    }
+}
+
+pub(super) fn sockaddr_in6_to_socket_addr(addr: &libc::sockaddr_in6) -> SocketAddr {
+    let v6 = Ipv6Addr::from(addr.sin6_addr.s6_addr);
+    let port = u16::from_be(addr.sin6_port);
+    match unmap_v4(v6) {
+        IpAddr::V4(v4) => SocketAddr::new(IpAddr::V4(v4), port),
+        // Keep the scope id: replies to link-local clients need it.
+        IpAddr::V6(v6) => SocketAddr::V6(SocketAddrV6::new(v6, port, 0, addr.sin6_scope_id)),
+    }
+}
+
+pub(super) fn socket_addr_to_sockaddr_in6(addr: SocketAddr) -> libc::sockaddr_in6 {
+    // SAFETY: sockaddr_in6 is a C struct; zeroing is the correct initialization before setting fields.
+    let mut sa: libc::sockaddr_in6 = unsafe { std::mem::zeroed() };
+    sa.sin6_family = libc::AF_INET6 as libc::sa_family_t;
+    sa.sin6_addr = ip_to_in6_addr(addr.ip());
+    sa.sin6_port = addr.port().to_be();
+    if let SocketAddr::V6(v6) = addr {
+        sa.sin6_scope_id = v6.scope_id();
+    }
     sa
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn unmap_v4_returns_real_v4_for_mapped_address() {
+        let mapped: Ipv6Addr = "::ffff:192.0.2.1".parse().unwrap();
+        assert_eq!(unmap_v4(mapped), IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+    }
+
+    #[test]
+    fn unmap_v4_keeps_native_v6() {
+        let v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        assert_eq!(unmap_v4(v6), IpAddr::V6(v6));
+    }
+
+    #[test]
+    fn ip_to_in6_addr_maps_v4() {
+        let addr = ip_to_in6_addr(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+        let expected: Ipv6Addr = "::ffff:192.0.2.1".parse().unwrap();
+        assert_eq!(addr.s6_addr, expected.octets());
+    }
+
+    #[test]
+    fn ip_to_in6_addr_passes_v6_through() {
+        let v6: Ipv6Addr = "2001:db8::2".parse().unwrap();
+        assert_eq!(ip_to_in6_addr(IpAddr::V6(v6)).s6_addr, v6.octets());
+    }
+
+    #[test]
+    fn is_unspecified_detects_both_families() {
+        assert!(is_unspecified("0.0.0.0".parse().unwrap()));
+        assert!(is_unspecified("::".parse().unwrap()));
+        assert!(!is_unspecified("192.0.2.1".parse().unwrap()));
+        assert!(!is_unspecified("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn sockaddr_round_trip_v4() {
+        let addr: SocketAddr = "192.0.2.1:5353".parse().unwrap();
+        let sa = socket_addr_to_sockaddr_in6(addr);
+        assert_eq!(sa.sin6_family, libc::AF_INET6 as libc::sa_family_t);
+        assert_eq!(sockaddr_in6_to_socket_addr(&sa), addr);
+    }
+
+    #[test]
+    fn sockaddr_round_trip_v6() {
+        let addr: SocketAddr = "[2001:db8::1]:53".parse().unwrap();
+        let sa = socket_addr_to_sockaddr_in6(addr);
+        assert_eq!(sockaddr_in6_to_socket_addr(&sa), addr);
+    }
+
+    #[test]
+    fn sockaddr_round_trip_keeps_link_local_scope_id() {
+        let addr = SocketAddr::V6(SocketAddrV6::new("fe80::1".parse().unwrap(), 53, 0, 7));
+        let sa = socket_addr_to_sockaddr_in6(addr);
+        assert_eq!(sa.sin6_scope_id, 7);
+        assert_eq!(sockaddr_in6_to_socket_addr(&sa), addr);
+        assert_eq!(dest_scope_id(addr), 7);
+    }
+
+    #[test]
+    fn unmap_socket_addr_normalises_mapped_peers() {
+        let mapped: SocketAddr = "[::ffff:192.0.2.1]:4242".parse().unwrap();
+        assert_eq!(
+            unmap_socket_addr(mapped),
+            "192.0.2.1:4242".parse::<SocketAddr>().unwrap()
+        );
+        let v6: SocketAddr = "[2001:db8::1]:4242".parse().unwrap();
+        assert_eq!(unmap_socket_addr(v6), v6);
+    }
 }

--- a/crates/cli/src/server/dns/tcp.rs
+++ b/crates/cli/src/server/dns/tcp.rs
@@ -1,4 +1,5 @@
 use super::connection_limiter::{ConnectionGuard, ConnectionLimiter};
+use super::pktinfo;
 use ferrous_dns_infrastructure::dns::proxy_protocol::{
     read_proxy_v2_client_ip, ProxyProtocolError,
 };
@@ -38,6 +39,9 @@ pub(super) async fn run_tcp_worker(
     loop {
         match listener.accept().await {
             Ok((stream, peer_addr)) => {
+                // The dual-stack listener reports IPv4 peers as `::ffff:a.b.c.d`;
+                // normalise so limits, groups, and logs see real IPv4.
+                let peer_addr = pktinfo::unmap_socket_addr(peer_addr);
                 let guard = match conn_limiter.try_acquire(peer_addr.ip()) {
                     Some(g) => g,
                     None => {

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -101,7 +101,7 @@ docker compose up -d
 
 ## Windows (WSL2)
 
-There is no native Windows build. Ferrous DNS's UDP hot path relies on Linux-only socket APIs (`SO_REUSEPORT` for the per-core listeners, `IP_PKTINFO` for source-address selection, `recvmmsg` for batched receives), so on Windows it runs inside **WSL2** — either the Linux binary directly or the Docker image via Docker Desktop's WSL2 backend.
+There is no native Windows build. Ferrous DNS's UDP hot path relies on Linux-only socket APIs (`SO_REUSEPORT` for the per-core listeners, `IPV6_PKTINFO` for source-address selection, `recvmmsg` for batched receives), so on Windows it runs inside **WSL2** — either the Linux binary directly or the Docker image via Docker Desktop's WSL2 backend.
 
 The catch is networking, not the build: by default WSL2 sits behind NAT with its own IP, so devices on your LAN cannot reach port 53 inside it. `netsh interface portproxy` does **not** solve this — it forwards TCP only, and DNS is primarily UDP. Network-wide blocking therefore requires WSL's *mirrored* networking mode.
 

--- a/docs/performance/internals.md
+++ b/docs/performance/internals.md
@@ -25,15 +25,15 @@ Tokio's runtime threads are pinned round-robin to cores as well.
 
 On Linux the UDP path reads and writes datagrams in batches of **64** using `recvmmsg` and `sendmmsg`, amortizing the syscall over up to 64 queries. All buffers and control-message storage are allocated once per worker and reused, so a batch costs no allocations.
 
-This is selected at compile time (`#[cfg(target_os = "linux")]`), not by a feature flag or config key. On non-Linux targets the server falls back to a single-datagram loop with identical behaviour and lower throughput.
+This is selected at compile time (`#[cfg(target_os = "linux")]`), not by a feature flag or config key. On non-Linux targets the server falls back to a single-datagram loop with the same behaviour and lower throughput. Every target needs dual-stack `AF_INET6` sockets (IPv4 is handled as v4-mapped addresses); platforms without them, such as kernels built without IPv6, are not supported.
 
 ---
 
-## Correct source address on multi-homed hosts (IP_PKTINFO)
+## Correct source address on multi-homed hosts (IPV6_PKTINFO)
 
-A server bound to `0.0.0.0` on a machine with several addresses can answer from the *wrong* source IP, and clients will drop such replies. Ferrous DNS enables `IP_PKTINFO` on its UDP sockets, records the destination address of each incoming query from the control message, and writes it back as a control message on the reply — so the answer always leaves from the address the client sent to.
+A server bound to a wildcard address on a machine with several addresses can answer from the *wrong* source IP, and clients will drop such replies. Ferrous DNS enables `IPV6_RECVPKTINFO` on its UDP sockets, records the destination address of each incoming query from the control message, and writes it back as a control message on the reply — so the answer always leaves from the address the client sent to.
 
-Only IPv4 `IP_PKTINFO` is handled today; there is no `IPV6_RECVPKTINFO` path.
+The DNS sockets are dual-stack `AF_INET6`: an IPv4 `bind_address` is bound in v4-mapped form (`::ffff:a.b.c.d`) and IPv4 clients arrive the same way, so a single `IPV6_PKTINFO` path covers both families. Client addresses are normalised back to plain IPv4 before they reach logging, grouping, and blocking.
 
 ---
 


### PR DESCRIPTION
## What

Make a `[::]` UDP bind actually answer queries, on both address families.

- `crates/cli/src/server/dns/pktinfo.rs`: convert the UDP receive/send path from `sockaddr_in`/`IP_PKTINFO` to `sockaddr_in6`/`IPV6_PKTINFO`, with unit tests for the new address helpers.
- `crates/cli/src/server/dns/mod.rs`: always create AF_INET6 DNS sockets. An IPv4 `bind_address` binds in v4-mapped form as `::ffff:a.b.c.d`.
- `crates/cli/src/server/dns/tcp.rs`: normalise v4-mapped TCP peer addresses back to plain IPv4, so per-client limits, groups, and logs keep seeing real IPv4 clients.
- `docs/performance/internals.md`, `docs/getting-started/installation.md`: update the pktinfo sections, which described the IPv4-only behaviour.

## Why

On an AF_INET6 socket the current UDP path has three bugs. Each one alone breaks replies:

1. The client source address gets truncated. `RecvBatch.src_addrs` is `Vec<sockaddr_in>` with `msg_namelen = 16`, but the kernel delivers a 28-byte `sockaddr_in6`. The reply goes to a garbage address.
2. The destination IP never gets captured. `enable_pktinfo` only sets `IP_PKTINFO`, never `IPV6_RECVPKTINFO`, so the server cannot pin the reply to the address the query arrived on.
3. Replies use the wrong address family. `SendBatch` and `try_send_with_src_ip` build `sockaddr_in` names and `in_pktinfo` cmsgs, which the kernel rejects or ignores on an AF_INET6 socket.

TCP is unaffected because tokio's listener is already dual-stack. The bug only shows over IPv6 or when replies must cross subnets, which is probably why it has survived: a same-subnet IPv4 test does not reproduce it.

## How

- The UDP path now assumes AF_INET6 sockets, which the `mod.rs` change guarantees. Binding `0.0.0.0` or a specific IPv4 address behaves as before through the v4-mapped form, while `[::]` becomes genuinely dual-stack. Both listeners already call `set_only_v6(false)`, so nothing else changes there.
- Both the UDP path and the TCP accept path normalise v4-mapped client addresses back to `IpAddr::V4`, in `unmap_v4` and `unmap_socket_addr`, before the connection limiter, the PROXY protocol fallback, client-IP logging, and blocking see them. IPv4 clients look exactly as they do today.
- Link-local clients work. The sockaddr round-trip keeps `sin6_scope_id`, and replies use the destination's scope id as `ipi6_ifindex`, so they leave on the link the query came from. Global traffic passes 0 and the kernel routes normally, per RFC 3542.
- The old `if let IpAddr::V4` guard around attaching pktinfo becomes an `is_unspecified` check. When no destination was captured, the send path omits the cmsg and the kernel picks the source address, which matches the previous fallback behaviour.
- All helper renames stay inside `pktinfo.rs`; `udp.rs` needs no changes. The conversion also covers `try_send_with_src_ip` and `socket_send_fallback` because the Linux batch path uses them too, not only the non-Linux fallback.

One tradeoff to weigh: this makes kernel IPv6 support a hard requirement, even for IPv4-only use. A Linux kernel booted with `ipv6.disable=1` or built without `CONFIG_IPV6` cannot create AF_INET6 sockets, and OpenBSD forbids v4-mapped dual-stack sockets outright. IPv6 does not need to be configured on the network; it only needs to exist in the kernel. If you consider those systems worth supporting, I am happy to add an AF_INET fallback path in this PR. I left it out to keep the change reviewable.

## Testing

- Unit tests in `pktinfo.rs` cover the address helpers: v4-mapped normalisation, `in6_addr` conversion, `is_unspecified`, the scope-id round-trip, and `sockaddr_in6` round-trips for both families.
- `make ci` passes: fmt check, clippy with `-D warnings`, and the workspace tests.
- I run this branch on top of v0.9.12 on a dual-stack NixOS LXC container. `dig` over UDP and TCP, IPv4 and IPv6, from clients on another subnet returns correct answers with the right source addresses. Without the patch those UDP queries time out while TCP keeps working. An earlier version of this fix has served that network in production since June 2026.
