### PR TITLE
fix(dns): key IPv4 clients on dual-stack listeners as plain IPv4

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -140,7 +140,7 @@ async fn async_main() -> anyhow::Result<()> {
     )
     .await;
 
-    let dns_addr = format!("{}:{}", config.server.bind_address, config.server.dns_port);
+    let dns_addr = config.server.dns_listen_address();
     let handler_use_case = dns_services.handler_use_case;
     let tcp_conn_limiter = dns_services.tcp_conn_limiter;
     let dot_conn_limiter = dns_services.dot_conn_limiter;
@@ -193,10 +193,7 @@ async fn async_main() -> anyhow::Result<()> {
 
     if config.server.encrypted_dns.dot_enabled {
         if let Some(tls_cfg) = tls_config.clone() {
-            let dot_addr = format!(
-                "{}:{}",
-                config.server.bind_address, config.server.encrypted_dns.dot_port
-            );
+            let dot_addr = config.server.dot_listen_address();
             let dot_handler = Arc::new(DnsServerHandler::new(
                 handler_use_case.clone(),
                 block_policy,
@@ -226,10 +223,7 @@ async fn async_main() -> anyhow::Result<()> {
             &[b"doq"],
         )?;
         if let Some(tls_cfg) = doq_tls_config {
-            let doq_addr = format!(
-                "{}:{}",
-                config.server.bind_address, config.server.encrypted_dns.doq_port
-            );
+            let doq_addr = config.server.doq_listen_address();
             let doq_handler = Arc::new(DnsServerHandler::new(
                 handler_use_case.clone(),
                 block_policy,
@@ -245,11 +239,10 @@ async fn async_main() -> anyhow::Result<()> {
     }
 
     let doh_handler = if config.server.encrypted_dns.doh_enabled {
-        if let Some(doh_port) = config.server.encrypted_dns.doh_port {
+        if let Some(doh_bind_addr) = config.server.doh_listen_address() {
             if tls_config.is_some() {
-                let doh_addr: SocketAddr = format!("{}:{}", config.server.bind_address, doh_port)
-                    .parse()
-                    .context("Invalid DoH bind address")?;
+                let doh_addr: SocketAddr =
+                    doh_bind_addr.parse().context("Invalid DoH bind address")?;
                 let dedicated_doh_handler = Arc::new(DnsServerHandler::new(
                     handler_use_case.clone(),
                     block_policy,
@@ -280,7 +273,9 @@ async fn async_main() -> anyhow::Result<()> {
         None
     };
 
-    let web_addr: SocketAddr = format!("{}:{}", config.server.bind_address, config.server.web_port)
+    let web_addr: SocketAddr = config
+        .server
+        .web_listen_address()
         .parse()
         .expect("Invalid address");
 

--- a/crates/cli/src/server/dns/doq.rs
+++ b/crates/cli/src/server/dns/doq.rs
@@ -3,7 +3,8 @@ use super::pktinfo;
 use ferrous_dns_infrastructure::dns::server::DnsServerHandler;
 use quinn::crypto::rustls::QuicServerConfig;
 use quinn::VarInt;
-use std::net::{IpAddr, SocketAddr};
+use socket2::{Domain, Protocol, Socket, Type};
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, info, warn};
@@ -26,12 +27,15 @@ const DOQ_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(5);
 /// on `bind_addr`, advertising whatever ALPN the supplied `tls_config` carries
 /// (the caller sets `doq`). Binding is synchronous, so the returned endpoint is
 /// ready to accept connections immediately.
+///
+/// Like the Do53 and DoT listeners, the socket is always AF_INET6 with
+/// `only_v6` off: an IPv4 `bind_addr` is bound in v4-mapped form and keeps its
+/// v4-only behaviour, while `[::]` serves both families on one socket.
 pub fn bind_doq_endpoint(
     bind_addr: &str,
     tls_config: Arc<rustls::ServerConfig>,
 ) -> anyhow::Result<quinn::Endpoint> {
-    let addr: SocketAddr = bind_addr.parse()?;
-
+    let addr = pktinfo::v6_mapped_bind_addr(bind_addr.parse()?);
     let quic_crypto = QuicServerConfig::try_from(tls_config)?;
     let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(quic_crypto));
     // A freshly built ServerConfig uniquely owns its transport config, so this
@@ -42,7 +46,18 @@ pub fn bind_doq_endpoint(
     transport_config.keep_alive_interval(Some(DOQ_KEEP_ALIVE_INTERVAL));
     transport_config.max_concurrent_bidi_streams(VarInt::from_u32(DOQ_MAX_CONCURRENT_BIDI_STREAMS));
 
-    Ok(quinn::Endpoint::server(server_config, addr)?)
+    let socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP))?;
+    socket.set_only_v6(false)?;
+    socket.bind(&addr.into())?;
+    socket.set_nonblocking(true)?;
+    let runtime = quinn::default_runtime()
+        .ok_or_else(|| anyhow::anyhow!("no async runtime available for the DoQ endpoint"))?;
+    Ok(quinn::Endpoint::new(
+        quinn::EndpointConfig::default(),
+        Some(server_config),
+        socket.into(),
+        runtime,
+    )?)
 }
 
 pub async fn start_doq_server(
@@ -52,7 +67,10 @@ pub async fn start_doq_server(
     doq_conn_limiter: ConnectionLimiter,
 ) -> anyhow::Result<()> {
     let endpoint = bind_doq_endpoint(&bind_addr, tls_config)?;
-    info!(bind_address = %endpoint.local_addr()?, "Starting DoQ server (DNS-over-QUIC, RFC 9250)");
+    // `local_addr` reports the v4-mapped form of an IPv4 bind; report the
+    // address the operator configured.
+    let local_addr = pktinfo::unmap_socket_addr(endpoint.local_addr()?);
+    info!(bind_address = %local_addr, "Starting DoQ server (DNS-over-QUIC, RFC 9250)");
     serve_doq(endpoint, handler, doq_conn_limiter).await;
     Ok(())
 }

--- a/crates/cli/src/server/dns/doq.rs
+++ b/crates/cli/src/server/dns/doq.rs
@@ -1,4 +1,5 @@
 use super::connection_limiter::{ConnectionGuard, ConnectionLimiter};
+use super::pktinfo;
 use ferrous_dns_infrastructure::dns::server::DnsServerHandler;
 use quinn::crypto::rustls::QuicServerConfig;
 use quinn::VarInt;
@@ -65,7 +66,9 @@ pub async fn serve_doq(
     doq_conn_limiter: ConnectionLimiter,
 ) {
     while let Some(incoming) = endpoint.accept().await {
-        let peer_addr = incoming.remote_address();
+        // A dual-stack endpoint reports IPv4 peers as `::ffff:a.b.c.d`;
+        // normalise so limits, groups, and logs see real IPv4.
+        let peer_addr = pktinfo::unmap_socket_addr(incoming.remote_address());
         let guard = match doq_conn_limiter.try_acquire(peer_addr.ip()) {
             Some(g) => g,
             None => {
@@ -83,7 +86,7 @@ async fn handle_doq_connection(
     handler: Arc<DnsServerHandler>,
     _guard: ConnectionGuard,
 ) {
-    let peer_addr = incoming.remote_address();
+    let peer_addr = pktinfo::unmap_socket_addr(incoming.remote_address());
 
     let connection = match incoming.await {
         Ok(c) => c,
@@ -94,7 +97,7 @@ async fn handle_doq_connection(
     };
 
     debug!(client = %peer_addr, "DoQ connection accepted");
-    let client_ip = connection.remote_address().ip();
+    let client_ip = pktinfo::unmap_socket_addr(connection.remote_address()).ip();
 
     loop {
         let (send_stream, recv_stream) = match connection.accept_bi().await {

--- a/crates/cli/src/server/dns/dot.rs
+++ b/crates/cli/src/server/dns/dot.rs
@@ -1,4 +1,5 @@
 use super::connection_limiter::{ConnectionGuard, ConnectionLimiter};
+use super::pktinfo;
 use ferrous_dns_infrastructure::dns::proxy_protocol::{
     read_proxy_v2_client_ip, ProxyProtocolError,
 };
@@ -12,11 +13,15 @@ use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 use tracing::{debug, error, info, warn};
 
-pub fn create_dot_listener(domain: Domain, addr: SocketAddr) -> anyhow::Result<TcpListener> {
-    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
-    if addr.is_ipv6() {
-        socket.set_only_v6(false)?;
-    }
+/// Binds the DoT listener on `bind_addr`. Like the Do53 listeners, the socket
+/// is always AF_INET6 with `only_v6` off: an IPv4 `bind_addr` is bound in
+/// v4-mapped form and keeps its v4-only behaviour, while `[::]` serves both
+/// families on one socket. Binding is synchronous, so the returned listener is
+/// ready to accept immediately.
+pub fn bind_dot_listener(bind_addr: &str) -> anyhow::Result<TcpListener> {
+    let addr = pktinfo::v6_mapped_bind_addr(bind_addr.parse()?);
+    let socket = Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP))?;
+    socket.set_only_v6(false)?;
     socket.set_reuse_address(true)?;
     #[cfg(unix)]
     socket.set_reuse_port(true)?;
@@ -35,18 +40,32 @@ pub async fn start_dot_server(
     proxy_protocol_enabled: bool,
     dot_conn_limiter: ConnectionLimiter,
 ) -> anyhow::Result<()> {
-    let addr: SocketAddr = bind_addr.parse()?;
-    let domain = if addr.is_ipv4() {
-        Domain::IPV4
-    } else {
-        Domain::IPV6
-    };
+    let listener = Arc::new(bind_dot_listener(&bind_addr)?);
+    info!(bind_address = %listener.local_addr()?, "Starting DoT server (DNS-over-TLS, RFC 7858)");
+    serve_dot(
+        listener,
+        tls_config,
+        handler,
+        num_workers,
+        proxy_protocol_enabled,
+        dot_conn_limiter,
+    )
+    .await;
+    Ok(())
+}
+
+/// Runs the accept loops for an already-bound DoT listener. Split from
+/// `start_dot_server` so tests can bind on an ephemeral port, read the
+/// resolved address, and drive the loop without a bind race.
+pub async fn serve_dot(
+    listener: Arc<TcpListener>,
+    tls_config: Arc<rustls::ServerConfig>,
+    handler: Arc<DnsServerHandler>,
+    num_workers: usize,
+    proxy_protocol_enabled: bool,
+    dot_conn_limiter: ConnectionLimiter,
+) {
     let acceptor = TlsAcceptor::from(tls_config);
-
-    info!(bind_address = %addr, "Starting DoT server (DNS-over-TLS, RFC 7858)");
-
-    let listener = Arc::new(create_dot_listener(domain, addr)?);
-
     let mut handles = Vec::with_capacity(num_workers);
     for _ in 0..num_workers {
         handles.push(tokio::spawn(run_dot_accept_loop(
@@ -58,11 +77,12 @@ pub async fn start_dot_server(
         )));
     }
 
-    info!("DoT server ready on {}", addr);
+    if let Ok(addr) = listener.local_addr() {
+        info!("DoT server ready on {}", addr);
+    }
     for handle in handles {
         let _ = handle.await;
     }
-    Ok(())
 }
 
 async fn run_dot_accept_loop(
@@ -75,6 +95,9 @@ async fn run_dot_accept_loop(
     loop {
         match listener.accept().await {
             Ok((stream, peer_addr)) => {
+                // The dual-stack listener reports IPv4 peers as `::ffff:a.b.c.d`;
+                // normalise so limits, groups, and logs see real IPv4.
+                let peer_addr = pktinfo::unmap_socket_addr(peer_addr);
                 let guard = match conn_limiter.try_acquire(peer_addr.ip()) {
                     Some(g) => g,
                     None => {

--- a/crates/cli/src/server/dns/dot.rs
+++ b/crates/cli/src/server/dns/dot.rs
@@ -41,7 +41,10 @@ pub async fn start_dot_server(
     dot_conn_limiter: ConnectionLimiter,
 ) -> anyhow::Result<()> {
     let listener = Arc::new(bind_dot_listener(&bind_addr)?);
-    info!(bind_address = %listener.local_addr()?, "Starting DoT server (DNS-over-TLS, RFC 7858)");
+    // `local_addr` reports the v4-mapped form of an IPv4 bind; report the
+    // address the operator configured.
+    let local_addr = pktinfo::unmap_socket_addr(listener.local_addr()?);
+    info!(bind_address = %local_addr, "Starting DoT server (DNS-over-TLS, RFC 7858)");
     serve_dot(
         listener,
         tls_config,
@@ -78,7 +81,7 @@ pub async fn serve_dot(
     }
 
     if let Ok(addr) = listener.local_addr() {
-        info!("DoT server ready on {}", addr);
+        info!("DoT server ready on {}", pktinfo::unmap_socket_addr(addr));
     }
     for handle in handles {
         let _ = handle.await;

--- a/crates/cli/src/server/dns/mod.rs
+++ b/crates/cli/src/server/dns/mod.rs
@@ -34,7 +34,8 @@ pub async fn start_dns_server(
     let socket_addr = pktinfo::v6_mapped_bind_addr(parsed);
     let domain = Domain::IPV6;
 
-    info!(bind_address = %socket_addr, num_workers, "Starting DNS server with SO_REUSEPORT");
+    // Report the address as configured, not the v4-mapped form it is bound as.
+    info!(bind_address = %parsed, num_workers, "Starting DNS server with SO_REUSEPORT");
 
     let handler = Arc::new(handler);
     let mut join_set: JoinSet<()> = JoinSet::new();

--- a/crates/cli/src/server/dns/mod.rs
+++ b/crates/cli/src/server/dns/mod.rs
@@ -31,12 +31,7 @@ pub async fn start_dns_server(
     // sockaddr_in6 / in6_pktinfo; `set_only_v6(false)` (in create_*_socket) lets
     // a `[::]` bind answer both families. A mapped IPv4 bind preserves v4-only
     // behaviour for that single address.
-    let socket_addr: SocketAddr = match parsed {
-        SocketAddr::V4(v4) => {
-            SocketAddr::new(std::net::IpAddr::V6(v4.ip().to_ipv6_mapped()), v4.port())
-        }
-        SocketAddr::V6(_) => parsed,
-    };
+    let socket_addr = pktinfo::v6_mapped_bind_addr(parsed);
     let domain = Domain::IPV6;
 
     info!(bind_address = %socket_addr, num_workers, "Starting DNS server with SO_REUSEPORT");

--- a/crates/cli/src/server/dns/pktinfo.rs
+++ b/crates/cli/src/server/dns/pktinfo.rs
@@ -586,6 +586,17 @@ pub(super) fn unmap_socket_addr(addr: SocketAddr) -> SocketAddr {
     }
 }
 
+/// Rewrites an IPv4 bind address into its v4-mapped form (`::ffff:a.b.c.d`) so
+/// every listener can be created on an AF_INET6 socket. An IPv6 bind is left
+/// alone: combined with `set_only_v6(false)`, a `[::]` bind then serves both
+/// families on a single socket, while a mapped IPv4 bind stays v4-only.
+pub(super) fn v6_mapped_bind_addr(addr: SocketAddr) -> SocketAddr {
+    match addr {
+        SocketAddr::V4(v4) => SocketAddr::new(IpAddr::V6(v4.ip().to_ipv6_mapped()), v4.port()),
+        SocketAddr::V6(_) => addr,
+    }
+}
+
 pub(super) fn sockaddr_in6_to_socket_addr(addr: &libc::sockaddr_in6) -> SocketAddr {
     let v6 = Ipv6Addr::from(addr.sin6_addr.s6_addr);
     let port = u16::from_be(addr.sin6_port);
@@ -679,5 +690,20 @@ mod tests {
         );
         let v6: SocketAddr = "[2001:db8::1]:4242".parse().unwrap();
         assert_eq!(unmap_socket_addr(v6), v6);
+    }
+
+    #[test]
+    fn v6_mapped_bind_addr_maps_ipv4_binds() {
+        let v4: SocketAddr = "192.0.2.1:853".parse().unwrap();
+        assert_eq!(
+            v6_mapped_bind_addr(v4),
+            "[::ffff:192.0.2.1]:853".parse::<SocketAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn v6_mapped_bind_addr_keeps_ipv6_binds() {
+        let wildcard: SocketAddr = "[::]:853".parse().unwrap();
+        assert_eq!(v6_mapped_bind_addr(wildcard), wildcard);
     }
 }

--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -5,7 +5,7 @@ mod web_tls;
 
 pub use dns::connection_limiter::ConnectionLimiter;
 pub use dns::doq::{bind_doq_endpoint, serve_doq, start_doq_server};
-pub use dns::dot::start_dot_server;
+pub use dns::dot::{bind_dot_listener, serve_dot, start_dot_server};
 pub use dns::start_dns_server;
 pub use dns::start_mdns_listener;
 pub use dns::tls_config::load_server_tls_config;

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -252,10 +252,12 @@ impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
 }
 
 /// True when a `[::]` socket also receives IPv4 traffic. Guards the dual-stack
-/// tests: a host with `net.ipv6.bindv6only=1`, or no IPv6 at all, cannot
-/// exercise the v4-mapped peer path.
+/// tests: a host with no IPv6 in the kernel cannot exercise the v4-mapped peer
+/// path. The probe binds the way the listeners do — AF_INET6 with `only_v6`
+/// explicitly off — so `net.ipv6.bindv6only=1` does not skip a test that would
+/// in fact have run.
 pub fn dual_stack_loopback_available() -> bool {
-    let Ok(server) = std::net::UdpSocket::bind("[::]:0") else {
+    let Some(server) = bind_dual_stack_probe_socket() else {
         return false;
     };
     let Ok(local) = server.local_addr() else {
@@ -278,4 +280,30 @@ pub fn dual_stack_loopback_available() -> bool {
     }
     let mut buf = [0u8; 8];
     server.recv_from(&mut buf).is_ok()
+}
+
+fn bind_dual_stack_probe_socket() -> Option<std::net::UdpSocket> {
+    let socket = socket2::Socket::new(
+        socket2::Domain::IPV6,
+        socket2::Type::DGRAM,
+        Some(socket2::Protocol::UDP),
+    )
+    .ok()?;
+    socket.set_only_v6(false).ok()?;
+    let addr: std::net::SocketAddr = "[::]:0".parse().ok()?;
+    socket.bind(&addr.into()).ok()?;
+    Some(socket.into())
+}
+
+/// Normalises the address a listener reports back to the family it was asked
+/// to bind. The listeners are AF_INET6, so an IPv4 bind resolves to
+/// `::ffff:127.0.0.1`, which an IPv4 client socket cannot send to.
+pub fn unmap_addr(addr: std::net::SocketAddr) -> std::net::SocketAddr {
+    match addr.ip() {
+        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => std::net::SocketAddr::new(std::net::IpAddr::V4(v4), addr.port()),
+            None => addr,
+        },
+        std::net::IpAddr::V4(_) => addr,
+    }
 }

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,0 +1,281 @@
+//! Test doubles and helpers shared by the encrypted-DNS listener tests
+//! (`doq_test.rs`, `dot_test.rs`).
+//!
+//! This module is compiled into every integration-test binary that declares
+//! `mod common;`, so items only one binary uses would otherwise trip
+//! dead-code warnings under `-D warnings`.
+#![allow(dead_code)]
+
+use async_trait::async_trait;
+use ferrous_dns_application::ports::{
+    BlockFilterEnginePort, CacheStats, DnsResolution, DnsResolver, FilterDecision,
+    PagedQueryResult, QueryLogRepository, TimeGranularity, TimelineBucket,
+};
+use ferrous_dns_application::use_cases::HandleDnsQueryUseCase;
+use ferrous_dns_domain::{
+    BlockResponseMode, DnsQuery, DnssecStats, DomainError, QueryLog, QueryLogFilter, QueryStats,
+};
+use ferrous_dns_infrastructure::dns::server::{BlockPolicy, DnsServerHandler};
+use hickory_proto::op::{Message, MessageType, OpCode, Query as WireQuery};
+use hickory_proto::rr::{DNSClass, Name, RecordType as HickoryRecordType};
+use hickory_proto::serialize::binary::{BinEncodable, BinEncoder};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use std::net::IpAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+// ── Minimal port doubles (hand-rolled per crate test-placement convention —
+// application crate mocks aren't reachable from the cli crate's test binary) ──
+
+/// Resolver whose cache always hits with a fixed set of addresses, regardless
+/// of the query's domain/type.
+pub struct CannedAddressResolver {
+    pub addresses: Vec<IpAddr>,
+    pub ttl: u32,
+}
+
+#[async_trait]
+impl DnsResolver for CannedAddressResolver {
+    async fn resolve(&self, _query: &DnsQuery) -> Result<DnsResolution, DomainError> {
+        unimplemented!("cache hit only")
+    }
+
+    fn try_cache(&self, _query: &DnsQuery) -> Option<DnsResolution> {
+        let mut res = DnsResolution::new(self.addresses.clone(), true);
+        res.min_ttl = Some(self.ttl);
+        Some(res)
+    }
+}
+
+/// Allows every domain; assigns the default group.
+pub struct AllowAllFilter;
+
+#[async_trait]
+impl BlockFilterEnginePort for AllowAllFilter {
+    fn resolve_group(&self, _ip: IpAddr) -> i64 {
+        0
+    }
+    fn check(&self, _domain: &str, _group_id: i64) -> FilterDecision {
+        FilterDecision::Allow
+    }
+    fn store_cname_decision(&self, _domain: &str, _group_id: i64, _ttl_secs: u64) {}
+    async fn reload(&self) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn load_client_groups(&self) -> Result<(), DomainError> {
+        Ok(())
+    }
+    fn compiled_domain_count(&self) -> usize {
+        0
+    }
+    fn is_blocking_enabled(&self) -> bool {
+        false
+    }
+    fn set_blocking_enabled(&self, _enabled: bool) {}
+}
+
+/// Drops every logged query.
+pub struct NoopQueryLog;
+
+#[async_trait]
+impl QueryLogRepository for NoopQueryLog {
+    async fn log_query(&self, _query: &QueryLog) -> Result<(), DomainError> {
+        Ok(())
+    }
+    async fn get_recent(
+        &self,
+        _limit: u32,
+        _period_hours: f32,
+    ) -> Result<Vec<QueryLog>, DomainError> {
+        unimplemented!()
+    }
+    async fn get_recent_paged(
+        &self,
+        _limit: u32,
+        _offset: u32,
+        _period_hours: f32,
+        _cursor: Option<i64>,
+        _filter: &QueryLogFilter,
+    ) -> Result<PagedQueryResult, DomainError> {
+        unimplemented!()
+    }
+    async fn get_stats(&self, _period_hours: f32) -> Result<QueryStats, DomainError> {
+        unimplemented!()
+    }
+    async fn get_dnssec_stats(&self, _period_hours: f32) -> Result<DnssecStats, DomainError> {
+        unimplemented!()
+    }
+    async fn get_timeline(
+        &self,
+        _period_hours: u32,
+        _granularity: TimeGranularity,
+    ) -> Result<Vec<TimelineBucket>, DomainError> {
+        unimplemented!()
+    }
+    async fn count_queries_since(&self, _seconds_ago: i64) -> Result<u64, DomainError> {
+        unimplemented!()
+    }
+    async fn get_cache_stats(&self, _period_hours: f32) -> Result<CacheStats, DomainError> {
+        unimplemented!()
+    }
+    async fn get_top_blocked_domains(
+        &self,
+        _limit: u32,
+        _period_hours: f32,
+    ) -> Result<Vec<(String, u64)>, DomainError> {
+        unimplemented!()
+    }
+    async fn get_top_allowed_domains(
+        &self,
+        _limit: u32,
+        _period_hours: f32,
+    ) -> Result<Vec<(String, u64)>, DomainError> {
+        unimplemented!()
+    }
+    async fn get_distinct_recent_domains(
+        &self,
+        _limit: u32,
+        _period_hours: f32,
+    ) -> Result<Vec<(String, u64)>, DomainError> {
+        unimplemented!()
+    }
+    async fn get_top_clients(
+        &self,
+        _limit: u32,
+        _period_hours: f32,
+    ) -> Result<Vec<(String, Option<String>, u64)>, DomainError> {
+        unimplemented!()
+    }
+    async fn delete_older_than(&self, _days: u32) -> Result<u64, DomainError> {
+        unimplemented!()
+    }
+}
+
+/// Builds a handler that always resolves to `addresses` with the given TTL.
+pub fn handler_with_canned_addresses(addresses: Vec<IpAddr>, ttl: u32) -> Arc<DnsServerHandler> {
+    let resolver: Arc<dyn DnsResolver> = Arc::new(CannedAddressResolver { addresses, ttl });
+    let use_case = Arc::new(HandleDnsQueryUseCase::new(
+        resolver,
+        Arc::new(AllowAllFilter),
+        Arc::new(NoopQueryLog),
+    ));
+    Arc::new(DnsServerHandler::new(
+        use_case,
+        BlockPolicy {
+            mode: BlockResponseMode::NullIp,
+            ttl: 60,
+            sinkhole_ipv4: None,
+            sinkhole_ipv6: None,
+        },
+    ))
+}
+
+/// Builds a valid wire-format A-record query for `name`.
+pub fn build_a_query(name: &str) -> Vec<u8> {
+    let fqdn = if name.ends_with('.') {
+        name.to_string()
+    } else {
+        format!("{name}.")
+    };
+    let mut query = WireQuery::new();
+    query.set_name(Name::from_str(&fqdn).unwrap());
+    query.set_query_type(HickoryRecordType::A);
+    query.set_query_class(DNSClass::IN);
+
+    let mut message = Message::new(fastrand::u16(..), MessageType::Query, OpCode::Query);
+    message.metadata.recursion_desired = true;
+    message.add_query(query);
+
+    let mut buf = Vec::with_capacity(64);
+    let mut encoder = BinEncoder::new(&mut buf);
+    message.emit(&mut encoder).unwrap();
+    buf
+}
+
+/// Dummy certificate verifier that accepts any certificate — the test server
+/// uses a throwaway self-signed cert, so there's nothing to chain to a root.
+#[derive(Debug)]
+pub struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
+
+impl SkipServerVerification {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self(
+            Arc::new(rustls::crypto::aws_lc_rs::default_provider()),
+        ))
+    }
+}
+
+impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+/// True when a `[::]` socket also receives IPv4 traffic. Guards the dual-stack
+/// tests: a host with `net.ipv6.bindv6only=1`, or no IPv6 at all, cannot
+/// exercise the v4-mapped peer path.
+pub fn dual_stack_loopback_available() -> bool {
+    let Ok(server) = std::net::UdpSocket::bind("[::]:0") else {
+        return false;
+    };
+    let Ok(local) = server.local_addr() else {
+        return false;
+    };
+    if server
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .is_err()
+    {
+        return false;
+    }
+    let Ok(client) = std::net::UdpSocket::bind("127.0.0.1:0") else {
+        return false;
+    };
+    if client
+        .send_to(b"probe", ("127.0.0.1", local.port()))
+        .is_err()
+    {
+        return false;
+    }
+    let mut buf = [0u8; 8];
+    server.recv_from(&mut buf).is_ok()
+}

--- a/crates/cli/tests/doq_test.rs
+++ b/crates/cli/tests/doq_test.rs
@@ -5,196 +5,22 @@
 //! upstream DoQ client setup in
 //! `ferrous_dns_infrastructure::dns::transport::quic`.
 
-use async_trait::async_trait;
+mod common;
+
+use common::{
+    build_a_query, dual_stack_loopback_available, handler_with_canned_addresses,
+    SkipServerVerification,
+};
 use ferrous_dns::server::{
     bind_doq_endpoint, load_server_tls_config, serve_doq, ConnectionLimiter,
 };
-use ferrous_dns_application::ports::{
-    BlockFilterEnginePort, CacheStats, DnsResolution, DnsResolver, FilterDecision,
-    PagedQueryResult, QueryLogRepository, TimeGranularity, TimelineBucket, TlsCertificatePort,
-};
-use ferrous_dns_application::use_cases::HandleDnsQueryUseCase;
-use ferrous_dns_domain::{
-    BlockResponseMode, DnsQuery, DnssecStats, DomainError, QueryLog, QueryLogFilter, QueryStats,
-};
-use ferrous_dns_infrastructure::dns::server::{BlockPolicy, DnsServerHandler};
+use ferrous_dns_application::ports::TlsCertificatePort;
 use ferrous_dns_infrastructure::tls::TlsCertificateService;
-use hickory_proto::op::{Message, MessageType, OpCode, Query as WireQuery};
-use hickory_proto::rr::{DNSClass, Name, RData, RecordType as HickoryRecordType};
-use hickory_proto::serialize::binary::{BinEncodable, BinEncoder};
-use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use hickory_proto::op::Message;
+use hickory_proto::rr::RData;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-
-// ── Minimal port doubles (hand-rolled per crate test-placement convention —
-// application crate mocks aren't reachable from the cli crate's test binary) ──
-
-/// Resolver whose cache always hits with a fixed set of addresses, regardless
-/// of the query's domain/type.
-struct CannedAddressResolver {
-    addresses: Vec<IpAddr>,
-    ttl: u32,
-}
-
-#[async_trait]
-impl DnsResolver for CannedAddressResolver {
-    async fn resolve(&self, _query: &DnsQuery) -> Result<DnsResolution, DomainError> {
-        unimplemented!("cache hit only")
-    }
-
-    fn try_cache(&self, _query: &DnsQuery) -> Option<DnsResolution> {
-        let mut res = DnsResolution::new(self.addresses.clone(), true);
-        res.min_ttl = Some(self.ttl);
-        Some(res)
-    }
-}
-
-/// Allows every domain; assigns the default group.
-struct AllowAllFilter;
-
-#[async_trait]
-impl BlockFilterEnginePort for AllowAllFilter {
-    fn resolve_group(&self, _ip: IpAddr) -> i64 {
-        0
-    }
-    fn check(&self, _domain: &str, _group_id: i64) -> FilterDecision {
-        FilterDecision::Allow
-    }
-    fn store_cname_decision(&self, _domain: &str, _group_id: i64, _ttl_secs: u64) {}
-    async fn reload(&self) -> Result<(), DomainError> {
-        Ok(())
-    }
-    async fn load_client_groups(&self) -> Result<(), DomainError> {
-        Ok(())
-    }
-    fn compiled_domain_count(&self) -> usize {
-        0
-    }
-    fn is_blocking_enabled(&self) -> bool {
-        false
-    }
-    fn set_blocking_enabled(&self, _enabled: bool) {}
-}
-
-/// Drops every logged query.
-struct NoopQueryLog;
-
-#[async_trait]
-impl QueryLogRepository for NoopQueryLog {
-    async fn log_query(&self, _query: &QueryLog) -> Result<(), DomainError> {
-        Ok(())
-    }
-    async fn get_recent(
-        &self,
-        _limit: u32,
-        _period_hours: f32,
-    ) -> Result<Vec<QueryLog>, DomainError> {
-        unimplemented!()
-    }
-    async fn get_recent_paged(
-        &self,
-        _limit: u32,
-        _offset: u32,
-        _period_hours: f32,
-        _cursor: Option<i64>,
-        _filter: &QueryLogFilter,
-    ) -> Result<PagedQueryResult, DomainError> {
-        unimplemented!()
-    }
-    async fn get_stats(&self, _period_hours: f32) -> Result<QueryStats, DomainError> {
-        unimplemented!()
-    }
-    async fn get_dnssec_stats(&self, _period_hours: f32) -> Result<DnssecStats, DomainError> {
-        unimplemented!()
-    }
-    async fn get_timeline(
-        &self,
-        _period_hours: u32,
-        _granularity: TimeGranularity,
-    ) -> Result<Vec<TimelineBucket>, DomainError> {
-        unimplemented!()
-    }
-    async fn count_queries_since(&self, _seconds_ago: i64) -> Result<u64, DomainError> {
-        unimplemented!()
-    }
-    async fn get_cache_stats(&self, _period_hours: f32) -> Result<CacheStats, DomainError> {
-        unimplemented!()
-    }
-    async fn get_top_blocked_domains(
-        &self,
-        _limit: u32,
-        _period_hours: f32,
-    ) -> Result<Vec<(String, u64)>, DomainError> {
-        unimplemented!()
-    }
-    async fn get_top_allowed_domains(
-        &self,
-        _limit: u32,
-        _period_hours: f32,
-    ) -> Result<Vec<(String, u64)>, DomainError> {
-        unimplemented!()
-    }
-    async fn get_distinct_recent_domains(
-        &self,
-        _limit: u32,
-        _period_hours: f32,
-    ) -> Result<Vec<(String, u64)>, DomainError> {
-        unimplemented!()
-    }
-    async fn get_top_clients(
-        &self,
-        _limit: u32,
-        _period_hours: f32,
-    ) -> Result<Vec<(String, Option<String>, u64)>, DomainError> {
-        unimplemented!()
-    }
-    async fn delete_older_than(&self, _days: u32) -> Result<u64, DomainError> {
-        unimplemented!()
-    }
-}
-
-/// Builds a handler that always resolves to `addresses` with the given TTL.
-fn handler_with_canned_addresses(addresses: Vec<IpAddr>, ttl: u32) -> Arc<DnsServerHandler> {
-    let resolver: Arc<dyn DnsResolver> = Arc::new(CannedAddressResolver { addresses, ttl });
-    let use_case = Arc::new(HandleDnsQueryUseCase::new(
-        resolver,
-        Arc::new(AllowAllFilter),
-        Arc::new(NoopQueryLog),
-    ));
-    Arc::new(DnsServerHandler::new(
-        use_case,
-        BlockPolicy {
-            mode: BlockResponseMode::NullIp,
-            ttl: 60,
-            sinkhole_ipv4: None,
-            sinkhole_ipv6: None,
-        },
-    ))
-}
-
-/// Builds a valid wire-format A-record query for `name`.
-fn build_a_query(name: &str) -> Vec<u8> {
-    let fqdn = if name.ends_with('.') {
-        name.to_string()
-    } else {
-        format!("{name}.")
-    };
-    let mut query = WireQuery::new();
-    query.set_name(Name::from_str(&fqdn).unwrap());
-    query.set_query_type(HickoryRecordType::A);
-    query.set_query_class(DNSClass::IN);
-
-    let mut message = Message::new(fastrand::u16(..), MessageType::Query, OpCode::Query);
-    message.metadata.recursion_desired = true;
-    message.add_query(query);
-
-    let mut buf = Vec::with_capacity(64);
-    let mut encoder = BinEncoder::new(&mut buf);
-    message.emit(&mut encoder).unwrap();
-    buf
-}
 
 /// Starts a DoQ listener on an ephemeral loopback port with a fresh
 /// self-signed cert and the given connection limiter. The endpoint is bound
@@ -230,64 +56,6 @@ async fn start_test_doq_server_on(bind: &str, conn_limiter: ConnectionLimiter) -
         handler_with_canned_addresses(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))], 300);
     tokio::spawn(serve_doq(endpoint, handler, conn_limiter));
     addr
-}
-
-/// Dummy certificate verifier that accepts any certificate — the test server
-/// uses a throwaway self-signed cert, so there's nothing to chain to a root.
-#[derive(Debug)]
-struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
-
-impl SkipServerVerification {
-    fn new() -> Arc<Self> {
-        Arc::new(Self(
-            Arc::new(rustls::crypto::aws_lc_rs::default_provider()),
-        ))
-    }
-}
-
-impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &ServerName<'_>,
-        _ocsp: &[u8],
-        _now: UnixTime,
-    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        Ok(rustls::client::danger::ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        message: &[u8],
-        cert: &CertificateDer<'_>,
-        dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        rustls::crypto::verify_tls12_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        message: &[u8],
-        cert: &CertificateDer<'_>,
-        dss: &rustls::DigitallySignedStruct,
-    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        rustls::crypto::verify_tls13_signature(
-            message,
-            cert,
-            dss,
-            &self.0.signature_verification_algorithms,
-        )
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        self.0.signature_verification_algorithms.supported_schemes()
-    }
 }
 
 /// Builds a `quinn` client endpoint configured for DoQ (ALPN `doq`) that
@@ -353,6 +121,49 @@ async fn round_trip_returns_expected_answer() {
     match &msg.answers[0].data {
         RData::A(a) => assert_eq!(a.0, Ipv4Addr::new(93, 184, 216, 34)),
         other => panic!("expected an A record, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn ipv4_client_on_a_dual_stack_bind_is_keyed_as_plain_ipv4() {
+    // Needs a `[::]` socket that actually receives IPv4 — the whole point of
+    // the test is the v4-mapped peer address a dual-stack bind produces.
+    if !dual_stack_loopback_available() {
+        eprintln!(
+            "skipping ipv4_client_on_a_dual_stack_bind_is_keyed_as_plain_ipv4: \
+             no dual-stack loopback available"
+        );
+        return;
+    }
+
+    let limiter = ConnectionLimiter::new(1);
+    let bound = start_test_doq_server_on("[::]:0", limiter.clone()).await;
+
+    // Take the single slot for plain 127.0.0.1. An IPv4 client reaching the
+    // dual-stack endpoint arrives at the socket as ::ffff:127.0.0.1: unless
+    // the accept path unmaps it, the limiter keys it separately and hands out
+    // a slot of its own instead of refusing.
+    let _held = limiter
+        .try_acquire(IpAddr::V4(Ipv4Addr::LOCALHOST))
+        .expect("the single slot for 127.0.0.1 should be free");
+
+    let target = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), bound.port());
+    let endpoint = build_test_client_endpoint();
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(5),
+        endpoint.connect(target, "localhost").unwrap(),
+    )
+    .await;
+
+    match outcome {
+        Ok(Ok(_conn)) => panic!(
+            "the IPv4 client was keyed as ::ffff:127.0.0.1 instead of 127.0.0.1, \
+             so the per-IP limit did not apply and it got a second slot"
+        ),
+        Ok(Err(_refused)) => { /* refused as expected: the peer was unmapped */ }
+        Err(_elapsed) => {
+            panic!("refused connection should resolve promptly, not hang past the timeout")
+        }
     }
 }
 

--- a/crates/cli/tests/doq_test.rs
+++ b/crates/cli/tests/doq_test.rs
@@ -51,7 +51,7 @@ async fn start_test_doq_server_on(bind: &str, conn_limiter: ConnectionLimiter) -
     .unwrap();
 
     let endpoint = bind_doq_endpoint(bind, tls_config).unwrap();
-    let addr = endpoint.local_addr().unwrap();
+    let addr = common::unmap_addr(endpoint.local_addr().unwrap());
     let handler =
         handler_with_canned_addresses(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))], 300);
     tokio::spawn(serve_doq(endpoint, handler, conn_limiter));

--- a/crates/cli/tests/dot_test.rs
+++ b/crates/cli/tests/dot_test.rs
@@ -1,0 +1,164 @@
+//! DNS-over-TLS (DoT) server listener (RFC 7858) end-to-end tests.
+//!
+//! Binds the real `serve_dot` accept loop against a self-signed test
+//! certificate and drives it with a real `tokio-rustls` client over the
+//! RFC 7858 two-byte length-prefixed framing.
+//!
+//! Also covers the dual-stack peer path: on a `[::]` bind the kernel reports
+//! IPv4 peers as `::ffff:a.b.c.d`, and the accept loop must normalise that
+//! back to plain IPv4 before the per-IP connection limiter (and everything
+//! else client-facing) sees it.
+
+mod common;
+
+use common::{
+    build_a_query, dual_stack_loopback_available, handler_with_canned_addresses,
+    SkipServerVerification,
+};
+use ferrous_dns::server::{
+    bind_dot_listener, load_server_tls_config, serve_dot, ConnectionLimiter,
+};
+use ferrous_dns_application::ports::TlsCertificatePort;
+use ferrous_dns_infrastructure::tls::TlsCertificateService;
+use hickory_proto::op::Message;
+use hickory_proto::rr::RData;
+use rustls::pki_types::ServerName;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+
+/// Starts a DoT listener on `bind` with a fresh self-signed cert and the given
+/// connection limiter. The listener is bound synchronously before this
+/// returns, so callers can connect immediately with no bind race — the
+/// resolved `SocketAddr` (actual port) is returned.
+async fn start_test_dot_server_on(bind: &str, conn_limiter: ConnectionLimiter) -> SocketAddr {
+    ferrous_dns::install_crypto_provider();
+
+    let dir = tempfile::tempdir().unwrap();
+    let cert_path = dir.path().join("cert.pem");
+    let key_path = dir.path().join("key.pem");
+    TlsCertificateService
+        .generate_self_signed(cert_path.to_str().unwrap(), key_path.to_str().unwrap())
+        .await
+        .unwrap();
+
+    let tls_config = load_server_tls_config(
+        cert_path.to_str().unwrap(),
+        key_path.to_str().unwrap(),
+        "dot_test",
+        &[],
+    )
+    .unwrap()
+    .unwrap();
+
+    let listener = Arc::new(bind_dot_listener(bind).unwrap());
+    let addr = listener.local_addr().unwrap();
+    let handler =
+        handler_with_canned_addresses(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))], 300);
+    // `tls_config` already holds the parsed cert and key, so the temp dir can
+    // go away once we get here.
+    tokio::spawn(serve_dot(
+        listener,
+        tls_config,
+        handler,
+        1,
+        false,
+        conn_limiter,
+    ));
+    addr
+}
+
+/// Builds a TLS client that trusts any server certificate — the test server
+/// uses a throwaway self-signed cert, so there's nothing to chain to a root.
+fn build_test_tls_connector() -> TlsConnector {
+    let tls_config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(SkipServerVerification::new())
+        .with_no_client_auth();
+    TlsConnector::from(Arc::new(tls_config))
+}
+
+#[tokio::test]
+async fn round_trip_returns_expected_answer() {
+    let addr = start_test_dot_server_on("127.0.0.1:0", ConnectionLimiter::new(0)).await;
+
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let server_name = ServerName::try_from("localhost").unwrap();
+    let mut tls_stream = build_test_tls_connector()
+        .connect(server_name, stream)
+        .await
+        .unwrap();
+
+    let query = build_a_query("example.com");
+    let query_id = u16::from_be_bytes([query[0], query[1]]);
+
+    // RFC 7858 framing: a two-byte big-endian length prefix per message.
+    tls_stream
+        .write_all(&(query.len() as u16).to_be_bytes())
+        .await
+        .unwrap();
+    tls_stream.write_all(&query).await.unwrap();
+
+    let mut len_buf = [0u8; 2];
+    tls_stream.read_exact(&mut len_buf).await.unwrap();
+    let mut response = vec![0u8; u16::from_be_bytes(len_buf) as usize];
+    tls_stream.read_exact(&mut response).await.unwrap();
+
+    let msg = Message::from_vec(&response).unwrap();
+    assert_eq!(msg.id, query_id);
+    assert_eq!(msg.answers.len(), 1);
+    match &msg.answers[0].data {
+        RData::A(a) => assert_eq!(a.0, Ipv4Addr::new(93, 184, 216, 34)),
+        other => panic!("expected an A record, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn ipv4_client_on_a_dual_stack_bind_is_keyed_as_plain_ipv4() {
+    // Needs a `[::]` socket that actually receives IPv4 — the whole point of
+    // the test is the v4-mapped peer address a dual-stack bind produces.
+    if !dual_stack_loopback_available() {
+        eprintln!(
+            "skipping ipv4_client_on_a_dual_stack_bind_is_keyed_as_plain_ipv4: \
+             no dual-stack loopback available"
+        );
+        return;
+    }
+
+    let limiter = ConnectionLimiter::new(1);
+    let bound = start_test_dot_server_on("[::]:0", limiter.clone()).await;
+
+    // Take the single slot for plain 127.0.0.1. An IPv4 client reaching the
+    // dual-stack listener arrives at the socket as ::ffff:127.0.0.1: unless
+    // the accept loop unmaps it, the limiter keys it separately and lets the
+    // connection through instead of dropping it.
+    let _held = limiter
+        .try_acquire(IpAddr::V4(Ipv4Addr::LOCALHOST))
+        .expect("the single slot for 127.0.0.1 should be free");
+
+    let target = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), bound.port());
+    let mut stream = TcpStream::connect(target).await.unwrap();
+
+    // On the rejected path the accept loop drops the stream before the TLS
+    // handshake, so the read must end promptly with EOF or a reset. If it
+    // hangs, the server accepted the connection and is waiting for a
+    // ClientHello — i.e. the peer was keyed as ::ffff:127.0.0.1 and the per-IP
+    // limit never applied.
+    let mut buf = [0u8; 1];
+    match tokio::time::timeout(Duration::from_secs(5), stream.read(&mut buf)).await {
+        Ok(Ok(0)) => { /* EOF: the connection was dropped, as expected */ }
+        Ok(Err(_reset)) => { /* connection reset: also the rejected path */ }
+        Ok(Ok(n)) => panic!(
+            "the server sent {n} byte(s) instead of dropping the connection, \
+             so the IPv4 client was keyed as ::ffff:127.0.0.1 rather than 127.0.0.1"
+        ),
+        Err(_elapsed) => panic!(
+            "the server kept the connection open waiting for a ClientHello, \
+             so the IPv4 client was keyed as ::ffff:127.0.0.1 instead of 127.0.0.1 \
+             and the per-IP limit did not apply"
+        ),
+    }
+}

--- a/crates/cli/tests/dot_test.rs
+++ b/crates/cli/tests/dot_test.rs
@@ -55,7 +55,7 @@ async fn start_test_dot_server_on(bind: &str, conn_limiter: ConnectionLimiter) -
     .unwrap();
 
     let listener = Arc::new(bind_dot_listener(bind).unwrap());
-    let addr = listener.local_addr().unwrap();
+    let addr = common::unmap_addr(listener.local_addr().unwrap());
     let handler =
         handler_with_canned_addresses(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))], 300);
     // `tls_config` already holds the parsed cert and key, so the temp dir can

--- a/crates/domain/src/config/encrypted_dns.rs
+++ b/crates/domain/src/config/encrypted_dns.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// If the cert/key files are absent at startup, the affected listeners are skipped
 /// with a warning — the server continues to serve plain DNS normally.
+///
+/// Each listener binds to `[server].bind_address` unless it carries its own
+/// `*_bind_address`, which lets a single deployment expose, say, DoT on every
+/// interface while keeping DoQ on one address.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EncryptedDnsConfig {
     /// Enable the DNS-over-TLS listener (RFC 7858) on `dot_port`.
@@ -17,6 +21,11 @@ pub struct EncryptedDnsConfig {
     /// TCP port for DNS-over-TLS. Standard port is 853.
     #[serde(default = "default_dot_port")]
     pub dot_port: u16,
+
+    /// Address the DoT listener binds to; falls back to `[server].bind_address`.
+    /// `"[::]"` serves IPv4 and IPv6 clients on one dual-stack socket.
+    #[serde(default)]
+    pub dot_bind_address: Option<String>,
 
     /// Enable the DNS-over-HTTPS endpoint `/dns-query` (RFC 8484).
     /// HTTPS termination is handled by a reverse proxy (nginx/Traefik/Caddy).
@@ -31,6 +40,12 @@ pub struct EncryptedDnsConfig {
     #[serde(default)]
     pub doh_port: Option<u16>,
 
+    /// Address the dedicated DoH listener binds to; falls back to
+    /// `[server].bind_address`. Ignored when `doh_port` is absent, since
+    /// `/dns-query` is then co-hosted on the web listener.
+    #[serde(default)]
+    pub doh_bind_address: Option<String>,
+
     /// Enable the DNS-over-QUIC listener (RFC 9250) on `doq_port`.
     #[serde(default)]
     pub doq_enabled: bool,
@@ -39,6 +54,11 @@ pub struct EncryptedDnsConfig {
     /// `dot_port`; no collision since DoQ is UDP-based and DoT is TCP-based).
     #[serde(default = "default_dot_port")]
     pub doq_port: u16,
+
+    /// Address the DoQ listener binds to; falls back to `[server].bind_address`.
+    /// `"[::]"` serves IPv4 and IPv6 clients on one dual-stack socket.
+    #[serde(default)]
+    pub doq_bind_address: Option<String>,
 
     /// Path to the PEM certificate file shared by DoT, DoH, and DoQ.
     #[serde(default = "default_cert_path")]
@@ -66,10 +86,13 @@ impl Default for EncryptedDnsConfig {
         Self {
             dot_enabled: false,
             dot_port: default_dot_port(),
+            dot_bind_address: None,
             doh_enabled: false,
             doh_port: None,
+            doh_bind_address: None,
             doq_enabled: false,
             doq_port: default_dot_port(),
+            doq_bind_address: None,
             tls_cert_path: default_cert_path(),
             tls_key_path: default_key_path(),
         }

--- a/crates/domain/src/config/root.rs
+++ b/crates/domain/src/config/root.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
 
 use super::auth::AuthConfig;
 use super::blocking::BlockingConfig;
@@ -87,6 +88,32 @@ impl Config {
             return Err(ConfigError::Validation("DNS port cannot be 0".to_string()));
         }
 
+        // Every listener parses its address only when it binds, and the
+        // encrypted ones bind inside a spawned task — so without this an
+        // unparseable address takes a listener down with a single log line
+        // while the process stays up. Check them all up front instead. A
+        // listener that falls back to `bind_address` is already covered by
+        // the first check, so only an explicit override is named separately.
+        check_listen_address("server.bind_address", &self.server.dns_listen_address())?;
+        let encrypted = &self.server.encrypted_dns;
+        if encrypted.dot_enabled && encrypted.dot_bind_address.is_some() {
+            check_listen_address(
+                "server.encrypted_dns.dot_bind_address",
+                &self.server.dot_listen_address(),
+            )?;
+        }
+        if encrypted.doq_enabled && encrypted.doq_bind_address.is_some() {
+            check_listen_address(
+                "server.encrypted_dns.doq_bind_address",
+                &self.server.doq_listen_address(),
+            )?;
+        }
+        if encrypted.doh_enabled && encrypted.doh_bind_address.is_some() {
+            if let Some(addr) = self.server.doh_listen_address() {
+                check_listen_address("server.encrypted_dns.doh_bind_address", &addr)?;
+            }
+        }
+
         if self.dns.pools.is_empty() && self.dns.upstream_servers.is_empty() {
             return Err(ConfigError::Validation(
                 "No upstream servers configured".to_string(),
@@ -123,4 +150,15 @@ pub struct CliOverrides {
     pub bind_address: Option<String>,
     pub database_path: Option<String>,
     pub log_level: Option<String>,
+}
+
+/// Rejects a listen address the listeners could not bind. `field` names the
+/// configuration key so the operator knows which one to fix.
+fn check_listen_address(field: &str, addr: &str) -> Result<(), ConfigError> {
+    if addr.parse::<SocketAddr>().is_ok() {
+        return Ok(());
+    }
+    Err(ConfigError::Validation(format!(
+        "{field} yields the invalid listen address '{addr}'; it must be an IPv4 or IPv6 literal, not a hostname"
+    )))
 }

--- a/crates/domain/src/config/server.rs
+++ b/crates/domain/src/config/server.rs
@@ -9,6 +9,10 @@ pub struct ServerConfig {
 
     pub web_port: u16,
 
+    /// Default address every listener binds to. `"0.0.0.0"` covers all IPv4
+    /// interfaces; `"[::]"` covers both families on one dual-stack socket.
+    /// A bare `"::"` is accepted too — the brackets are added when the
+    /// listen address is built.
     pub bind_address: String,
 
     #[serde(default = "default_cors_origins")]
@@ -38,6 +42,64 @@ pub struct ServerConfig {
 
 fn default_cors_origins() -> Vec<String> {
     vec!["*".to_string()]
+}
+
+impl ServerConfig {
+    /// Listen address for plain DNS (Do53), shared by the UDP and TCP listeners.
+    pub fn dns_listen_address(&self) -> String {
+        join_host_port(&self.bind_address, self.dns_port)
+    }
+
+    /// Listen address for the web dashboard and REST API.
+    pub fn web_listen_address(&self) -> String {
+        join_host_port(&self.bind_address, self.web_port)
+    }
+
+    /// Listen address for the DoT listener, honouring
+    /// `[server.encrypted_dns].dot_bind_address` when it is set.
+    pub fn dot_listen_address(&self) -> String {
+        join_host_port(
+            self.encrypted_dns
+                .dot_bind_address
+                .as_deref()
+                .unwrap_or(&self.bind_address),
+            self.encrypted_dns.dot_port,
+        )
+    }
+
+    /// Listen address for the DoQ listener, honouring
+    /// `[server.encrypted_dns].doq_bind_address` when it is set.
+    pub fn doq_listen_address(&self) -> String {
+        join_host_port(
+            self.encrypted_dns
+                .doq_bind_address
+                .as_deref()
+                .unwrap_or(&self.bind_address),
+            self.encrypted_dns.doq_port,
+        )
+    }
+
+    /// Listen address for the dedicated DoH listener, or `None` when
+    /// `doh_port` is absent and `/dns-query` is co-hosted on `web_port`.
+    pub fn doh_listen_address(&self) -> Option<String> {
+        let port = self.encrypted_dns.doh_port?;
+        Some(join_host_port(
+            self.encrypted_dns
+                .doh_bind_address
+                .as_deref()
+                .unwrap_or(&self.bind_address),
+            port,
+        ))
+    }
+}
+
+/// Joins a bind host with a port. A bare IPv6 literal is bracketed, so both
+/// `"::"` and `"[::]"` yield an address that parses as a `SocketAddr`.
+fn join_host_port(host: &str, port: u16) -> String {
+    if host.contains(':') && !host.starts_with('[') {
+        return format!("[{host}]:{port}");
+    }
+    format!("{host}:{port}")
 }
 
 impl Default for ServerConfig {

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -15,8 +15,8 @@ pub use config::{
     DgaDetectionAction, DgaDetectionConfig, Dns64Config, DnsConfig, DnsCookiesConfig, DnssecMode,
     EncryptedDnsConfig, HealthCheckConfig, LocalDnsRecord, NxdomainHijackAction,
     NxdomainHijackConfig, RateLimitConfig, ResponseIpFilterAction, ResponseIpFilterConfig,
-    TunnelingAction, TunnelingDetectionConfig, UpstreamPool, UpstreamStrategy, WebauthnConfig,
-    DEFAULT_BLOCK_TTL, DEFAULT_DNS64_PREFIX,
+    ServerConfig, TunnelingAction, TunnelingDetectionConfig, UpstreamPool, UpstreamStrategy,
+    WebauthnConfig, DEFAULT_BLOCK_TTL, DEFAULT_DNS64_PREFIX,
 };
 pub use dns_record::{DnsRecord, RecordCategory, RecordType};
 pub use entities::api_token::ApiToken;

--- a/crates/domain/tests/config_validation_test.rs
+++ b/crates/domain/tests/config_validation_test.rs
@@ -1,0 +1,84 @@
+use ferrous_dns_domain::{Config, ConfigError};
+
+/// A config that passes every check unrelated to bind addresses, so a failure
+/// can only come from the address validation under test.
+fn valid_config() -> Config {
+    let mut config = Config::default();
+    config.dns.upstream_servers = vec!["1.1.1.1:53".to_string()];
+    config
+}
+
+fn validation_message(config: &Config) -> String {
+    match config.validate() {
+        Err(ConfigError::Validation(message)) => message,
+        other => panic!("expected a validation error, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_valid_config_passes() {
+    valid_config().validate().unwrap();
+}
+
+#[test]
+fn a_bare_ipv6_bind_address_is_accepted() {
+    let mut config = valid_config();
+    config.server.bind_address = "::".to_string();
+    config.validate().unwrap();
+}
+
+#[test]
+fn an_unparseable_bind_address_is_rejected() {
+    let mut config = valid_config();
+    config.server.bind_address = "192.168.1.300".to_string();
+
+    let message = validation_message(&config);
+    assert!(
+        message.contains("server.bind_address"),
+        "the message should name the offending key: {message}"
+    );
+}
+
+#[test]
+fn a_hostname_bind_address_is_rejected_rather_than_panicking_at_bind_time() {
+    let mut config = valid_config();
+    config.server.bind_address = "localhost".to_string();
+
+    assert!(validation_message(&config).contains("not a hostname"));
+}
+
+#[test]
+fn an_unparseable_per_protocol_bind_address_names_its_own_key() {
+    let mut config = valid_config();
+    config.server.encrypted_dns.dot_enabled = true;
+    config.server.encrypted_dns.dot_bind_address = Some("not-an-address".to_string());
+
+    let message = validation_message(&config);
+    assert!(
+        message.contains("dot_bind_address"),
+        "the message should name the DoT key, not the global one: {message}"
+    );
+}
+
+#[test]
+fn a_bad_bind_address_on_a_disabled_listener_does_not_block_startup() {
+    // The listener is never bound, so a stale value must not be fatal.
+    let mut config = valid_config();
+    config.server.encrypted_dns.doq_enabled = false;
+    config.server.encrypted_dns.doq_bind_address = Some("not-an-address".to_string());
+
+    config.validate().unwrap();
+}
+
+#[test]
+fn the_doh_bind_address_is_only_checked_when_a_dedicated_port_is_set() {
+    let mut config = valid_config();
+    config.server.encrypted_dns.doh_enabled = true;
+    config.server.encrypted_dns.doh_bind_address = Some("not-an-address".to_string());
+
+    // No `doh_port`, so `/dns-query` is co-hosted and the address is unused.
+    config.validate().unwrap();
+
+    config.server.encrypted_dns.doh_port = Some(443);
+    assert!(validation_message(&config).contains("doh_bind_address"));
+}

--- a/crates/domain/tests/encrypted_dns_config_test.rs
+++ b/crates/domain/tests/encrypted_dns_config_test.rs
@@ -25,14 +25,42 @@ fn parses_doq_fields_from_toml() {
 }
 
 #[test]
+fn bind_addresses_are_absent_unless_configured() {
+    let config = EncryptedDnsConfig::default();
+    assert!(config.dot_bind_address.is_none());
+    assert!(config.doh_bind_address.is_none());
+    assert!(config.doq_bind_address.is_none());
+}
+
+#[test]
+fn parses_per_protocol_bind_addresses_from_toml() {
+    let toml = r#"
+        dot_enabled      = true
+        dot_bind_address = "[::]"
+        doh_enabled      = true
+        doh_port         = 8053
+        doh_bind_address = "127.0.0.1"
+        doq_enabled      = true
+        doq_bind_address = "192.168.1.10"
+    "#;
+    let config: EncryptedDnsConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.dot_bind_address.as_deref(), Some("[::]"));
+    assert_eq!(config.doh_bind_address.as_deref(), Some("127.0.0.1"));
+    assert_eq!(config.doq_bind_address.as_deref(), Some("192.168.1.10"));
+}
+
+#[test]
 fn round_trips_doq_fields() {
     let original = EncryptedDnsConfig {
         dot_enabled: true,
         dot_port: 853,
+        dot_bind_address: Some("[::]".to_string()),
         doh_enabled: false,
         doh_port: None,
+        doh_bind_address: None,
         doq_enabled: true,
         doq_port: 8853,
+        doq_bind_address: None,
         tls_cert_path: "/data/cert.pem".to_string(),
         tls_key_path: "/data/key.pem".to_string(),
     };
@@ -40,4 +68,6 @@ fn round_trips_doq_fields() {
     let restored: EncryptedDnsConfig = toml::from_str(&toml_str).unwrap();
     assert_eq!(restored.doq_enabled, original.doq_enabled);
     assert_eq!(restored.doq_port, original.doq_port);
+    assert_eq!(restored.dot_bind_address, original.dot_bind_address);
+    assert_eq!(restored.doq_bind_address, original.doq_bind_address);
 }

--- a/crates/domain/tests/server_config_test.rs
+++ b/crates/domain/tests/server_config_test.rs
@@ -1,0 +1,76 @@
+use ferrous_dns_domain::ServerConfig;
+
+fn config_with_bind(bind_address: &str) -> ServerConfig {
+    ServerConfig {
+        bind_address: bind_address.to_string(),
+        ..ServerConfig::default()
+    }
+}
+
+#[test]
+fn listen_addresses_use_the_global_bind_address_by_default() {
+    let config = config_with_bind("0.0.0.0");
+    assert_eq!(config.dns_listen_address(), "0.0.0.0:53");
+    assert_eq!(config.web_listen_address(), "0.0.0.0:8080");
+    assert_eq!(config.dot_listen_address(), "0.0.0.0:853");
+    assert_eq!(config.doq_listen_address(), "0.0.0.0:853");
+}
+
+#[test]
+fn a_bare_ipv6_bind_address_is_bracketed() {
+    let config = config_with_bind("::");
+    assert_eq!(config.dns_listen_address(), "[::]:53");
+    assert_eq!(config.dot_listen_address(), "[::]:853");
+    assert_eq!(config.doq_listen_address(), "[::]:853");
+    assert_eq!(config.web_listen_address(), "[::]:8080");
+}
+
+#[test]
+fn an_already_bracketed_ipv6_bind_address_is_left_alone() {
+    let config = config_with_bind("[::1]");
+    assert_eq!(config.dns_listen_address(), "[::1]:53");
+}
+
+#[test]
+fn every_listen_address_parses_as_a_socket_address() {
+    let config = config_with_bind("::");
+    for address in [
+        config.dns_listen_address(),
+        config.web_listen_address(),
+        config.dot_listen_address(),
+        config.doq_listen_address(),
+    ] {
+        address
+            .parse::<std::net::SocketAddr>()
+            .unwrap_or_else(|e| panic!("{address} should parse as a socket address: {e}"));
+    }
+}
+
+#[test]
+fn per_protocol_bind_addresses_override_the_global_one() {
+    let mut config = config_with_bind("0.0.0.0");
+    config.encrypted_dns.dot_bind_address = Some("[::]".to_string());
+    config.encrypted_dns.doq_bind_address = Some("192.168.1.10".to_string());
+
+    assert_eq!(config.dot_listen_address(), "[::]:853");
+    assert_eq!(config.doq_listen_address(), "192.168.1.10:853");
+    // Untouched protocols keep inheriting the global bind address.
+    assert_eq!(config.dns_listen_address(), "0.0.0.0:53");
+}
+
+#[test]
+fn doh_has_no_listen_address_when_it_is_co_hosted_on_the_web_port() {
+    let config = config_with_bind("0.0.0.0");
+    assert!(config.encrypted_dns.doh_port.is_none());
+    assert_eq!(config.doh_listen_address(), None);
+}
+
+#[test]
+fn doh_listen_address_honours_its_own_bind_address() {
+    let mut config = config_with_bind("0.0.0.0");
+    config.encrypted_dns.doh_port = Some(443);
+    assert_eq!(config.doh_listen_address().as_deref(), Some("0.0.0.0:443"));
+
+    config.encrypted_dns.doh_bind_address = Some("::".to_string());
+    assert_eq!(config.doh_listen_address().as_deref(), Some("[::]:443"));
+}

--- a/crates/infrastructure/src/dns/proxy_protocol.rs
+++ b/crates/infrastructure/src/dns/proxy_protocol.rs
@@ -111,7 +111,15 @@ fn extract_source_ip(
                 additional[14],
                 additional[15],
             ];
-            Ok(IpAddr::V6(Ipv6Addr::from(octets)))
+            // A dual-stack frontend encodes an IPv4 client as TCP6 with a
+            // v4-mapped address. Normalise it, so a client keyed as
+            // `10.0.0.1` on the direct path is not keyed as
+            // `::ffff:10.0.0.1` behind the proxy.
+            let v6 = Ipv6Addr::from(octets);
+            Ok(match v6.to_ipv4_mapped() {
+                Some(v4) => IpAddr::V4(v4),
+                None => IpAddr::V6(v6),
+            })
         }
         FAMILY_UNSPEC => Ok(peer_addr),
         _ => Ok(peer_addr),

--- a/crates/infrastructure/tests/proxy_protocol_tests.rs
+++ b/crates/infrastructure/tests/proxy_protocol_tests.rs
@@ -70,6 +70,20 @@ async fn test_proxy_v2_tcp6_returns_real_client_ip() {
 }
 
 #[tokio::test]
+async fn test_proxy_v2_tcp6_unmaps_a_v4_mapped_client_ip() {
+    // A dual-stack frontend forwards an IPv4 client as TCP6 with
+    // `::ffff:10.0.0.100`. It has to key the same as the direct path.
+    let src_ip = Ipv4Addr::new(10, 0, 0, 100).to_ipv6_mapped().octets();
+    let header = build_tcp6_header(src_ip, [0; 16], 54321, 853);
+
+    let peer_addr: IpAddr = "::1".parse().unwrap();
+    let mut stream = header.as_slice();
+    let result = read_proxy_v2_client_ip(&mut stream, peer_addr).await;
+
+    assert_eq!(result.unwrap(), IpAddr::V4(Ipv4Addr::new(10, 0, 0, 100)));
+}
+
+#[tokio::test]
 async fn test_proxy_v2_local_command_returns_peer_addr() {
     let header = build_local_header();
 

--- a/crates/infrastructure/tests/unmap_v4_mapped_addresses_migration_test.rs
+++ b/crates/infrastructure/tests/unmap_v4_mapped_addresses_migration_test.rs
@@ -1,0 +1,255 @@
+//! Exercises the `20260822000001_unmap_v4_mapped_client_addresses` migration
+//! against hand-seeded rows in the shape earlier releases left behind.
+
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::Row;
+
+const MIGRATION: &str =
+    include_str!("../../../migrations/20260822000001_unmap_v4_mapped_client_addresses.sql");
+
+async fn seeded_db() -> sqlx::SqlitePool {
+    let pool = SqlitePoolOptions::new()
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(
+        r#"
+        CREATE TABLE groups (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE
+        );
+        CREATE TABLE clients (
+            id            INTEGER  PRIMARY KEY AUTOINCREMENT,
+            ip_address    TEXT     NOT NULL UNIQUE,
+            mac_address   TEXT,
+            hostname      TEXT,
+            first_seen    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            last_seen     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            query_count   INTEGER  NOT NULL DEFAULT 0,
+            created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+            group_id      INTEGER  REFERENCES groups(id) ON DELETE SET NULL
+        );
+        CREATE TABLE client_subnets (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            subnet_cidr TEXT NOT NULL UNIQUE,
+            group_id    INTEGER NOT NULL,
+            updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE query_log (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            client_ip TEXT NOT NULL
+        );
+        INSERT INTO groups (id, name) VALUES (2, 'kids'), (3, 'servers');
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    pool
+}
+
+async fn run_migration(pool: &sqlx::SqlitePool) {
+    sqlx::raw_sql(MIGRATION).execute(pool).await.unwrap();
+}
+
+async fn client_addresses(pool: &sqlx::SqlitePool) -> Vec<String> {
+    sqlx::query("SELECT ip_address FROM clients ORDER BY ip_address")
+        .fetch_all(pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| row.get::<String, _>("ip_address"))
+        .collect()
+}
+
+#[tokio::test]
+async fn a_mapped_row_without_a_plain_twin_is_renamed_in_place() {
+    let pool = seeded_db().await;
+    sqlx::query(
+        "INSERT INTO clients (ip_address, hostname, query_count, group_id)
+         VALUES ('::ffff:10.0.0.7', 'laptop', 12, 2)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    run_migration(&pool).await;
+
+    let row = sqlx::query("SELECT ip_address, hostname, query_count, group_id FROM clients")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<String, _>("ip_address"), "10.0.0.7");
+    assert_eq!(row.get::<String, _>("hostname"), "laptop");
+    assert_eq!(row.get::<i64, _>("query_count"), 12);
+    assert_eq!(row.get::<i64, _>("group_id"), 2);
+}
+
+#[tokio::test]
+async fn a_mapped_row_is_merged_into_its_plain_twin() {
+    let pool = seeded_db().await;
+    sqlx::query(
+        "INSERT INTO clients (ip_address, hostname, query_count, first_seen, last_seen, group_id)
+         VALUES ('10.0.0.7', NULL, 10, '2026-01-01 00:00:00', '2026-06-01 00:00:00', NULL),
+                ('::ffff:10.0.0.7', 'laptop', 5, '2025-12-01 00:00:00', '2026-07-01 00:00:00', 2)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    run_migration(&pool).await;
+
+    assert_eq!(client_addresses(&pool).await, vec!["10.0.0.7"]);
+    let row =
+        sqlx::query("SELECT hostname, query_count, first_seen, last_seen, group_id FROM clients")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(row.get::<i64, _>("query_count"), 15);
+    // The mapped row fills in what the plain row was missing.
+    assert_eq!(row.get::<String, _>("hostname"), "laptop");
+    assert_eq!(row.get::<i64, _>("group_id"), 2);
+    // The merged row spans both rows' activity.
+    assert_eq!(row.get::<String, _>("first_seen"), "2025-12-01 00:00:00");
+    assert_eq!(row.get::<String, _>("last_seen"), "2026-07-01 00:00:00");
+}
+
+#[tokio::test]
+async fn an_explicit_group_on_the_plain_row_is_not_overwritten() {
+    let pool = seeded_db().await;
+    sqlx::query(
+        "INSERT INTO clients (ip_address, group_id)
+         VALUES ('10.0.0.7', 3), ('::ffff:10.0.0.7', 2)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    run_migration(&pool).await;
+
+    let group_id: i64 = sqlx::query_scalar("SELECT group_id FROM clients")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(group_id, 3);
+}
+
+#[tokio::test]
+async fn a_genuine_ipv6_client_is_left_alone() {
+    let pool = seeded_db().await;
+    sqlx::query(
+        "INSERT INTO clients (ip_address) VALUES ('2001:db8::1'), ('::1'), ('192.168.1.5')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    run_migration(&pool).await;
+
+    assert_eq!(
+        client_addresses(&pool).await,
+        vec!["192.168.1.5", "2001:db8::1", "::1"]
+    );
+}
+
+#[tokio::test]
+async fn query_log_entries_follow_the_client_rows() {
+    let pool = seeded_db().await;
+    sqlx::query(
+        "INSERT INTO query_log (client_ip)
+         VALUES ('::ffff:10.0.0.7'), ('10.0.0.7'), ('2001:db8::1')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    run_migration(&pool).await;
+
+    let addresses: Vec<String> = sqlx::query_scalar("SELECT client_ip FROM query_log ORDER BY id")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert_eq!(addresses, vec!["10.0.0.7", "10.0.0.7", "2001:db8::1"]);
+}
+
+#[tokio::test]
+async fn a_mapped_subnet_loses_both_the_prefix_and_the_96_mask_bits() {
+    let pool = seeded_db().await;
+    sqlx::query(
+        "INSERT INTO client_subnets (subnet_cidr, group_id)
+         VALUES ('::ffff:10.0.0.0/104', 2),
+                ('::ffff:192.168.1.0/120', 3),
+                ('2001:db8::/32', 2),
+                ('172.16.0.0/12', 3)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    run_migration(&pool).await;
+
+    let subnets: Vec<String> =
+        sqlx::query_scalar("SELECT subnet_cidr FROM client_subnets ORDER BY id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        subnets,
+        vec![
+            "10.0.0.0/8",
+            "192.168.1.0/24",
+            "2001:db8::/32",
+            "172.16.0.0/12"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn a_mapped_subnet_duplicating_a_plain_one_is_dropped() {
+    let pool = seeded_db().await;
+    sqlx::query(
+        "INSERT INTO client_subnets (subnet_cidr, group_id)
+         VALUES ('10.0.0.0/8', 3), ('::ffff:10.0.0.0/104', 2)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    run_migration(&pool).await;
+
+    let subnets: Vec<String> = sqlx::query_scalar("SELECT subnet_cidr FROM client_subnets")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert_eq!(subnets, vec!["10.0.0.0/8"]);
+}
+
+#[tokio::test]
+async fn running_the_migration_twice_changes_nothing_the_second_time() {
+    let pool = seeded_db().await;
+    sqlx::query(
+        "INSERT INTO clients (ip_address, query_count)
+         VALUES ('10.0.0.7', 10), ('::ffff:10.0.0.7', 5)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    run_migration(&pool).await;
+    let after_first: i64 = sqlx::query_scalar("SELECT query_count FROM clients")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    run_migration(&pool).await;
+    let after_second: i64 = sqlx::query_scalar("SELECT query_count FROM clients")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(after_first, 15);
+    assert_eq!(after_second, 15);
+}

--- a/docs/configuration/ferrous-dns-toml.md
+++ b/docs/configuration/ferrous-dns-toml.md
@@ -67,7 +67,7 @@ metrics_enabled          = false
 |:-------|:-----|:--------|:------------|
 | `dns_port` | `int` | `53` | UDP and TCP port for DNS queries |
 | `web_port` | `int` | `8080` | HTTP/HTTPS port for the dashboard and REST API |
-| `bind_address` | `str` | `"0.0.0.0"` | Network interface to bind to; `0.0.0.0` listens on all interfaces |
+| `bind_address` | `str` | `"0.0.0.0"` | Default address every listener binds to; `"0.0.0.0"` is all IPv4 interfaces, `"[::]"` is dual-stack (IPv4 + IPv6) |
 | `pihole_compat` | `bool` | `false` | Expose Pi-hole v6 compatible API at `/api/*`; Ferrous DNS native API moves to `/ferrous/api/*` |
 | `proxy_protocol_enabled` | `bool` | `false` | Enable PROXY Protocol v2 on TCP DNS and DoT listeners |
 | `metrics_enabled` | `bool` | `false` | Serve an unauthenticated Prometheus text-exposition endpoint at `/metrics` on the web port |
@@ -122,10 +122,13 @@ tls_key_path  = "/data/key.pem"
 |:-------|:-----|:--------|:------------|
 | `dot_enabled` | `bool` | `false` | Enable DNS-over-TLS listener |
 | `dot_port` | `int` | `853` | TCP port for DoT (RFC 7858 standard: 853) |
+| `dot_bind_address` | `str` | — | Address for the DoT listener; inherits `bind_address` when omitted |
 | `doh_enabled` | `bool` | `false` | Enable the `/dns-query` DoH endpoint |
 | `doh_port` | `int` | — | Dedicated HTTPS port for DoH; omit to co-host on `web_port` |
+| `doh_bind_address` | `str` | — | Address for the dedicated DoH listener; ignored when `doh_port` is omitted |
 | `doq_enabled` | `bool` | `false` | Enable the DNS-over-QUIC listener |
 | `doq_port` | `int` | `853` | UDP port for DoQ (RFC 9250 standard: 853) |
+| `doq_bind_address` | `str` | — | Address for the DoQ listener; inherits `bind_address` when omitted |
 | `tls_cert_path` | `str` | `"/data/cert.pem"` | Path to the PEM-encoded TLS certificate |
 | `tls_key_path` | `str` | `"/data/key.pem"` | Path to the PEM-encoded TLS private key |
 

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -18,8 +18,41 @@ metrics_enabled = false
 |:-------|:--------|:------------|
 | `dns_port` | `53` | UDP and TCP port for DNS queries |
 | `web_port` | `8080` | HTTP/HTTPS port for the dashboard and REST API |
-| `bind_address` | `0.0.0.0` | Network interface to bind to. Use a specific IP to restrict access |
+| `bind_address` | `0.0.0.0` | Default address every listener binds to. Use a specific IP to restrict access, or `[::]` for dual-stack |
 | `metrics_enabled` | `false` | Serve an unauthenticated Prometheus text-exposition endpoint at `/metrics` on the web port (opt-in) |
+
+### Dual-stack (IPv4 + IPv6) {#dual-stack}
+
+`bind_address = "[::]"` makes every listener — Do53 (UDP and TCP), DoT, DoH, DoQ, and the web dashboard — serve IPv4 and IPv6 clients on a single dual-stack socket:
+
+```toml
+[server]
+bind_address = "[::]"
+```
+
+IPv4 clients arrive on that socket in v4-mapped form (`::ffff:192.168.1.10`). Ferrous DNS normalises them back to plain IPv4 before anything client-facing sees them, so client groups, per-client rules, the per-IP connection limit, and the query log key a device the same way whichever protocol and address family it used.
+
+A bare `bind_address = "::"` works too; the brackets are added automatically when the listen address is built.
+
+!!! note "IPv6 must exist in the kernel"
+    All DNS listeners are created as `AF_INET6` sockets, even for an IPv4-only `bind_address` (which is bound in v4-mapped form). A kernel booted with `ipv6.disable=1` or built without `CONFIG_IPV6` cannot create them. IPv6 does not need to be configured on the network — it only needs to be available in the kernel.
+
+### Per-listener bind addresses {#per-listener-bind}
+
+Each encrypted-DNS listener can override `bind_address`, which is useful when the protocols should not all be exposed on the same interface:
+
+```toml
+[server]
+bind_address = "0.0.0.0"            # Do53 and the dashboard stay on IPv4
+
+[server.encrypted_dns]
+dot_enabled      = true
+dot_bind_address = "[::]"           # DoT is dual-stack
+doq_enabled      = true
+doq_bind_address = "192.168.1.10"   # DoQ only on the LAN address
+```
+
+See [Encrypted DNS](#encrypted-dns) for the full list of options.
 
 ---
 
@@ -162,10 +195,13 @@ tls_key_path  = "/data/key.pem"
 |:-------|:--------|:------------|
 | `dot_enabled` | `false` | Enable DoT listener |
 | `dot_port` | `853` | TCP port for DoT (RFC 7858 standard: 853) |
+| `dot_bind_address` | — | Address for the DoT listener; inherits `[server].bind_address` when omitted |
 | `doh_enabled` | `false` | Enable DoH endpoint (`/dns-query`) |
 | `doh_port` | — | Dedicated HTTPS port for DoH; omit to co-host on `web_port` |
+| `doh_bind_address` | — | Address for the dedicated DoH listener; ignored when `doh_port` is omitted |
 | `doq_enabled` | `false` | Enable DoQ listener |
 | `doq_port` | `853` | UDP port for DoQ (RFC 9250 standard: 853) |
+| `doq_bind_address` | — | Address for the DoQ listener; inherits `[server].bind_address` when omitted |
 | `tls_cert_path` | `/data/cert.pem` | Path to TLS certificate (PEM) |
 | `tls_key_path` | `/data/key.pem` | Path to TLS private key (PEM) |
 

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -30,12 +30,17 @@ metrics_enabled = false
 bind_address = "[::]"
 ```
 
-IPv4 clients arrive on that socket in v4-mapped form (`::ffff:192.168.1.10`). Ferrous DNS normalises them back to plain IPv4 before anything client-facing sees them, so client groups, per-client rules, the per-IP connection limit, and the query log key a device the same way whichever protocol and address family it used.
+IPv4 clients arrive on that socket in v4-mapped form (`::ffff:192.168.1.10`). Do53, DoT, and DoQ normalise them back to plain IPv4 before anything client-facing sees them, so client groups, per-client rules, the per-IP connection limit, and the query log key a device the same way whichever of those protocols it used. The same normalisation is applied to the address a PROXY protocol v2 header carries.
+
+DoH is the exception: it never looks at the socket peer. It reads the client from the `X-Real-IP` / `X-Forwarded-For` headers its reverse proxy sets, so what a DoH client is keyed as depends on what the proxy sends.
+
+!!! note "Upgrading from a release that stored mapped addresses"
+    Earlier releases stored the v4-mapped form for DoT and DoQ clients, so a device could end up with two client rows. A migration runs once on first start and rewrites them: `::ffff:10.0.0.1` becomes `10.0.0.1`, a mapped row is merged into its plain twin (query counts add up, and a group assigned to the mapped row is kept unless the plain row already had one), the query log follows, and a subnet written as `::ffff:10.0.0.0/104` becomes `10.0.0.0/8`. Nothing needs to be done by hand.
 
 A bare `bind_address = "::"` works too; the brackets are added automatically when the listen address is built.
 
 !!! note "IPv6 must exist in the kernel"
-    All DNS listeners are created as `AF_INET6` sockets, even for an IPv4-only `bind_address` (which is bound in v4-mapped form). A kernel booted with `ipv6.disable=1` or built without `CONFIG_IPV6` cannot create them. IPv6 does not need to be configured on the network — it only needs to be available in the kernel.
+    The DNS listeners — Do53 (UDP and TCP), DoT, and DoQ — are created as `AF_INET6` sockets with `IPV6_V6ONLY` off, even for an IPv4-only `bind_address` (which is bound in v4-mapped form). A kernel booted with `ipv6.disable=1` or built without `CONFIG_IPV6` cannot create them, and those listeners will fail to start. IPv6 does not need to be configured on the network — it only needs to be available in the kernel. The dedicated DoH listener and the web dashboard bind the address as given, so they are unaffected.
 
 ### Per-listener bind addresses {#per-listener-bind}
 

--- a/docs/features/encrypted-dns.md
+++ b/docs/features/encrypted-dns.md
@@ -86,6 +86,17 @@ tls_cert_path = "/data/cert.pem"   # certificate for the DoT and DoQ listeners
 tls_key_path  = "/data/key.pem"    # private key for the DoT and DoQ listeners
 ```
 
+Each listener binds to `[server].bind_address`. To put one on a different interface, give it its own address:
+
+```toml
+[server.encrypted_dns]
+dot_bind_address = "[::]"           # DoT dual-stack on every interface
+doq_bind_address = "192.168.1.10"   # DoQ only on the LAN address
+doh_bind_address = "127.0.0.1"      # DoH reachable only from the local reverse proxy
+```
+
+`doh_bind_address` is ignored when `doh_port` is omitted, since `/dns-query` is then co-hosted on `web_port`. See [Per-listener bind addresses](../configuration/server.md#per-listener-bind) for the details.
+
 !!! note "DoH TLS termination"
     `tls_cert_path` / `tls_key_path` apply to the DoT listener. The DoH endpoint (`/dns-query`) is served over plain HTTP — put it behind a reverse proxy that terminates TLS and forwards to `doh_port` (or to `web_port` if `doh_port` is omitted). The cert/key must still load successfully for DoH to start.
 

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -8,7 +8,7 @@
 [server]
 dns_port = 53                           # UDP/TCP port for DNS queries
 web_port = 8080                         # HTTP port for the web dashboard and REST API
-bind_address = "0.0.0.0"                # Address to bind on; 0.0.0.0 listens on all interfaces
+bind_address = "0.0.0.0"                # Default address every listener binds to; "0.0.0.0" is all IPv4 interfaces, "[::]" is dual-stack (IPv4 + IPv6)
 
 # Enables the Pi-hole v6 compatible API at /api/* so third-party dashboards,
 # plugins, and automations that expect the Pi-hole API continue to work.
@@ -49,10 +49,13 @@ tls_key_path  = "/data/key.pem"
 # [server.encrypted_dns]
 # dot_enabled   = true                    # Enable DoT listener on dot_port
 # dot_port      = 853                     # TCP port for DNS-over-TLS (standard: 853)
+# dot_bind_address = "[::]"               # Address for the DoT listener (omit to inherit [server].bind_address)
 # doh_enabled   = true                    # Enable /dns-query endpoint on web_port or doh_port
 # doh_port      = 443                     # Dedicated port for DoH (omit to co-host on web_port)
+# doh_bind_address = "[::]"               # Address for the dedicated DoH listener (ignored when doh_port is omitted)
 # doq_enabled   = true                    # Enable DoQ listener on doq_port
 # doq_port      = 853                     # UDP port for DNS-over-QUIC (standard: 853; no collision with TCP dot_port)
+# doq_bind_address = "[::]"               # Address for the DoQ listener (omit to inherit [server].bind_address)
 # tls_cert_path = "/data/cert.pem"
 # tls_key_path  = "/data/key.pem"
 

--- a/migrations/20260822000001_unmap_v4_mapped_client_addresses.sql
+++ b/migrations/20260822000001_unmap_v4_mapped_client_addresses.sql
@@ -1,0 +1,89 @@
+-- Rewrite the v4-mapped client addresses left behind by earlier releases.
+--
+-- Before the DoT/DoQ peer-address fix, a listener bound on `[::]` reported an
+-- IPv4 client as `::ffff:10.0.0.1`. That string was stored verbatim, so the
+-- same device could end up with two client rows, two sets of query-log
+-- entries, and a group assignment on whichever row the operator happened to
+-- see. Now that every listener keys the device as `10.0.0.1`, the mapped rows
+-- would simply stop matching, silently dropping the client back to the
+-- default group.
+--
+-- `::ffff:` is 7 characters, so `substr(x, 8)` is the unmapped address. The
+-- `%.%.%.%` guard keeps this to the dotted-quad form Rust emits and leaves any
+-- genuine IPv6 address alone.
+
+-- 1. Fold a mapped row into its plain twin where both exist. The plain row
+--    keeps its identity; the mapped row contributes what the plain one lacks.
+--    `group_id` matters most: NULL means the default group, so a group the
+--    operator assigned to the mapped row wins over the plain row's default,
+--    but never over an explicit assignment.
+UPDATE clients
+SET query_count = query_count + COALESCE((
+        SELECT m.query_count FROM clients m
+        WHERE m.ip_address = '::ffff:' || clients.ip_address
+    ), 0),
+    first_seen = MIN(first_seen, COALESCE((
+        SELECT m.first_seen FROM clients m
+        WHERE m.ip_address = '::ffff:' || clients.ip_address
+    ), first_seen)),
+    last_seen = MAX(last_seen, COALESCE((
+        SELECT m.last_seen FROM clients m
+        WHERE m.ip_address = '::ffff:' || clients.ip_address
+    ), last_seen)),
+    mac_address = COALESCE(mac_address, (
+        SELECT m.mac_address FROM clients m
+        WHERE m.ip_address = '::ffff:' || clients.ip_address
+    )),
+    hostname = COALESCE(hostname, (
+        SELECT m.hostname FROM clients m
+        WHERE m.ip_address = '::ffff:' || clients.ip_address
+    )),
+    group_id = COALESCE(group_id, (
+        SELECT m.group_id FROM clients m
+        WHERE m.ip_address = '::ffff:' || clients.ip_address
+    )),
+    updated_at = CURRENT_TIMESTAMP
+WHERE EXISTS (
+    SELECT 1 FROM clients m
+    WHERE m.ip_address = '::ffff:' || clients.ip_address
+);
+
+-- 2. Drop the mapped rows just merged, so the rename below cannot collide with
+--    the UNIQUE index on ip_address.
+DELETE FROM clients
+WHERE ip_address LIKE '::ffff:%.%.%.%'
+  AND substr(ip_address, 8) IN (SELECT ip_address FROM clients);
+
+-- 3. Rename the mapped rows that had no plain twin.
+UPDATE clients
+SET ip_address = substr(ip_address, 8),
+    updated_at = CURRENT_TIMESTAMP
+WHERE ip_address LIKE '::ffff:%.%.%.%';
+
+-- 4. The query log joins back to clients on the address text, so stale mapped
+--    entries would lose their hostname in the log view and split the
+--    top-clients aggregate.
+UPDATE query_log
+SET client_ip = substr(client_ip, 8)
+WHERE client_ip LIKE '::ffff:%.%.%.%';
+
+-- 5. A subnet an operator wrote to work around the old behaviour
+--    (`::ffff:10.0.0.0/104`) has to lose both the prefix and the 96 bits it
+--    added to the mask. Same collision handling as the client rows: an
+--    equivalent plain subnet already present wins.
+DELETE FROM client_subnets
+WHERE subnet_cidr LIKE '::ffff:%.%.%.%/%'
+  AND CAST(substr(subnet_cidr, instr(subnet_cidr, '/') + 1) AS INTEGER) >= 96
+  AND (
+        substr(subnet_cidr, 8, instr(subnet_cidr, '/') - 8)
+        || '/'
+        || CAST(CAST(substr(subnet_cidr, instr(subnet_cidr, '/') + 1) AS INTEGER) - 96 AS TEXT)
+      ) IN (SELECT subnet_cidr FROM client_subnets);
+
+UPDATE client_subnets
+SET subnet_cidr = substr(subnet_cidr, 8, instr(subnet_cidr, '/') - 8)
+                  || '/'
+                  || CAST(CAST(substr(subnet_cidr, instr(subnet_cidr, '/') + 1) AS INTEGER) - 96 AS TEXT),
+    updated_at = CURRENT_TIMESTAMP
+WHERE subnet_cidr LIKE '::ffff:%.%.%.%/%'
+  AND CAST(substr(subnet_cidr, instr(subnet_cidr, '/') + 1) AS INTEGER) >= 96;


### PR DESCRIPTION
## Summary

On a dual-stack (`[::]`) bind, the kernel hands an IPv4 client to `accept()` as a v4-mapped address (`::ffff:10.0.0.1`). Every layer that keys a client by address — the client repository, the group assignment, the query log — stringifies that verbatim, so the same device showed up as two distinct clients depending on which protocol it used. A group assigned to one row had no effect on the other.

This PR normalises the client address at every ingress point, makes the DoQ listener behave like the rest, and repairs the rows already written by earlier releases.

### Client address normalisation

- DoT and DoQ unmap the peer address before it reaches the repositories, so an IPv4 client is keyed as `10.0.0.1` on every protocol.
- The PROXY protocol v2 parser (`extract_source_ip`) does the same, which covers both DoT and Do53 over TCP behind a dual-stack frontend.
- DoH is unchanged: it reads its client from the forwarding headers rather than the socket, and binds the address as configured.

### Listeners

- `bind_doq_endpoint` now builds an AF_INET6 socket with `only_v6` disabled and hands it to `quinn::Endpoint::new`, matching DoT. Before this, a `[::]` DoQ bind silently refused IPv4 clients.
- Each encrypted-DNS protocol takes its own bind address, so DoT, DoQ and DoH no longer have to share one.
- `Config::validate()` parses all four bind addresses at startup instead of letting a typo surface as a panic mid-boot. A disabled listener is skipped, and `doh_bind_address` is only checked when `doh_port` is set.

### Database

Migration `20260822000001` rewrites the v4-mapped addresses already stored. Because `clients.ip_address` is UNIQUE, a plain `UPDATE` would abort wherever both spellings exist, so the migration merges instead: the plain row keeps its identity, `query_count` values are summed, and `group_id` is `COALESCE`d so a group assigned to the mapped row survives but never overwrites an explicit assignment on the plain row. `query_log.client_ip` is rewritten as well, since the log view joins back to `clients` on the address text. `client_subnets` gets the same treatment, dropping the prefix and the 96 mask bits a `::ffff:10.0.0.0/104` entry carried.

Every statement is guarded on the `%.%.%.%` dotted-quad form Rust emits, so a genuine IPv6 address is untouched, and the whole file is idempotent.

## Related issues

None — found while reviewing the dual-stack listener behavior.

## Test plan

- [x] `make ci` green (fmt-check + clippy `-D warnings` + full test suite). Full workspace run: 1883 passed, 7 skipped.
- [x] New/updated tests: `crates/infrastructure/tests/unmap_v4_mapped_addresses_migration_test.rs` (8 tests: merge, idempotency, subnets, query log, genuine IPv6 left alone), plus the existing DoT/DoQ/PROXY-protocol and config-validation suites.
- [x] Manual: applied the full migration chain to a scratch SQLite database with `sqlite3` to confirm the SQL runs against the real schema, not just the simplified one the test builds.
- [x] `cargo audit`: two warnings, both pre-existing (`event-listener` unsound, `spin` yanked). No new advisories.
- [x] Not done: the release binary was not started against a live dual-stack interface. The listener changes are covered by tests only.

## Known follow-ups / out of scope

- Switching DoQ to AF_INET6 broke the five existing DoQ tests: `local_addr()` began reporting `::ffff:127.0.0.1`, and an IPv4 client socket cannot reach a v6 destination (quinn rejects it with `InvalidRemoteAddress`). The test helpers were updated accordingly.
- That same change would have made the startup logs print `[::ffff:0.0.0.0]:853` where they previously echoed the operator's configured value, so DoT, DoQ and Do53 now unmap the address before logging it. This is cosmetic but user-visible.
- The review that prompted this work suggested client subnets might need normalising at config load. They are stored in the `client_subnets` table and managed through the API, not the TOML, so the migration covers them and no config-load change was needed.
