### PR TITLE
fix(dns): relay local_dns_server answers so LAN reverse lookups return the router's PTR

### DIFF
--- a/crates/infrastructure/src/dns/resolver/core.rs
+++ b/crates/infrastructure/src/dns/resolver/core.rs
@@ -86,7 +86,11 @@ impl CoreResolver {
                         upstream_pool: None,
                         min_ttl: response.min_ttl,
                         negative_soa_ttl: response.negative_soa_ttl,
-                        upstream_wire_data: None,
+                        // Relay the local server's full answer, exactly as the pool path
+                        // does. Without this, non-address answers (PTR for LAN clients,
+                        // SRV/TXT/MX under the local domain) were parsed into an empty
+                        // `addresses` and reached the client as an empty response.
+                        upstream_wire_data: Some(response.raw_bytes),
                     });
                 }
                 Ok(_) => {

--- a/crates/infrastructure/tests/local_dns_server_ptr_test.rs
+++ b/crates/infrastructure/tests/local_dns_server_ptr_test.rs
@@ -1,0 +1,153 @@
+//! Regression: answers from `local_dns_server` must be relayed on the wire.
+//!
+//! `CoreResolver::resolve_local_tld` forwards private-range PTR queries (and
+//! anything under `local_domain`) to the configured local DNS server, typically
+//! the LAN router. The parser only lifts A/AAAA rdata into `addresses`, so a PTR
+//! (or SRV/TXT/MX) answer has nothing to carry it unless the raw upstream bytes
+//! are attached as `upstream_wire_data`, the way the pool path already does.
+//! Before the fix the client received an empty NXDOMAIN for every LAN reverse
+//! lookup even though the router had answered correctly.
+
+use ferrous_dns_application::ports::DnsResolver;
+use ferrous_dns_domain::{DnsQuery, RecordType, UpstreamPool, UpstreamStrategy};
+use ferrous_dns_infrastructure::dns::events::QueryEventEmitter;
+use ferrous_dns_infrastructure::dns::load_balancer::PoolManager;
+use ferrous_dns_infrastructure::dns::resolver::CoreResolver;
+use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
+use hickory_proto::rr::rdata::{A, PTR};
+use hickory_proto::rr::{Name, RData, Record, RecordType as WireRecordType};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+
+const LAN_HOST_IP: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 5);
+const LAN_HOST_NAME: &str = "desktop.lan.";
+
+/// Minimal "router" resolver: answers PTR with a fixed hostname and A with a
+/// fixed address, echoing the query id and question like a real server.
+async fn spawn_local_dns_server() -> SocketAddr {
+    let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = socket.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 1500];
+        while let Ok((len, peer)) = socket.recv_from(&mut buf).await {
+            let Ok(req) = Message::from_vec(&buf[..len]) else {
+                continue;
+            };
+            let Some(q) = req.queries.first().cloned() else {
+                continue;
+            };
+
+            let mut resp = Message::new(req.id, MessageType::Response, OpCode::Query);
+            resp.metadata.recursion_desired = true;
+            resp.metadata.recursion_available = true;
+            resp.metadata.response_code = ResponseCode::NoError;
+            resp.add_query(q.clone());
+
+            match q.query_type() {
+                WireRecordType::PTR => {
+                    resp.add_answer(Record::from_rdata(
+                        q.name().clone(),
+                        60,
+                        RData::PTR(PTR(Name::from_str(LAN_HOST_NAME).unwrap())),
+                    ));
+                }
+                WireRecordType::A => {
+                    resp.add_answer(Record::from_rdata(
+                        q.name().clone(),
+                        60,
+                        RData::A(A(LAN_HOST_IP)),
+                    ));
+                }
+                _ => {}
+            }
+
+            let _ = socket.send_to(&resp.to_vec().unwrap(), peer).await;
+        }
+    });
+
+    addr
+}
+
+/// A pool manager is required by `CoreResolver::new`; point it at the same
+/// responder. It must not be consulted for the queries under test.
+async fn manager(addr: SocketAddr) -> Arc<PoolManager> {
+    let pool = UpstreamPool {
+        name: "unused".into(),
+        strategy: UpstreamStrategy::Parallel,
+        priority: 1,
+        servers: vec![format!("udp://{addr}")],
+        weight: None,
+    };
+    Arc::new(
+        PoolManager::new(vec![pool], None, QueryEventEmitter::new_disabled())
+            .await
+            .unwrap(),
+    )
+}
+
+async fn resolver_with_local_server(addr: SocketAddr) -> CoreResolver {
+    CoreResolver::new(manager(addr).await, 2000, false)
+        .with_local_domain(Some("lan".to_string()))
+        .with_local_dns_server(Some(addr.to_string()))
+}
+
+#[tokio::test]
+async fn test_local_dns_server_ptr_relayed_on_wire() {
+    let addr = spawn_local_dns_server().await;
+    let resolver = resolver_with_local_server(addr).await;
+
+    let query = DnsQuery::new("5.0.0.10.in-addr.arpa", RecordType::PTR);
+    let resolution = resolver
+        .resolve(&query)
+        .await
+        .expect("PTR via local_dns_server must resolve");
+
+    assert!(resolution.local_dns, "answer must be marked as local DNS");
+    assert_eq!(
+        resolution.upstream_server.as_deref(),
+        Some(addr.to_string().as_str())
+    );
+
+    let wire = resolution
+        .upstream_wire_data
+        .as_ref()
+        .expect("PTR answer must carry the upstream wire bytes (regression: was None)");
+    let msg = Message::from_vec(wire).expect("wire bytes must be a valid DNS message");
+
+    let ptr_targets: Vec<String> = msg
+        .answers
+        .iter()
+        .filter_map(|r| match &r.data {
+            RData::PTR(p) => Some(p.0.to_utf8()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        ptr_targets,
+        vec![LAN_HOST_NAME.to_string()],
+        "relayed message must contain the router's PTR answer"
+    );
+    assert_eq!(resolution.min_ttl, Some(60));
+}
+
+#[tokio::test]
+async fn test_local_dns_server_a_record_populates_addresses() {
+    let addr = spawn_local_dns_server().await;
+    let resolver = resolver_with_local_server(addr).await;
+
+    let query = DnsQuery::new("nas.lan", RecordType::A);
+    let resolution = resolver
+        .resolve(&query)
+        .await
+        .expect("A under local_domain must resolve via local_dns_server");
+
+    assert!(resolution.local_dns);
+    assert_eq!(resolution.addresses.to_vec(), vec![IpAddr::V4(LAN_HOST_IP)]);
+    assert!(
+        resolution.upstream_wire_data.is_some(),
+        "address answers should also carry wire bytes, matching the pool path"
+    );
+}


### PR DESCRIPTION
## Summary

- A reverse lookup for a LAN IP with `local_dns_server` configured is forwarded to the router and answered correctly, but the client gets an empty NXDOMAIN. `CoreResolver::resolve_local_tld` built its `DnsResolution` with `upstream_wire_data: None`, and the parser only lifts A/AAAA rdata into `addresses`, so a PTR (or any SRV/TXT/MX under `local_domain`) had nothing to carry it.
- Fix: attach `response.raw_bytes` as `upstream_wire_data`, exactly as the pool path does. The DNS server already relays wire data whenever `addresses` is empty, so no server change is needed. A/AAAA answers under `local_domain` are unaffected: `addresses` still wins on the server side.
- Effect: `dig -x <lan-ip>` and OS/app reverse lookups of LAN addresses work for clients, which is what Pi-hole's conditional forwarding provided for users migrating. The dashboard's client hostname sync is unaffected either way: `PtrHostnameResolver` already forwards to `local_dns_server` and parses `RData::PTR` from `raw_answers` itself.

### Resolver

One line in `crates/infrastructure/src/dns/resolver/core.rs`, with a comment explaining why the field must be set.

## Related issues

Closes #217

## Test plan

- [x] `make ci` green (fmt-check + clippy `-D warnings` + full test suite): all crates, 0 failures.
- [x] New tests: `crates/infrastructure/tests/local_dns_server_ptr_test.rs`
  - `test_local_dns_server_ptr_relayed_on_wire`: UDP responder stands in for the router; a private PTR must resolve with `local_dns = true` and the relayed wire message must contain the router's PTR record. Fails on `main` at "PTR answer must carry the upstream wire bytes", passes with the fix.
  - `test_local_dns_server_a_record_populates_addresses`: an A record under `local_domain` still populates `addresses` and now also carries wire bytes, matching the pool path.
- [x] Manual: release build of this branch run side by side with the v0.9.15 release binary, same config, same LAN, ASUS router (dnsmasq) as `local_dns_server`:

```text
                      v0.9.15        this branch
dig -x 192.168.8.249  (empty)        Desktop.
dig -x 192.168.8.2    (empty)        vpn.
dig -x 192.168.8.250  (empty)        homeassistant.
dig -x 192.168.8.248  pve.lan.       pve.lan.        (local record, auto-PTR, unchanged)
dig pve.lan A         192.168.8.248  192.168.8.248   (unchanged)
dig nas.lan A         NXDOMAIN       NXDOMAIN        (unchanged)
```

## Known follow-ups / out of scope

- `docs/configuration/dns.md` already describes `local_dns_server` as "used for PTR lookups and client hostname resolution"; the code now matches the docs, so no doc change.
- No wire-format parser was touched, so no fuzz target applies. No dependency changes.

Note: `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md` describe different PR body formats; this PR follows the `.github` template, which is what `.claudin/rules/pr-titles.md` points at. Happy to reshape if you prefer the other.