### PR TITLE
fix(docker): ship patched openssl in the published images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,6 +100,34 @@ jobs:
             org.opencontainers.image.vendor=Ferrous DNS Project
             org.opencontainers.image.authors=Anderson Viudes
 
+      # Scan before publishing: the scan further down runs against the image
+      # that is already on Docker Hub, so a vulnerable image is public by the
+      # time the alert shows up. Build amd64 only and keep it local — the
+      # multi-arch build below reuses these layers from the gha cache.
+      - name: Build image for pre-publish scan
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.release
+          platforms: linux/amd64
+          load: true
+          tags: ${{ env.REGISTRY_IMAGE_DOCKERHUB }}:pre-publish-scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Fails the release on anything fixable: an upgradable package means the
+      # runtime stage's `apk upgrade` did not cover it and the Dockerfile needs
+      # attention. Unfixed CVEs are left to the SARIF scan below, which reports
+      # them without blocking a release nobody can unblock.
+      - name: Fail on fixable vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY_IMAGE_DOCKERHUB }}:pre-publish-scan
+          scanners: vuln
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '1'
+
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,12 @@ RUN find crates -name "*.rs" -exec touch {} + && \
 
 FROM alpine:3.24
 
-RUN apk add --no-cache \
+# Upgrade first: the alpine:3.24 tag is rebuilt less often than its package
+# repository, so a fresh pull still ships stale packages (libssl3/libcrypto3
+# 3.5.7-r0 while v3.24/main already has 3.5.8-r0). Those are exactly what the
+# release Trivy scan reports as CVEs against the published image.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
     ca-certificates \
     libcap \
     tzdata && \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -2,7 +2,12 @@ FROM alpine:3.24
 
 ARG TARGETARCH
 
-RUN apk add --no-cache \
+# Upgrade first: the alpine:3.24 tag is rebuilt less often than its package
+# repository, so a fresh pull still ships stale packages (libssl3/libcrypto3
+# 3.5.7-r0 while v3.24/main already has 3.5.8-r0). Those are exactly what the
+# release Trivy scan reports as CVEs against the published image.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
     ca-certificates \
     libcap \
     tzdata && \


### PR DESCRIPTION
## Summary

### Base packages are stale inside the pinned tag

All twenty open code-scanning alerts are the same ten OpenSSL CVEs (CVE-2026-14456, -18798, -63072, -63076, -14457, -54874, -63073, -63074, -63075, -75803), duplicated across the v0.9.15 and v0.9.16 release scans. Every one of them is `libssl3`/`libcrypto3` 3.5.7-r0, fixed in 3.5.8-r0.

The cause is not our code: the `alpine:3.24` tag is rebuilt far less often than the repository it points at. A pull today (digest `28bd5fe8…`) still ships 3.5.7-r0 while `v3.24/main` already serves 3.5.8-r0, so a plain rebuild would have published exactly the same finding. `Dockerfile` and `Dockerfile.release` now run `apk upgrade --no-cache` before installing the runtime packages, which pulls the patched versions at build time. Dependabot cannot cover this — its `docker` ecosystem bumps the tag (3.24 → 3.25), never the packages inside it.

On exposure: the alerts are real, in that the vulnerable file is in the image, but they are not reachable from the service. `ldd /usr/local/bin/ferrous-dns` on the published image lists only the musl loader, so the static binary never loads the image `libssl.so`; `libssl3` is there for `apk-tools`/`libapk` and `ssl_client`, neither of which runs at runtime.

### The scan ran after the push

The existing Trivy step scans the tag that is already on Docker Hub, so the vulnerable image is public by the time the alert appears in the Security tab. A pre-publish step now builds amd64 locally (reusing the gha cache, so the multi-arch build below is unaffected) and fails the job on any vulnerability that has a fixed version — an upgradable package means the `apk upgrade` did not cover it and the Dockerfile needs attention. Unfixed CVEs are deliberately left to the SARIF scan, which reports them without blocking a release nobody can unblock.

## Related issues

None — the alerts live in the Security tab: https://github.com/ferrous-networking/ferrous-dns/security/code-scanning

## Test plan

- [x] Reproduced the alerts locally with Trivy against a layer built from the unmodified runtime stage: the ten CVEs, `libssl3` 3.5.7-r0.
- [x] Same scan after `apk upgrade`: `libssl3`/`libcrypto3` 3.5.8-r0 (and `apk-tools` 3.0.8-r0), **0 vulnerabilities**.
- [x] Built the real `Dockerfile.release` with a stub binary in `dist/` and ran the exact flags of the new gate (`--ignore-unfixed --severity CRITICAL,HIGH,MEDIUM --exit-code 1`): exit **1** before the fix (8 findings across `libssl3` and `libcrypto3`), exit **0** after. The gate would have caught this release.
- [x] `docker build --check` clean on both Dockerfiles; the workflow YAML parses and the new steps sit between the metadata step and the push.
- [x] `make ci` green — no Rust code changed, run as a regression check only.

## Known follow-ups / out of scope

- **The binary carries its own OpenSSL, and no scanner sees it.** `crates/infrastructure/Cargo.toml` vendors OpenSSL through `webauthn-rs` (`openssl-src 300.6.1+3.6.3`, i.e. 3.6.3) so the aarch64/musl cross build works. OpenSSL 3.6.3 is affected by the same ten CVEs, first fixed in 3.6.4 — and neither Trivy (stripped binary, no `cargo auditable`) nor `cargo audit` (no RustSec advisory for `openssl-src`) reports it. There is no upgrade path today: crates.io tops out at `300.6.1+3.6.3` on the 300.x line, and `400.0.1+4.0.2` needs an `openssl-sys` that does not exist yet (0.9.117 requires `^300.2.0`). Exploitability is nil in practice: no crate calls `openssl::` directly, QUIC is `quinn` + aws-lc-rs, HTTP is rustls, and the ten CVEs need QUIC server, DTLS, CMP, `CMS_decrypt`, TLS raw public keys or low-level `EVP_Cipher` AEAD — none of which WebAuthn attestation touches. Worth a tracking issue so the bump happens when `openssl-src` ships 3.6.4.
- **Nothing re-scans between releases.** The base image drifts after a release and no job notices until the next one. A weekly scheduled scan of `:latest` uploading SARIF under its own category would close that gap; not added here to keep this PR to the fix.
- The twenty existing alerts should close on their own after the next release scan. If GitHub keeps them open (the duplicate sets suggest fingerprints move between runs), they can be dismissed manually as fixed.