### PR TITLE
fix(auth): drop the Secure cookie flag when HTTPS falls back to HTTP

### DIFF
--- a/crates/api/src/handlers/auth.rs
+++ b/crates/api/src/handlers/auth.rs
@@ -751,3 +751,25 @@ fn extract_user_agent(request: &Request) -> String {
         .unwrap_or("unknown")
         .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::session_cookie;
+
+    #[test]
+    fn test_session_cookie_omits_secure_over_plain_http() {
+        let cookie = session_cookie("session-id", 86400, false);
+
+        assert!(!cookie.contains("Secure"));
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("SameSite=Strict"));
+        assert!(cookie.contains("Max-Age=86400"));
+    }
+
+    #[test]
+    fn test_session_cookie_sets_secure_over_https() {
+        let cookie = session_cookie("session-id", 86400, true);
+
+        assert!(cookie.contains("; Secure"));
+    }
+}

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -185,6 +185,10 @@ pub struct AppState {
     pub config_file_persistence: Arc<dyn ConfigFilePersistence>,
     pub config_path: Option<Arc<str>>,
     pub tls_cert: Arc<dyn TlsCertificatePort>,
+    /// Whether the web server is actually serving HTTPS. Drives the session
+    /// cookie's `Secure` attribute, so it must not be taken from the
+    /// `[server.web_tls] enabled` flag: that one stays `true` when the
+    /// certificate is missing and the server falls back to plain HTTP.
     pub tls_enabled: bool,
     /// Whether `[auth.webauthn]` is populated (passkeys usable).
     pub webauthn_configured: bool,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -131,12 +131,28 @@ async fn async_main() -> anyhow::Result<()> {
         effective_config_path.clone(),
     );
 
+    // The session cookie's `Secure` flag must follow the transport actually in
+    // use, so the web TLS material is loaded before the state is built: with
+    // `enabled = true` and no certificate on disk the server falls back to
+    // plain HTTP, and a `Secure` cookie would then be dropped by the browser.
+    let web_tls_config = if config.server.web_tls.enabled {
+        server::load_server_tls_config(
+            &config.server.web_tls.tls_cert_path,
+            &config.server.web_tls.tls_key_path,
+            "Web HTTPS",
+            &[],
+        )?
+    } else {
+        None
+    };
+
     let app_state = wiring::build_app_state(
         use_cases,
         &repos,
         &dns_services,
         config_arc,
         effective_config_path,
+        web_tls_config.is_some(),
     )
     .await;
 
@@ -258,17 +274,6 @@ async fn async_main() -> anyhow::Result<()> {
         } else {
             tls_config.map(|_| Arc::new(DnsServerHandler::new(handler_use_case, block_policy)))
         }
-    } else {
-        None
-    };
-
-    let web_tls_config = if config.server.web_tls.enabled {
-        server::load_server_tls_config(
-            &config.server.web_tls.tls_cert_path,
-            &config.server.web_tls.tls_key_path,
-            "Web HTTPS",
-            &[],
-        )?
     } else {
         None
     };

--- a/crates/cli/src/wiring/app_state.rs
+++ b/crates/cli/src/wiring/app_state.rs
@@ -27,12 +27,18 @@ use tokio::sync::RwLock;
 
 use super::{DnsServices, Repositories, UseCases};
 
+/// Builds the shared API state.
+///
+/// `https_active` must reflect whether the web server really serves HTTPS, not
+/// the `[server.web_tls] enabled` flag: it drives the session cookie's `Secure`
+/// attribute, and a browser stores such a cookie only over a secure origin.
 pub async fn build_app_state(
     use_cases: UseCases,
     repos: &Repositories,
     dns_services: &DnsServices,
     config: Arc<RwLock<Config>>,
     config_path: Option<Arc<str>>,
+    https_active: bool,
 ) -> AppState {
     let effective_path = config_path
         .as_deref()
@@ -47,8 +53,6 @@ pub async fn build_app_state(
         let cfg = config.read().await;
         Arc::new(cfg.auth.clone())
     };
-
-    let tls_enabled = config.read().await.server.web_tls.enabled;
 
     let config_persistence: Arc<dyn ConfigFilePersistence> = Arc::new(TomlConfigFilePersistence);
 
@@ -293,7 +297,7 @@ pub async fn build_app_state(
         },
         auth,
         backup,
-        tls_enabled,
+        tls_enabled: https_active,
         config,
         config_file_persistence: config_persistence,
         config_path,

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -30,9 +30,11 @@ pihole_compat = true
 # ── Web HTTPS (TLS for Dashboard / API) ──────────────────────────────────────
 # When enabled, the web dashboard and REST API are served over HTTPS on the
 # same web_port (8080). If cert/key files are missing, falls back to HTTP.
+# No certificate ships with the image: generate one from the dashboard under
+# Settings > Security > HTTPS / TLS, then set enabled = true and restart.
 
 [server.web_tls]
-enabled       = true
+enabled       = false
 tls_cert_path = "/data/cert.pem"
 tls_key_path  = "/data/key.pem"
 


### PR DESCRIPTION
## Summary

Fixes the login loop reported on Docker: the login request succeeds, the dashboard flashes once, and the user lands back on the login screen.

### Root cause

`AppState.tls_enabled` was read from the `[server.web_tls] enabled` config flag rather than from the transport actually in use (`crates/cli/src/wiring/app_state.rs:51`). The shipped `ferrous-dns.toml` sets `enabled = true` with `tls_cert_path = "/data/cert.pem"`, and nothing in the image ever creates that certificate — neither the `Dockerfile` nor `docker/entrypoint.sh`. At startup `load_server_tls_config` logs `TLS cert file not found — Web HTTPS disabled` and returns `Ok(None)`, so the web server runs plain HTTP while the session cookie is still emitted with `; Secure`.

A browser on `http://<lan-ip>:8080` refuses to store a `Secure` cookie, because a bare LAN IP is not a trustworthy origin. `POST /auth/login` still returns 200 so the UI redirects and renders, then `checkAuth()` probes `/api/auth/sessions` without a cookie, `require_auth` returns 401, and `web/static/shared.js:98` sends the user back to `/login.html`. This never reproduces on `http://localhost`, which browsers do treat as a secure context.

### Fix

- Load the web TLS material before the app state is built and derive `tls_enabled` from `web_tls_config.is_some()`, so the cookie attribute follows the transport that is really serving.
- Default the shipped `[server.web_tls] enabled` to `false`. The documented default was already `false` (`docs/configuration/server.md:138`), so this aligns the shipped file with the docs; users who generate a certificate from **Settings > Security > HTTPS / TLS** flip it back on.

No behavior changes when a certificate is present: HTTPS serves as before and the cookie keeps its `Secure` flag.

## Related issues

Closes #214

## Test plan

- [x] `make ci` green (fmt-check, clippy `-D warnings`, 1922 tests passing), plus `cargo test --doc --all-features --workspace`.
- [x] New tests: `crates/api/src/handlers/auth.rs` — `test_session_cookie_omits_secure_over_plain_http` and `test_session_cookie_sets_secure_over_https`.
- [x] Manual, against the pre-fix binary bound to a LAN IP with `web_tls.enabled = true` and no certificate on disk: login returned `200` with `set-cookie: ferrous_session=...; HttpOnly; SameSite=Strict; Secure; Path=/; Max-Age=86400`, and the following `GET /api/auth/sessions` returned `401` — the reported loop.
- [x] Manual, same config on this branch: login returns `200` with the same cookie minus `Secure`, `GET /api/auth/sessions` returns `200`, and `GET /` returns `200`.
- [x] Manual, with a self-signed certificate at the configured paths: the server starts on `https://`, and login over TLS still sets `; Secure`.
- [x] Manual: logout clears the cookie with matching attributes and the session is invalidated (`401` afterwards); `remember_me: true` still yields `Max-Age=2592000`.

## Known follow-ups / out of scope

- `AdminConfig` derives `Default`, so a config file with no `[auth.admin]` table gets `username = ""` instead of the `default_admin_username()` value of `"admin"` that applies when the table exists but the key does not. Hit this while setting up the manual repro; unrelated to the cookie bug, so left alone.
- The Docker image still ships cert paths under `/data` that it never populates. Defaulting `enabled` to `false` makes that harmless, but generating a self-signed certificate on first run could be a nicer default.