### PR TITLE
feat(dns): resolve wildcard local DNS records

### DIFF
--- a/crates/api/src/handlers/cache.rs
+++ b/crates/api/src/handlers/cache.rs
@@ -183,6 +183,21 @@ pub async fn delete_cache_entry(
         DomainError::InvalidInput(format!("unknown record type: {}", params.record_type))
     })?;
 
+    // A permanent entry is a local DNS record, and nothing reloads it: evicting
+    // it here would silently unpublish the name until the next restart. Send the
+    // operator to the page that owns the record instead.
+    if state
+        .dns
+        .cache
+        .is_permanent_record(&params.domain, &record_type)
+    {
+        return Err(ApiError(DomainError::InvalidInput(format!(
+            "{} {} is a local DNS record — remove it in Local DNS settings",
+            params.domain,
+            record_type.as_str()
+        ))));
+    }
+
     if !state.dns.cache.remove_record(&params.domain, &record_type) {
         return Err(ApiError(DomainError::NotFound(format!(
             "cache entry {} {}",

--- a/crates/application/src/ports/dns_cache_port.rs
+++ b/crates/application/src/ports/dns_cache_port.rs
@@ -142,7 +142,12 @@ pub trait DnsCachePort: Send + Sync {
         domain: &str,
         record_type: RecordType,
         addresses: Vec<IpAddr>,
+        ttl: u32,
     );
     fn remove_record(&self, domain: &str, record_type: &RecordType) -> bool;
+    /// Whether the entry is permanent — a local DNS record, not a cached
+    /// upstream answer. Nothing reloads a permanent entry once it is removed,
+    /// so callers that expose eviction to users need to know the difference.
+    fn is_permanent_record(&self, domain: &str, record_type: &RecordType) -> bool;
     fn list_entries(&self, query: &CacheEntryQuery) -> CacheEntryPage;
 }

--- a/crates/application/src/ports/mod.rs
+++ b/crates/application/src/ports/mod.rs
@@ -39,6 +39,7 @@ mod user_repository;
 mod webauthn_service;
 mod whitelist_repository;
 mod whitelist_source_repository;
+mod wildcard_record_registry;
 
 pub use api_token_repository::ApiTokenRepository;
 pub use arp_reader::{ArpReader, ArpTable};
@@ -91,5 +92,6 @@ pub use user_repository::{CreateUserInput, PasswordHasher, UserProvider, UserRep
 pub use webauthn_service::{AuthenticatedCredential, RegisteredCredential, WebauthnService};
 pub use whitelist_repository::WhitelistRepository;
 pub use whitelist_source_repository::WhitelistSourceRepository;
+pub use wildcard_record_registry::WildcardRecordRegistry;
 
 pub use ferrous_dns_domain::DnsQuery;

--- a/crates/application/src/ports/wildcard_record_registry.rs
+++ b/crates/application/src/ports/wildcard_record_registry.rs
@@ -1,0 +1,17 @@
+use ferrous_dns_domain::RecordType;
+use std::net::IpAddr;
+
+/// Live registry of wildcard local DNS records — `*.home.lan` and the like.
+///
+/// Implementations keep an in-memory index updated at runtime so that a wildcard
+/// added or removed through the admin UI takes effect on the next query, without
+/// a server restart. Wildcards deliberately never reach the DNS cache: a cache
+/// key is matched exactly, so an expansion could not be invalidated on delete.
+pub trait WildcardRecordRegistry: Send + Sync {
+    /// Inserts or overwrites the wildcard covering `suffix` — the fully-qualified
+    /// name with its leading `*.` removed — for the given record type.
+    fn register(&self, suffix: &str, record_type: RecordType, address: IpAddr, ttl: u32);
+
+    /// Removes the wildcard covering `suffix` for `record_type`, if present.
+    fn unregister(&self, suffix: &str, record_type: RecordType);
+}

--- a/crates/application/src/use_cases/local_records/create.rs
+++ b/crates/application/src/use_cases/local_records/create.rs
@@ -4,13 +4,16 @@ use async_trait::async_trait;
 use ferrous_dns_domain::{Config, DomainError, LocalDnsRecord, RecordType};
 use tokio::sync::RwLock;
 
-use crate::ports::{ConfigRepository, DnsCachePort, LocalRecordCreator, PtrRecordRegistry};
+use crate::ports::{
+    ConfigRepository, DnsCachePort, LocalRecordCreator, PtrRecordRegistry, WildcardRecordRegistry,
+};
 
 pub struct CreateLocalRecordUseCase {
     config: Arc<RwLock<Config>>,
     config_repo: Arc<dyn ConfigRepository>,
     ptr_registry: Option<Arc<dyn PtrRecordRegistry>>,
     dns_cache: Option<Arc<dyn DnsCachePort>>,
+    wildcard_registry: Option<Arc<dyn WildcardRecordRegistry>>,
 }
 
 impl CreateLocalRecordUseCase {
@@ -20,6 +23,7 @@ impl CreateLocalRecordUseCase {
             config_repo,
             ptr_registry: None,
             dns_cache: None,
+            wildcard_registry: None,
         }
     }
 
@@ -37,6 +41,17 @@ impl CreateLocalRecordUseCase {
         self
     }
 
+    /// Attaches the live wildcard index so that a newly created wildcard record
+    /// answers queries immediately. Wildcards never enter the DNS cache — its
+    /// keys are matched exactly, so a `*.example.com` entry there is dead weight.
+    pub fn with_wildcard_registry(
+        mut self,
+        registry: Option<Arc<dyn WildcardRecordRegistry>>,
+    ) -> Self {
+        self.wildcard_registry = registry;
+        self
+    }
+
     pub async fn execute(
         &self,
         hostname: String,
@@ -45,6 +60,11 @@ impl CreateLocalRecordUseCase {
         record_type: String,
         ttl: Option<u32>,
     ) -> Result<(LocalDnsRecord, usize), DomainError> {
+        LocalDnsRecord::validate_hostname(&hostname).map_err(DomainError::InvalidDomainName)?;
+        if let Some(ref domain) = domain {
+            LocalDnsRecord::validate_domain(domain).map_err(DomainError::InvalidDomainName)?;
+        }
+
         let parsed_ip = ip
             .parse::<std::net::IpAddr>()
             .map_err(|_| DomainError::InvalidIpAddress("Invalid IP address".to_string()))?;
@@ -69,6 +89,17 @@ impl CreateLocalRecordUseCase {
         };
 
         let mut config = self.config.write().await;
+
+        if new_record.is_wildcard()
+            && new_record
+                .wildcard_suffix(&config.dns.local_domain)
+                .is_none()
+        {
+            return Err(DomainError::InvalidDomainName(
+                "A wildcard record needs a domain to anchor it: set the domain field or dns.local_domain".to_string(),
+            ));
+        }
+
         config.dns.local_records.push(new_record.clone());
         let new_index = config.dns.local_records.len() - 1;
 
@@ -78,6 +109,18 @@ impl CreateLocalRecordUseCase {
                 "Failed to save configuration: {}",
                 e
             )));
+        }
+
+        if let Some(suffix) = new_record.wildcard_suffix(&config.dns.local_domain) {
+            if let Some(ref registry) = self.wildcard_registry {
+                registry.register(
+                    &suffix,
+                    parsed_record_type,
+                    parsed_ip,
+                    new_record.ttl_or_default(),
+                );
+            }
+            return Ok((new_record, new_index));
         }
 
         let fqdn = new_record.fqdn(&config.dns.local_domain);

--- a/crates/application/src/use_cases/local_records/create.rs
+++ b/crates/application/src/use_cases/local_records/create.rs
@@ -134,7 +134,12 @@ impl CreateLocalRecordUseCase {
         }
 
         if let Some(ref cache) = self.dns_cache {
-            cache.insert_permanent_record(&fqdn, parsed_record_type, vec![parsed_ip]);
+            cache.insert_permanent_record(
+                &fqdn,
+                parsed_record_type,
+                vec![parsed_ip],
+                new_record.ttl_or_default(),
+            );
         }
 
         Ok((new_record, new_index))

--- a/crates/application/src/use_cases/local_records/delete.rs
+++ b/crates/application/src/use_cases/local_records/delete.rs
@@ -4,13 +4,14 @@ use ferrous_dns_domain::{Config, DomainError, LocalDnsRecord, RecordType};
 use tokio::sync::RwLock;
 use tracing::warn;
 
-use crate::ports::{ConfigRepository, DnsCachePort, PtrRecordRegistry};
+use crate::ports::{ConfigRepository, DnsCachePort, PtrRecordRegistry, WildcardRecordRegistry};
 
 pub struct DeleteLocalRecordUseCase {
     config: Arc<RwLock<Config>>,
     config_repo: Arc<dyn ConfigRepository>,
     ptr_registry: Option<Arc<dyn PtrRecordRegistry>>,
     dns_cache: Option<Arc<dyn DnsCachePort>>,
+    wildcard_registry: Option<Arc<dyn WildcardRecordRegistry>>,
 }
 
 impl DeleteLocalRecordUseCase {
@@ -20,6 +21,7 @@ impl DeleteLocalRecordUseCase {
             config_repo,
             ptr_registry: None,
             dns_cache: None,
+            wildcard_registry: None,
         }
     }
 
@@ -34,6 +36,16 @@ impl DeleteLocalRecordUseCase {
     /// removes the forward record (A/AAAA) from the cache without requiring a server restart.
     pub fn with_dns_cache(mut self, cache: Option<Arc<dyn DnsCachePort>>) -> Self {
         self.dns_cache = cache;
+        self
+    }
+
+    /// Attaches the live wildcard index so that deleting a wildcard record stops
+    /// it answering on the next query, without a server restart.
+    pub fn with_wildcard_registry(
+        mut self,
+        registry: Option<Arc<dyn WildcardRecordRegistry>>,
+    ) -> Self {
+        self.wildcard_registry = registry;
         self
     }
 
@@ -56,6 +68,20 @@ impl DeleteLocalRecordUseCase {
                 "Failed to save configuration: {}",
                 e
             )));
+        }
+
+        if let Some(suffix) = removed_record.wildcard_suffix(&config.dns.local_domain) {
+            if let Some(ref registry) = self.wildcard_registry {
+                if let Ok(record_type) = removed_record.record_type.parse::<RecordType>() {
+                    registry.unregister(&suffix, record_type);
+                } else {
+                    warn!(
+                        record_type = %removed_record.record_type,
+                        "Wildcard registry: unrecognised record type on removed record, skipping removal"
+                    );
+                }
+            }
+            return Ok(removed_record);
         }
 
         if let Some(ref registry) = self.ptr_registry {

--- a/crates/application/src/use_cases/local_records/update.rs
+++ b/crates/application/src/use_cases/local_records/update.rs
@@ -181,6 +181,7 @@ impl UpdateLocalRecordUseCase {
                     &new_fqdn,
                     new_parsed_record_type,
                     vec![new_parsed_ip],
+                    updated_record.ttl_or_default(),
                 );
             }
         }

--- a/crates/application/src/use_cases/local_records/update.rs
+++ b/crates/application/src/use_cases/local_records/update.rs
@@ -4,13 +4,14 @@ use ferrous_dns_domain::{Config, DomainError, LocalDnsRecord, RecordType};
 use tokio::sync::RwLock;
 use tracing::warn;
 
-use crate::ports::{ConfigRepository, DnsCachePort, PtrRecordRegistry};
+use crate::ports::{ConfigRepository, DnsCachePort, PtrRecordRegistry, WildcardRecordRegistry};
 
 pub struct UpdateLocalRecordUseCase {
     config: Arc<RwLock<Config>>,
     config_repo: Arc<dyn ConfigRepository>,
     ptr_registry: Option<Arc<dyn PtrRecordRegistry>>,
     dns_cache: Option<Arc<dyn DnsCachePort>>,
+    wildcard_registry: Option<Arc<dyn WildcardRecordRegistry>>,
 }
 
 impl UpdateLocalRecordUseCase {
@@ -20,6 +21,7 @@ impl UpdateLocalRecordUseCase {
             config_repo,
             ptr_registry: None,
             dns_cache: None,
+            wildcard_registry: None,
         }
     }
 
@@ -37,6 +39,16 @@ impl UpdateLocalRecordUseCase {
         self
     }
 
+    /// Attaches the live wildcard index so that an update moving a record into
+    /// or out of wildcard form takes effect without a server restart.
+    pub fn with_wildcard_registry(
+        mut self,
+        registry: Option<Arc<dyn WildcardRecordRegistry>>,
+    ) -> Self {
+        self.wildcard_registry = registry;
+        self
+    }
+
     pub async fn execute(
         &self,
         id: i64,
@@ -46,6 +58,11 @@ impl UpdateLocalRecordUseCase {
         record_type: String,
         ttl: Option<u32>,
     ) -> Result<(LocalDnsRecord, LocalDnsRecord), DomainError> {
+        LocalDnsRecord::validate_hostname(&hostname).map_err(DomainError::InvalidDomainName)?;
+        if let Some(ref domain) = domain {
+            LocalDnsRecord::validate_domain(domain).map_err(DomainError::InvalidDomainName)?;
+        }
+
         let new_parsed_ip = ip
             .parse::<std::net::IpAddr>()
             .map_err(|_| DomainError::InvalidIpAddress("Invalid IP address".to_string()))?;
@@ -79,6 +96,16 @@ impl UpdateLocalRecordUseCase {
             )));
         }
 
+        if updated_record.is_wildcard()
+            && updated_record
+                .wildcard_suffix(&config.dns.local_domain)
+                .is_none()
+        {
+            return Err(DomainError::InvalidDomainName(
+                "A wildcard record needs a domain to anchor it: set the domain field or dns.local_domain".to_string(),
+            ));
+        }
+
         let old_record = config.dns.local_records[idx].clone();
         config.dns.local_records[idx] = updated_record.clone();
 
@@ -90,34 +117,72 @@ impl UpdateLocalRecordUseCase {
             )));
         }
 
-        let old_fqdn = old_record.fqdn(&config.dns.local_domain);
-        let new_fqdn = updated_record.fqdn(&config.dns.local_domain);
-
-        if let Some(ref registry) = self.ptr_registry {
-            if let Ok(old_ip) = old_record.ip.parse() {
-                registry.unregister(old_ip);
-            } else {
-                warn!(ip = %old_record.ip, "PTR registry: failed to parse old IP after update");
+        // Retire the old record from whichever side held it: a wildcard lives in
+        // the wildcard index, an exact record in the PTR map and the DNS cache.
+        if let Some(old_suffix) = old_record.wildcard_suffix(&config.dns.local_domain) {
+            if let Some(ref registry) = self.wildcard_registry {
+                // old_record.record_type was already validated when first created; parse
+                // defensively and skip removal only if the stored value is somehow invalid.
+                if let Ok(old_rt) = old_record.record_type.parse::<RecordType>() {
+                    registry.unregister(&old_suffix, old_rt);
+                } else {
+                    warn!(
+                        record_type = %old_record.record_type,
+                        "Wildcard registry: unrecognised record type on old record, skipping removal"
+                    );
+                }
             }
-            registry.register(
-                new_parsed_ip,
-                Arc::from(new_fqdn.as_str()),
-                updated_record.ttl_or_default(),
-            );
+        } else {
+            let old_fqdn = old_record.fqdn(&config.dns.local_domain);
+
+            if let Some(ref registry) = self.ptr_registry {
+                if let Ok(old_ip) = old_record.ip.parse() {
+                    registry.unregister(old_ip);
+                } else {
+                    warn!(ip = %old_record.ip, "PTR registry: failed to parse old IP after update");
+                }
+            }
+
+            if let Some(ref cache) = self.dns_cache {
+                if let Ok(old_rt) = old_record.record_type.parse::<RecordType>() {
+                    cache.remove_record(&old_fqdn, &old_rt);
+                } else {
+                    warn!(
+                        record_type = %old_record.record_type,
+                        "DNS cache: unrecognised record type on old record, skipping eviction"
+                    );
+                }
+            }
         }
 
-        if let Some(ref cache) = self.dns_cache {
-            // old_record.record_type was already validated when first created; parse
-            // defensively and skip eviction only if the stored value is somehow invalid.
-            if let Ok(old_rt) = old_record.record_type.parse::<RecordType>() {
-                cache.remove_record(&old_fqdn, &old_rt);
-            } else {
-                warn!(
-                    record_type = %old_record.record_type,
-                    "DNS cache: unrecognised record type on old record, skipping eviction"
+        // Install the updated record on whichever side it now belongs to.
+        if let Some(new_suffix) = updated_record.wildcard_suffix(&config.dns.local_domain) {
+            if let Some(ref registry) = self.wildcard_registry {
+                registry.register(
+                    &new_suffix,
+                    new_parsed_record_type,
+                    new_parsed_ip,
+                    updated_record.ttl_or_default(),
                 );
             }
-            cache.insert_permanent_record(&new_fqdn, new_parsed_record_type, vec![new_parsed_ip]);
+        } else {
+            let new_fqdn = updated_record.fqdn(&config.dns.local_domain);
+
+            if let Some(ref registry) = self.ptr_registry {
+                registry.register(
+                    new_parsed_ip,
+                    Arc::from(new_fqdn.as_str()),
+                    updated_record.ttl_or_default(),
+                );
+            }
+
+            if let Some(ref cache) = self.dns_cache {
+                cache.insert_permanent_record(
+                    &new_fqdn,
+                    new_parsed_record_type,
+                    vec![new_parsed_ip],
+                );
+            }
         }
 
         Ok((updated_record, old_record))

--- a/crates/application/tests/local_records_wildcard_test.rs
+++ b/crates/application/tests/local_records_wildcard_test.rs
@@ -1,0 +1,403 @@
+//! Wildcard local DNS records (issue #223) at the use-case level: validation of
+//! the hostname, and routing each record to the side that can actually answer it
+//! — the wildcard index for `*`, the PTR map and DNS cache for an exact name.
+
+use async_trait::async_trait;
+use ferrous_dns_application::ports::{ConfigRepository, PtrRecordRegistry, WildcardRecordRegistry};
+use ferrous_dns_application::use_cases::{
+    CreateLocalRecordUseCase, DeleteLocalRecordUseCase, UpdateLocalRecordUseCase,
+};
+use ferrous_dns_domain::{Config, DomainError, LocalDnsRecord, RecordType};
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+use tokio::sync::RwLock;
+
+// ── Mock ConfigRepository ────────────────────────────────────────────────────
+
+struct MockConfigRepository {
+    should_fail: bool,
+}
+
+impl MockConfigRepository {
+    fn ok() -> Arc<Self> {
+        Arc::new(Self { should_fail: false })
+    }
+
+    fn failing() -> Arc<Self> {
+        Arc::new(Self { should_fail: true })
+    }
+}
+
+#[async_trait]
+impl ConfigRepository for MockConfigRepository {
+    async fn save_local_records(&self, _config: &Config) -> Result<(), DomainError> {
+        if self.should_fail {
+            Err(DomainError::IoError("disk full".to_string()))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// ── Mock registries ──────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct MockWildcardRegistry {
+    registered: Mutex<Vec<(String, RecordType, IpAddr, u32)>>,
+    unregistered: Mutex<Vec<(String, RecordType)>>,
+}
+
+impl MockWildcardRegistry {
+    fn new_arc() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+}
+
+impl WildcardRecordRegistry for MockWildcardRegistry {
+    fn register(&self, suffix: &str, record_type: RecordType, address: IpAddr, ttl: u32) {
+        self.registered
+            .lock()
+            .unwrap()
+            .push((suffix.to_string(), record_type, address, ttl));
+    }
+
+    fn unregister(&self, suffix: &str, record_type: RecordType) {
+        self.unregistered
+            .lock()
+            .unwrap()
+            .push((suffix.to_string(), record_type));
+    }
+}
+
+#[derive(Default)]
+struct MockPtrRegistry {
+    registered: Mutex<Vec<(IpAddr, String, u32)>>,
+    unregistered: Mutex<Vec<IpAddr>>,
+}
+
+impl MockPtrRegistry {
+    fn new_arc() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+}
+
+impl PtrRecordRegistry for MockPtrRegistry {
+    fn register(&self, ip: IpAddr, fqdn: Arc<str>, ttl: u32) {
+        self.registered
+            .lock()
+            .unwrap()
+            .push((ip, fqdn.to_string(), ttl));
+    }
+
+    fn unregister(&self, ip: IpAddr) {
+        self.unregistered.lock().unwrap().push(ip);
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn default_config() -> Arc<RwLock<Config>> {
+    Arc::new(RwLock::new(Config::default()))
+}
+
+fn config_with(record: LocalDnsRecord) -> Arc<RwLock<Config>> {
+    let mut config = Config::default();
+    config.dns.local_records.push(record);
+    Arc::new(RwLock::new(config))
+}
+
+fn wildcard_record() -> LocalDnsRecord {
+    LocalDnsRecord {
+        hostname: "*".to_string(),
+        domain: Some("home.lan".to_string()),
+        ip: "192.168.1.10".to_string(),
+        record_type: "A".to_string(),
+        ttl: Some(300),
+    }
+}
+
+fn exact_record() -> LocalDnsRecord {
+    LocalDnsRecord {
+        hostname: "nas".to_string(),
+        domain: Some("home.lan".to_string()),
+        ip: "192.168.1.50".to_string(),
+        record_type: "A".to_string(),
+        ttl: Some(300),
+    }
+}
+
+// ── Create ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_create_wildcard_registers_in_the_wildcard_index() {
+    let wildcards = MockWildcardRegistry::new_arc();
+    let use_case = CreateLocalRecordUseCase::new(default_config(), MockConfigRepository::ok())
+        .with_wildcard_registry(Some(wildcards.clone() as Arc<dyn WildcardRecordRegistry>));
+
+    let result = use_case
+        .execute(
+            "*".to_string(),
+            Some("home.lan".to_string()),
+            "192.168.1.10".to_string(),
+            "A".to_string(),
+            Some(300),
+        )
+        .await;
+
+    assert!(result.is_ok());
+    let registered = wildcards.registered.lock().unwrap();
+    assert_eq!(registered.len(), 1);
+    assert_eq!(registered[0].0, "home.lan");
+    assert_eq!(registered[0].1, RecordType::A);
+    assert_eq!(registered[0].2, "192.168.1.10".parse::<IpAddr>().unwrap());
+    assert_eq!(registered[0].3, 300);
+}
+
+#[tokio::test]
+async fn test_create_wildcard_skips_the_ptr_registry() {
+    let ptr = MockPtrRegistry::new_arc();
+    let use_case = CreateLocalRecordUseCase::new(default_config(), MockConfigRepository::ok())
+        .with_ptr_registry(Some(ptr.clone() as Arc<dyn PtrRecordRegistry>));
+
+    let result = use_case
+        .execute(
+            "*".to_string(),
+            Some("home.lan".to_string()),
+            "192.168.1.10".to_string(),
+            "A".to_string(),
+            None,
+        )
+        .await;
+
+    assert!(result.is_ok());
+    assert!(
+        ptr.registered.lock().unwrap().is_empty(),
+        "a wildcard has no single name to reverse to"
+    );
+}
+
+#[tokio::test]
+async fn test_create_exact_record_leaves_the_wildcard_index_alone() {
+    let wildcards = MockWildcardRegistry::new_arc();
+    let use_case = CreateLocalRecordUseCase::new(default_config(), MockConfigRepository::ok())
+        .with_wildcard_registry(Some(wildcards.clone() as Arc<dyn WildcardRecordRegistry>));
+
+    let result = use_case
+        .execute(
+            "nas".to_string(),
+            Some("home.lan".to_string()),
+            "192.168.1.50".to_string(),
+            "A".to_string(),
+            None,
+        )
+        .await;
+
+    assert!(result.is_ok());
+    assert!(wildcards.registered.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_create_rejects_a_misplaced_wildcard() {
+    let use_case = CreateLocalRecordUseCase::new(default_config(), MockConfigRepository::ok());
+
+    let result = use_case
+        .execute(
+            "a.*.b".to_string(),
+            Some("home.lan".to_string()),
+            "192.168.1.10".to_string(),
+            "A".to_string(),
+            None,
+        )
+        .await;
+
+    assert!(matches!(result, Err(DomainError::InvalidDomainName(_))));
+}
+
+#[tokio::test]
+async fn test_create_rejects_an_invalid_hostname() {
+    let use_case = CreateLocalRecordUseCase::new(default_config(), MockConfigRepository::ok());
+
+    let result = use_case
+        .execute(
+            "my host".to_string(),
+            None,
+            "192.168.1.10".to_string(),
+            "A".to_string(),
+            None,
+        )
+        .await;
+
+    assert!(matches!(result, Err(DomainError::InvalidDomainName(_))));
+}
+
+#[tokio::test]
+async fn test_create_rejects_a_wildcard_in_the_domain_field() {
+    let use_case = CreateLocalRecordUseCase::new(default_config(), MockConfigRepository::ok());
+
+    let result = use_case
+        .execute(
+            "nas".to_string(),
+            Some("*.home.lan".to_string()),
+            "192.168.1.10".to_string(),
+            "A".to_string(),
+            None,
+        )
+        .await;
+
+    assert!(matches!(result, Err(DomainError::InvalidDomainName(_))));
+}
+
+#[tokio::test]
+async fn test_create_rejects_a_wildcard_with_nothing_to_anchor_it() {
+    // No domain field and no dns.local_domain: the record would cover every
+    // query in existence, so it is refused instead of silently stored.
+    let use_case = CreateLocalRecordUseCase::new(default_config(), MockConfigRepository::ok());
+
+    let result = use_case
+        .execute(
+            "*".to_string(),
+            None,
+            "192.168.1.10".to_string(),
+            "A".to_string(),
+            None,
+        )
+        .await;
+
+    assert!(matches!(result, Err(DomainError::InvalidDomainName(_))));
+}
+
+#[tokio::test]
+async fn test_create_wildcard_does_not_register_on_save_failure() {
+    let wildcards = MockWildcardRegistry::new_arc();
+    let use_case = CreateLocalRecordUseCase::new(default_config(), MockConfigRepository::failing())
+        .with_wildcard_registry(Some(wildcards.clone() as Arc<dyn WildcardRecordRegistry>));
+
+    let result = use_case
+        .execute(
+            "*".to_string(),
+            Some("home.lan".to_string()),
+            "192.168.1.10".to_string(),
+            "A".to_string(),
+            None,
+        )
+        .await;
+
+    assert!(result.is_err());
+    assert!(wildcards.registered.lock().unwrap().is_empty());
+}
+
+// ── Delete ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_delete_wildcard_unregisters_it() {
+    let wildcards = MockWildcardRegistry::new_arc();
+    let ptr = MockPtrRegistry::new_arc();
+    let use_case =
+        DeleteLocalRecordUseCase::new(config_with(wildcard_record()), MockConfigRepository::ok())
+            .with_wildcard_registry(Some(wildcards.clone() as Arc<dyn WildcardRecordRegistry>))
+            .with_ptr_registry(Some(ptr.clone() as Arc<dyn PtrRecordRegistry>));
+
+    let result = use_case.execute(0).await;
+
+    assert!(result.is_ok());
+    let unregistered = wildcards.unregistered.lock().unwrap();
+    assert_eq!(unregistered.len(), 1);
+    assert_eq!(unregistered[0], ("home.lan".to_string(), RecordType::A));
+    assert!(ptr.unregistered.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_delete_exact_record_leaves_the_wildcard_index_alone() {
+    let wildcards = MockWildcardRegistry::new_arc();
+    let use_case =
+        DeleteLocalRecordUseCase::new(config_with(exact_record()), MockConfigRepository::ok())
+            .with_wildcard_registry(Some(wildcards.clone() as Arc<dyn WildcardRecordRegistry>));
+
+    let result = use_case.execute(0).await;
+
+    assert!(result.is_ok());
+    assert!(wildcards.unregistered.lock().unwrap().is_empty());
+}
+
+// ── Update ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_update_from_exact_to_wildcard_moves_the_record() {
+    let wildcards = MockWildcardRegistry::new_arc();
+    let ptr = MockPtrRegistry::new_arc();
+    let use_case =
+        UpdateLocalRecordUseCase::new(config_with(exact_record()), MockConfigRepository::ok())
+            .with_wildcard_registry(Some(wildcards.clone() as Arc<dyn WildcardRecordRegistry>))
+            .with_ptr_registry(Some(ptr.clone() as Arc<dyn PtrRecordRegistry>));
+
+    let result = use_case
+        .execute(
+            0,
+            "*".to_string(),
+            Some("home.lan".to_string()),
+            "192.168.1.10".to_string(),
+            "A".to_string(),
+            Some(120),
+        )
+        .await;
+
+    assert!(result.is_ok());
+    // The old exact record leaves the PTR map, the new wildcard enters the index.
+    assert_eq!(
+        ptr.unregistered.lock().unwrap()[0],
+        "192.168.1.50".parse::<IpAddr>().unwrap()
+    );
+    assert!(ptr.registered.lock().unwrap().is_empty());
+    let registered = wildcards.registered.lock().unwrap();
+    assert_eq!(registered[0].0, "home.lan");
+    assert_eq!(registered[0].3, 120);
+}
+
+#[tokio::test]
+async fn test_update_from_wildcard_to_exact_moves_it_back() {
+    let wildcards = MockWildcardRegistry::new_arc();
+    let ptr = MockPtrRegistry::new_arc();
+    let use_case =
+        UpdateLocalRecordUseCase::new(config_with(wildcard_record()), MockConfigRepository::ok())
+            .with_wildcard_registry(Some(wildcards.clone() as Arc<dyn WildcardRecordRegistry>))
+            .with_ptr_registry(Some(ptr.clone() as Arc<dyn PtrRecordRegistry>));
+
+    let result = use_case
+        .execute(
+            0,
+            "nas".to_string(),
+            Some("home.lan".to_string()),
+            "192.168.1.50".to_string(),
+            "A".to_string(),
+            Some(300),
+        )
+        .await;
+
+    assert!(result.is_ok());
+    assert_eq!(
+        wildcards.unregistered.lock().unwrap()[0],
+        ("home.lan".to_string(), RecordType::A)
+    );
+    assert!(wildcards.registered.lock().unwrap().is_empty());
+    let registered = ptr.registered.lock().unwrap();
+    assert_eq!(registered[0].1, "nas.home.lan");
+}
+
+#[tokio::test]
+async fn test_update_rejects_a_misplaced_wildcard() {
+    let use_case =
+        UpdateLocalRecordUseCase::new(config_with(exact_record()), MockConfigRepository::ok());
+
+    let result = use_case
+        .execute(
+            0,
+            "*x".to_string(),
+            Some("home.lan".to_string()),
+            "192.168.1.10".to_string(),
+            "A".to_string(),
+            None,
+        )
+        .await;
+
+    assert!(matches!(result, Err(DomainError::InvalidDomainName(_))));
+}

--- a/crates/cli/src/wiring/app_state.rs
+++ b/crates/cli/src/wiring/app_state.rs
@@ -160,6 +160,7 @@ pub async fn build_app_state(
         let local_record_creator_for_import = Arc::new(
             CreateLocalRecordUseCase::new(config.clone(), config_repo.clone())
                 .with_ptr_registry(dns_services.ptr_registry.clone())
+                .with_wildcard_registry(Some(dns_services.wildcard_registry.clone()))
                 .with_dns_cache(Some(dns_services.cache.clone()
                     as Arc<dyn ferrous_dns_application::ports::DnsCachePort>)),
         );
@@ -204,18 +205,21 @@ pub async fn build_app_state(
             create_local_record: Arc::new(
                 CreateLocalRecordUseCase::new(config.clone(), config_repo.clone())
                     .with_ptr_registry(dns_services.ptr_registry.clone())
+                    .with_wildcard_registry(Some(dns_services.wildcard_registry.clone()))
                     .with_dns_cache(Some(dns_services.cache.clone()
                         as Arc<dyn ferrous_dns_application::ports::DnsCachePort>)),
             ),
             update_local_record: Arc::new(
                 UpdateLocalRecordUseCase::new(config.clone(), config_repo.clone())
                     .with_ptr_registry(dns_services.ptr_registry.clone())
+                    .with_wildcard_registry(Some(dns_services.wildcard_registry.clone()))
                     .with_dns_cache(Some(dns_services.cache.clone()
                         as Arc<dyn ferrous_dns_application::ports::DnsCachePort>)),
             ),
             delete_local_record: Arc::new(
                 DeleteLocalRecordUseCase::new(config.clone(), config_repo)
                     .with_ptr_registry(dns_services.ptr_registry.clone())
+                    .with_wildcard_registry(Some(dns_services.wildcard_registry.clone()))
                     .with_dns_cache(Some(dns_services.cache.clone()
                         as Arc<dyn ferrous_dns_application::ports::DnsCachePort>)),
             ),

--- a/crates/cli/src/wiring/dns/cache.rs
+++ b/crates/cli/src/wiring/dns/cache.rs
@@ -131,7 +131,7 @@ pub(super) fn preload_local_records_into_cache(
 
         let ttl = record.ttl.unwrap_or(300);
 
-        cache.insert_permanent(&fqdn, record_type, data, None);
+        cache.insert_permanent(&fqdn, record_type, data, ttl, None);
 
         info!(
             fqdn = %fqdn,

--- a/crates/cli/src/wiring/dns/cache.rs
+++ b/crates/cli/src/wiring/dns/cache.rs
@@ -69,8 +69,17 @@ pub(super) fn preload_local_records_into_cache(
 
     let mut success_count = 0;
     let mut error_count = 0;
+    let mut wildcard_count = 0;
 
     for record in records {
+        // Wildcards are served by `LocalWildcardResolver` above the cache: a
+        // cache key is matched exactly, so `*.home.lan` here would be an entry
+        // no query could ever reach.
+        if record.is_wildcard() {
+            wildcard_count += 1;
+            continue;
+        }
+
         let fqdn = record.fqdn(default_domain);
 
         let ip: std::net::IpAddr = match record.ip.parse() {
@@ -139,6 +148,7 @@ pub(super) fn preload_local_records_into_cache(
         info!(
             count = success_count,
             errors = error_count,
+            wildcards = wildcard_count,
             "✓ Preloaded {} local DNS record(s) into permanent cache",
             success_count
         );

--- a/crates/cli/src/wiring/dns/mod.rs
+++ b/crates/cli/src/wiring/dns/mod.rs
@@ -6,7 +6,7 @@ use crate::server::dns::connection_limiter::ConnectionLimiter;
 use ferrous_dns_application::ports::{
     CacheMaintenancePort, DgaEvictionTarget, DgaFlagStore, DnssecStatsPort, NxdomainHijackIpStore,
     NxdomainHijackProbeTarget, PtrRecordRegistry, ResponseIpFilterEvictionTarget,
-    ResponseIpFilterStore, TunnelingEvictionTarget, TunnelingFlagStore,
+    ResponseIpFilterStore, TunnelingEvictionTarget, TunnelingFlagStore, WildcardRecordRegistry,
 };
 use ferrous_dns_application::use_cases::dns::rate_limiter::DnsRateLimiter;
 use ferrous_dns_application::use_cases::dns::tsc_timer;
@@ -14,10 +14,13 @@ use ferrous_dns_application::use_cases::dns::DnsCookieGuard;
 use ferrous_dns_application::use_cases::HandleDnsQueryUseCase;
 use ferrous_dns_domain::Config;
 use ferrous_dns_infrastructure::dns::{
-    cache::DnsCache, cache_maintenance::DnsCacheMaintenance, dnssec::DnssecStatsAdapter,
-    events::QueryEventEmitter, resolver::LocalPtrResolver, DgaDetector, HealthChecker,
-    HickoryDnsResolver, NxdomainHijackDetector, PoolManager, RefreshScanOptions, RefreshSenders,
-    ResponseIpFilterDetector, TunnelingDetector,
+    cache::DnsCache,
+    cache_maintenance::DnsCacheMaintenance,
+    dnssec::DnssecStatsAdapter,
+    events::QueryEventEmitter,
+    resolver::{LocalPtrResolver, LocalWildcardResolver, WildcardRegistry},
+    DgaDetector, HealthChecker, HickoryDnsResolver, NxdomainHijackDetector, PoolManager,
+    RefreshScanOptions, RefreshSenders, ResponseIpFilterDetector, TunnelingDetector,
 };
 use ferrous_dns_jobs::{
     DgaEvictionJob, NxdomainHijackEvictionJob, ResponseIpFilterEvictionJob, TunnelingEvictionJob,
@@ -42,6 +45,9 @@ pub struct DnsServices {
     pub health_checker: Option<Arc<HealthChecker>>,
     pub cache_maintenance: Option<Arc<dyn CacheMaintenancePort>>,
     pub ptr_registry: Option<Arc<dyn PtrRecordRegistry>>,
+    /// Live wildcard index. Always present, even with no wildcard configured,
+    /// so the first one added from the admin UI answers without a restart.
+    pub wildcard_registry: Arc<dyn WildcardRecordRegistry>,
     pub tcp_conn_limiter: ConnectionLimiter,
     pub dot_conn_limiter: ConnectionLimiter,
     pub doq_conn_limiter: ConnectionLimiter,
@@ -143,6 +149,17 @@ impl DnsServices {
             } else {
                 None
             };
+
+        // Unconditional, unlike the PTR map above: an empty index costs one
+        // `is_empty()` check per query, and it is what lets a wildcard created
+        // from the admin UI take effect on the next query.
+        let wildcard_map = LocalWildcardResolver::map_from_local_records(
+            &config.dns.local_records,
+            &config.dns.local_domain,
+        );
+        dns_resolver = dns_resolver.with_local_wildcards(Arc::clone(&wildcard_map));
+        let wildcard_registry: Arc<dyn WildcardRecordRegistry> =
+            Arc::new(WildcardRegistry::new(wildcard_map));
 
         let resolver = Arc::new(dns_resolver);
 
@@ -356,6 +373,7 @@ impl DnsServices {
             health_checker: stored_health_checker,
             cache_maintenance,
             ptr_registry,
+            wildcard_registry,
             tcp_conn_limiter,
             dot_conn_limiter,
             doq_conn_limiter,

--- a/crates/domain/src/config/local_records.rs
+++ b/crates/domain/src/config/local_records.rs
@@ -1,5 +1,11 @@
 use serde::{Deserialize, Serialize};
 
+/// Longest a DNS name may be, in bytes (RFC 1035 §2.3.4).
+const MAX_NAME_LEN: usize = 253;
+
+/// Longest a single DNS label may be, in bytes (RFC 1035 §2.3.4).
+const MAX_LABEL_LEN: usize = 63;
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LocalDnsRecord {
     pub hostname: String,
@@ -29,4 +35,93 @@ impl LocalDnsRecord {
     pub fn ttl_or_default(&self) -> u32 {
         self.ttl.unwrap_or(300)
     }
+
+    /// True when the record covers a whole subtree instead of a single name:
+    /// `*` on its own, or a `*.`-prefixed hostname such as `*.dev`.
+    pub fn is_wildcard(&self) -> bool {
+        is_wildcard_hostname(&self.hostname)
+    }
+
+    /// Suffix a wildcard record answers for, lowercased for matching:
+    /// `*.home.lan` covers `home.lan`.
+    ///
+    /// `None` for an exact record, and for a wildcard with no domain to anchor
+    /// it — a bare `*` would otherwise cover every query in existence.
+    pub fn wildcard_suffix(&self, default_domain: &Option<String>) -> Option<String> {
+        if !self.is_wildcard() {
+            return None;
+        }
+
+        self.fqdn(default_domain)
+            .strip_prefix("*.")
+            .map(str::to_ascii_lowercase)
+    }
+
+    /// Validates the `hostname` field. A wildcard is accepted only as the
+    /// leftmost label, because that is the only position the resolver can
+    /// match — anything else would be stored as a record no query can reach.
+    pub fn validate_hostname(hostname: &str) -> Result<(), String> {
+        if hostname.is_empty() {
+            return Err("Hostname cannot be empty".to_string());
+        }
+        if hostname.len() > MAX_NAME_LEN {
+            return Err(format!("Hostname cannot exceed {MAX_NAME_LEN} characters"));
+        }
+        if hostname.contains('*') && !is_wildcard_hostname(hostname) {
+            return Err("Wildcard must be the leftmost label: use '*' or '*.sub'".to_string());
+        }
+
+        let remainder = hostname.strip_prefix("*.").unwrap_or(hostname);
+        if remainder == "*" {
+            return Ok(());
+        }
+
+        validate_labels(remainder, "Hostname")
+    }
+
+    /// Validates the optional `domain` suffix. Wildcards are rejected here:
+    /// the subtree is expressed by the hostname, so a `*` in the suffix would
+    /// land in the middle of the composed name.
+    pub fn validate_domain(domain: &str) -> Result<(), String> {
+        if domain.is_empty() {
+            return Err("Domain cannot be empty".to_string());
+        }
+        if domain.len() > MAX_NAME_LEN {
+            return Err(format!("Domain cannot exceed {MAX_NAME_LEN} characters"));
+        }
+        if domain.contains('*') {
+            return Err(
+                "Domain cannot contain a wildcard: put the '*' in the hostname".to_string(),
+            );
+        }
+
+        validate_labels(domain, "Domain")
+    }
+}
+
+fn is_wildcard_hostname(hostname: &str) -> bool {
+    hostname == "*" || hostname.starts_with("*.")
+}
+
+fn validate_labels(name: &str, field: &str) -> Result<(), String> {
+    for label in name.split('.') {
+        if label.is_empty() {
+            return Err(format!("{field} cannot contain an empty label"));
+        }
+        if label.len() > MAX_LABEL_LEN {
+            return Err(format!(
+                "{field} label cannot exceed {MAX_LABEL_LEN} characters"
+            ));
+        }
+        if !label
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(format!(
+                "{field} contains invalid characters (only alphanumeric, hyphens and underscores are allowed)"
+            ));
+        }
+    }
+
+    Ok(())
 }

--- a/crates/domain/tests/local_records_test.rs
+++ b/crates/domain/tests/local_records_test.rs
@@ -1,0 +1,109 @@
+use ferrous_dns_domain::LocalDnsRecord;
+
+fn record(hostname: &str, domain: Option<&str>) -> LocalDnsRecord {
+    LocalDnsRecord {
+        hostname: hostname.to_string(),
+        domain: domain.map(str::to_string),
+        ip: "192.168.1.10".to_string(),
+        record_type: "A".to_string(),
+        ttl: None,
+    }
+}
+
+#[test]
+fn test_validate_hostname_accepts_plain_names() {
+    assert!(LocalDnsRecord::validate_hostname("nas").is_ok());
+    assert!(LocalDnsRecord::validate_hostname("www-1").is_ok());
+    assert!(LocalDnsRecord::validate_hostname("my_host").is_ok());
+    assert!(LocalDnsRecord::validate_hostname("app.internal").is_ok());
+}
+
+#[test]
+fn test_validate_hostname_accepts_leftmost_wildcard() {
+    assert!(LocalDnsRecord::validate_hostname("*").is_ok());
+    assert!(LocalDnsRecord::validate_hostname("*.dev").is_ok());
+}
+
+#[test]
+fn test_validate_hostname_rejects_misplaced_wildcard() {
+    assert!(LocalDnsRecord::validate_hostname("a.*.b").is_err());
+    assert!(LocalDnsRecord::validate_hostname("*x").is_err());
+    assert!(LocalDnsRecord::validate_hostname("dev.*").is_err());
+}
+
+#[test]
+fn test_validate_hostname_rejects_empty() {
+    assert!(LocalDnsRecord::validate_hostname("").is_err());
+}
+
+#[test]
+fn test_validate_hostname_rejects_empty_label() {
+    assert!(LocalDnsRecord::validate_hostname("foo..bar").is_err());
+    assert!(LocalDnsRecord::validate_hostname(".foo").is_err());
+    assert!(LocalDnsRecord::validate_hostname("foo.").is_err());
+}
+
+#[test]
+fn test_validate_hostname_rejects_oversized_label() {
+    let label = "a".repeat(64);
+    assert!(LocalDnsRecord::validate_hostname(&label).is_err());
+}
+
+#[test]
+fn test_validate_hostname_rejects_invalid_characters() {
+    assert!(LocalDnsRecord::validate_hostname("my host").is_err());
+    assert!(LocalDnsRecord::validate_hostname("host!").is_err());
+    assert!(LocalDnsRecord::validate_hostname("héllo").is_err());
+}
+
+#[test]
+fn test_validate_domain_rejects_wildcard() {
+    assert!(LocalDnsRecord::validate_domain("example.com").is_ok());
+    assert!(LocalDnsRecord::validate_domain("*.example.com").is_err());
+    assert!(LocalDnsRecord::validate_domain("").is_err());
+}
+
+#[test]
+fn test_is_wildcard_follows_hostname() {
+    assert!(record("*", Some("home.lan")).is_wildcard());
+    assert!(record("*.dev", Some("home.lan")).is_wildcard());
+    assert!(!record("nas", Some("home.lan")).is_wildcard());
+}
+
+#[test]
+fn test_wildcard_suffix_strips_the_star_label() {
+    assert_eq!(
+        record("*", Some("home.lan")).wildcard_suffix(&None),
+        Some("home.lan".to_string())
+    );
+    assert_eq!(
+        record("*.dev", Some("home.lan")).wildcard_suffix(&None),
+        Some("dev.home.lan".to_string())
+    );
+}
+
+#[test]
+fn test_wildcard_suffix_uses_the_default_domain() {
+    assert_eq!(
+        record("*", None).wildcard_suffix(&Some("lan".to_string())),
+        Some("lan".to_string())
+    );
+}
+
+#[test]
+fn test_wildcard_suffix_is_lowercased() {
+    assert_eq!(
+        record("*", Some("HOME.LAN")).wildcard_suffix(&None),
+        Some("home.lan".to_string())
+    );
+}
+
+#[test]
+fn test_wildcard_suffix_none_without_a_domain_to_anchor_it() {
+    assert_eq!(record("*", None).wildcard_suffix(&None), None);
+}
+
+#[test]
+fn test_wildcard_suffix_none_for_an_exact_record() {
+    assert_eq!(record("nas", Some("home.lan")).wildcard_suffix(&None), None);
+}

--- a/crates/infrastructure/src/dns/cache/storage.rs
+++ b/crates/infrastructure/src/dns/cache/storage.rs
@@ -55,7 +55,6 @@ impl Ord for EvictionCandidate {
 }
 
 const BLOOM_TARGET_FP_RATE: f64 = 0.01;
-const PERMANENT_TTL_SECS: u32 = 365 * 24 * 60 * 60;
 const STALE_SERVE_TTL: u32 = 2;
 
 /// Message carried by a refresh queue.
@@ -268,7 +267,15 @@ impl DnsCache {
                 self.metrics.hits.fetch_add(1, AtomicOrdering::Relaxed);
                 record.record_hit();
                 self.bloom.refresh(&borrowed);
-                let remaining_ttl = record.expires_at_secs.saturating_sub(now_secs) as u32;
+                // A permanent entry never expires, so the distance to
+                // `expires_at_secs` (u64::MAX) is meaningless — serve the TTL the
+                // record was configured with instead, or the client is told to
+                // hold the answer for the next eighty years.
+                let remaining_ttl = if record.is_permanent() {
+                    record.ttl
+                } else {
+                    record.expires_at_secs.saturating_sub(now_secs) as u32
+                };
                 self.promote_to_l1(domain, record_type, record, now_secs);
                 return Some((
                     record.data.clone(),
@@ -362,6 +369,7 @@ impl DnsCache {
         domain: &str,
         record_type: RecordType,
         data: CachedData,
+        ttl: u32,
         _dnssec_status: Option<CachedDnssecStatus>,
     ) {
         let domain = normalize_domain(domain);
@@ -380,19 +388,30 @@ impl DnsCache {
             None
         };
 
-        let record = CachedRecord::permanent(data, PERMANENT_TTL_SECS, record_type);
+        let record = CachedRecord::permanent(data, ttl, record_type);
         self.cache.insert(key, record);
 
         if let Some(addresses) = maybe_l1_addresses {
             // Permanent (local DNS / hosts) entries are not DNSSEC-validated.
+            // L1 gets a real expiry so the TTL it reports is the configured one;
+            // when it lapses the entry is simply promoted again from L2, which
+            // still holds it forever.
             l1_insert(
                 domain,
                 &record_type,
                 addresses,
                 CachedDnssecStatus::Unknown,
-                u64::MAX,
+                coarse_now_secs() + ttl as u64,
             );
         }
+    }
+
+    /// Whether `domain`/`record_type` is held as a permanent entry — a local DNS
+    /// record preloaded from config, not something resolved from upstream.
+    pub fn is_permanent(&self, domain: &str, record_type: &RecordType) -> bool {
+        let domain = normalize_domain(domain);
+        let key = CacheKey::new(domain.as_ref(), *record_type);
+        self.permanent_keys.contains(&key)
     }
 
     pub fn remove(&self, domain: &str, record_type: &RecordType) -> bool {
@@ -414,6 +433,24 @@ impl DnsCache {
     }
 
     pub fn clear(&self) {
+        // Permanent entries are configuration, not cached upstream answers:
+        // local DNS records live here and nothing reloads them, so dropping them
+        // would leave every one of them unanswerable until the next restart.
+        let preserved: Vec<(CacheKey, CachedData, u32, RecordType)> = self
+            .permanent_keys
+            .iter()
+            .filter_map(|key| {
+                let entry = self.cache.get(key.key())?;
+                let record = entry.value();
+                Some((
+                    key.key().clone(),
+                    record.data.clone(),
+                    record.ttl,
+                    record.record_type,
+                ))
+            })
+            .collect();
+
         self.cache.clear();
         self.bloom.clear();
         self.negative.clear();
@@ -422,7 +459,19 @@ impl DnsCache {
         self.metrics.hits.store(0, AtomicOrdering::Relaxed);
         self.metrics.misses.store(0, AtomicOrdering::Relaxed);
         self.metrics.evictions.store(0, AtomicOrdering::Relaxed);
-        info!("Cache cleared (L1 generation bumped for cross-thread invalidation)");
+
+        let restored = preserved.len();
+        for (key, data, ttl, record_type) in preserved {
+            self.bloom.set(&key);
+            self.permanent_keys.insert(key.clone());
+            self.cache
+                .insert(key, CachedRecord::permanent(data, ttl, record_type));
+        }
+
+        info!(
+            restored,
+            "Cache cleared (L1 generation bumped for cross-thread invalidation)"
+        );
     }
 
     pub fn metrics(&self) -> Arc<CacheMetrics> {
@@ -624,12 +673,19 @@ impl DnsCache {
             if record.expires_at_secs <= now_secs {
                 return;
             }
+            // Same reason as in `get`: a permanent entry's `expires_at_secs` is
+            // u64::MAX, which L1 would turn into an absurd remaining TTL.
+            let expires_secs = if record.is_permanent() {
+                now_secs + record.ttl as u64
+            } else {
+                record.expires_at_secs
+            };
             l1_insert(
                 domain,
                 record_type,
                 Arc::clone(&entry.addresses),
                 record.dnssec_status,
-                record.expires_at_secs,
+                expires_secs,
             );
         }
     }
@@ -812,15 +868,24 @@ impl ferrous_dns_application::ports::DnsCachePort for DnsCache {
         domain: &str,
         record_type: ferrous_dns_domain::RecordType,
         addresses: Vec<std::net::IpAddr>,
+        ttl: u32,
     ) {
         let data = CachedData::IpAddresses(super::data::CachedAddresses {
             addresses: Arc::new(addresses),
         });
-        self.insert_permanent(domain, record_type, data, None);
+        self.insert_permanent(domain, record_type, data, ttl, None);
     }
 
     fn remove_record(&self, domain: &str, record_type: &ferrous_dns_domain::RecordType) -> bool {
         self.remove(domain, record_type)
+    }
+
+    fn is_permanent_record(
+        &self,
+        domain: &str,
+        record_type: &ferrous_dns_domain::RecordType,
+    ) -> bool {
+        self.is_permanent(domain, record_type)
     }
 
     fn list_entries(

--- a/crates/infrastructure/src/dns/resolver/builder.rs
+++ b/crates/infrastructure/src/dns/resolver/builder.rs
@@ -9,6 +9,7 @@ use super::dnssec_layer::DnssecResolver;
 use super::filtered_resolver::FilteredResolver;
 use super::filters::QueryFilters;
 use super::local_ptr::{LocalPtrResolver, PtrMap};
+use super::local_wildcard::{LocalWildcardResolver, WildcardMap};
 use ferrous_dns_application::ports::DnsResolver;
 use std::net::Ipv6Addr;
 use std::sync::Arc;
@@ -25,6 +26,7 @@ pub struct ResolverBuilder {
     local_dns_server: Option<String>,
     filters: Option<QueryFilters>,
     local_ptr_map: Option<Arc<PtrMap>>,
+    local_wildcards: Option<Arc<WildcardMap>>,
     dns64_prefix: Option<Ipv6Addr>,
 }
 
@@ -41,6 +43,7 @@ impl ResolverBuilder {
             local_dns_server: None,
             filters: None,
             local_ptr_map: None,
+            local_wildcards: None,
             dns64_prefix: None,
         }
     }
@@ -101,6 +104,14 @@ impl ResolverBuilder {
         self
     }
 
+    /// Attaches the live wildcard index, adding `LocalWildcardResolver` just
+    /// above the cache. Always attach it, even empty: it is what lets a
+    /// wildcard added at runtime answer without a restart.
+    pub fn with_local_wildcards(mut self, map: Arc<WildcardMap>) -> Self {
+        self.local_wildcards = Some(map);
+        self
+    }
+
     /// Enables DNS64 (RFC 6147) AAAA synthesis using the given `/96` NAT64
     /// network prefix. The layer is placed just below the cache so synthesized
     /// answers are cached and served consistently.
@@ -115,6 +126,7 @@ impl ResolverBuilder {
             cache = self.cache.is_some(),
             filters = self.filters.is_some(),
             local_ptr = self.local_ptr_map.is_some(),
+            wildcards = self.local_wildcards.as_ref().map_or(0, |m| m.len()),
             "Building DNS resolver"
         );
 
@@ -170,6 +182,13 @@ impl ResolverBuilder {
             );
 
             resolver = Arc::new(cached);
+        }
+
+        // Wildcard local records answer above the cache. A cache key is matched
+        // exactly, so an expansion of `*.home.lan` stored under a concrete name
+        // could never be found again to invalidate when the wildcard is deleted.
+        if let Some(map) = self.local_wildcards {
+            resolver = Arc::new(LocalWildcardResolver::new(resolver, map));
         }
 
         if let Some(filters) = self.filters {

--- a/crates/infrastructure/src/dns/resolver/legacy.rs
+++ b/crates/infrastructure/src/dns/resolver/legacy.rs
@@ -5,6 +5,7 @@ use super::builder::ResolverBuilder;
 use super::config::ResolverConfig;
 use super::filters::QueryFilters;
 use super::local_ptr::PtrMap;
+use super::local_wildcard::WildcardMap;
 use async_trait::async_trait;
 use ferrous_dns_application::ports::{DnsResolution, DnsResolver, QueryLogRepository};
 use ferrous_dns_domain::{DnsQuery, DomainError};
@@ -30,6 +31,7 @@ struct BuilderState {
     local_dns_server: Option<String>,
     filters: Option<QueryFilters>,
     local_ptr_map: Option<Arc<PtrMap>>,
+    local_wildcards: Option<Arc<WildcardMap>>,
     dns64_prefix: Option<Ipv6Addr>,
 }
 
@@ -58,6 +60,7 @@ impl HickoryDnsResolver {
             local_dns_server: None,
             filters: None,
             local_ptr_map: None,
+            local_wildcards: None,
             dns64_prefix: None,
         };
 
@@ -137,6 +140,14 @@ impl HickoryDnsResolver {
         self
     }
 
+    /// Attaches the live wildcard index so that wildcard local records answer,
+    /// and so that one added at runtime takes effect without a restart.
+    pub fn with_local_wildcards(mut self, map: Arc<WildcardMap>) -> Self {
+        self.builder_state.local_wildcards = Some(map);
+        self.rebuild();
+        self
+    }
+
     /// Enables DNS64 (RFC 6147) AAAA synthesis using the given `/96` NAT64
     /// network prefix.
     pub fn with_dns64(mut self, prefix: Ipv6Addr) -> Self {
@@ -173,6 +184,10 @@ impl HickoryDnsResolver {
 
         if let Some(map) = &self.builder_state.local_ptr_map {
             builder = builder.with_local_ptr_map(Arc::clone(map));
+        }
+
+        if let Some(map) = &self.builder_state.local_wildcards {
+            builder = builder.with_local_wildcards(Arc::clone(map));
         }
 
         if let Some(prefix) = self.builder_state.dns64_prefix {

--- a/crates/infrastructure/src/dns/resolver/local_ptr.rs
+++ b/crates/infrastructure/src/dns/resolver/local_ptr.rs
@@ -45,6 +45,12 @@ impl LocalPtrResolver {
         let mut count = 0usize;
 
         for record in records {
+            // A wildcard covers a whole subtree, so there is no single name an
+            // address could reverse to. Skip it rather than inventing one.
+            if record.is_wildcard() {
+                continue;
+            }
+
             match record.ip.parse::<IpAddr>() {
                 Ok(ip) => {
                     let fqdn = record.fqdn(default_domain);

--- a/crates/infrastructure/src/dns/resolver/local_wildcard.rs
+++ b/crates/infrastructure/src/dns/resolver/local_wildcard.rs
@@ -1,0 +1,281 @@
+use async_trait::async_trait;
+use dashmap::DashMap;
+use ferrous_dns_application::ports::{
+    DnsResolution, DnsResolver, WildcardRecordRegistry, EMPTY_CNAME_CHAIN,
+};
+use ferrous_dns_domain::{DnsQuery, DomainError, LocalDnsRecord, RecordType};
+use rustc_hash::FxBuildHasher;
+use std::borrow::Cow;
+use std::net::IpAddr;
+use std::sync::Arc;
+use tracing::{debug, info, warn};
+
+/// Concurrent index of wildcard suffix → answers. The key is the covered
+/// suffix, lowercased and without the leading `*.`: `*.home.lan` is stored
+/// under `home.lan`.
+pub type WildcardMap = DashMap<Box<str>, WildcardAnswer, FxBuildHasher>;
+
+/// What a wildcard answers with, one address per record type. A second record
+/// for the same suffix and type overwrites the first, the same way an exact
+/// record overwrites its permanent cache entry.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WildcardAnswer {
+    a: Option<(IpAddr, u32)>,
+    aaaa: Option<(IpAddr, u32)>,
+}
+
+impl WildcardAnswer {
+    fn get(&self, record_type: RecordType) -> Option<(IpAddr, u32)> {
+        match record_type {
+            RecordType::A => self.a,
+            RecordType::AAAA => self.aaaa,
+            _ => None,
+        }
+    }
+
+    fn set(&mut self, record_type: RecordType, address: IpAddr, ttl: u32) {
+        match record_type {
+            RecordType::A => self.a = Some((address, ttl)),
+            RecordType::AAAA => self.aaaa = Some((address, ttl)),
+            _ => {}
+        }
+    }
+
+    fn clear(&mut self, record_type: RecordType) {
+        match record_type {
+            RecordType::A => self.a = None,
+            RecordType::AAAA => self.aaaa = None,
+            _ => {}
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.a.is_none() && self.aaaa.is_none()
+    }
+}
+
+/// DNS resolver layer that answers queries covered by a wildcard local record.
+///
+/// It sits above the cache, so its answers are never stored under a concrete
+/// name — a cache key is matched exactly and an expansion of `*.home.lan` could
+/// not be found again for invalidation when the wildcard is deleted. The price
+/// is one index lookup per query, skipped entirely while no wildcard exists.
+pub struct LocalWildcardResolver {
+    inner: Arc<dyn DnsResolver>,
+    /// Live index of covered suffix → answers.
+    pub map: Arc<WildcardMap>,
+}
+
+impl LocalWildcardResolver {
+    /// Creates a resolver wrapping `inner` with an existing live index.
+    pub fn new(inner: Arc<dyn DnsResolver>, map: Arc<WildcardMap>) -> Self {
+        Self { inner, map }
+    }
+
+    /// Builds an index from the wildcard entries among the configured local
+    /// records. Exact records are left to the permanent cache.
+    pub fn map_from_local_records(
+        records: &[LocalDnsRecord],
+        default_domain: &Option<String>,
+    ) -> Arc<WildcardMap> {
+        let map: WildcardMap = DashMap::with_hasher(FxBuildHasher);
+
+        for record in records {
+            let Some(suffix) = record.wildcard_suffix(default_domain) else {
+                if record.is_wildcard() {
+                    warn!(
+                        hostname = %record.hostname,
+                        "Wildcard record has no domain to anchor it, skipping"
+                    );
+                }
+                continue;
+            };
+
+            let Ok(address) = record.ip.parse::<IpAddr>() else {
+                warn!(
+                    hostname = %record.hostname,
+                    ip = %record.ip,
+                    "Wildcard record: invalid IP address, skipping"
+                );
+                continue;
+            };
+
+            let Ok(record_type) = record.record_type.parse::<RecordType>() else {
+                warn!(
+                    hostname = %record.hostname,
+                    record_type = %record.record_type,
+                    "Wildcard record: unrecognised record type, skipping"
+                );
+                continue;
+            };
+
+            register_in(&map, &suffix, record_type, address, record.ttl_or_default());
+        }
+
+        if !map.is_empty() {
+            info!(count = map.len(), "Wildcard local DNS records loaded");
+        }
+
+        Arc::new(map)
+    }
+
+    /// Longest covering wildcard for `domain`, or `None` when no wildcard
+    /// covers it. The walk starts at the query name's parent, so a name never
+    /// matches a wildcard anchored on itself — `*.example.com` does not answer
+    /// for `example.com` (RFC 4592 §2.1.1).
+    fn lookup(&self, domain: &str) -> Option<WildcardAnswer> {
+        let lowered = normalize(domain);
+        let mut candidate = lowered.as_ref();
+
+        while let Some((_, parent)) = candidate.split_once('.') {
+            if let Some(entry) = self.map.get(parent) {
+                return Some(*entry.value());
+            }
+            candidate = parent;
+        }
+
+        None
+    }
+}
+
+/// Mutating handle on the live wildcard index, held by the CRUD use cases.
+///
+/// Separate from the resolver on purpose: the use cases only ever add and
+/// remove entries, and building a resolver — which needs an inner resolver to
+/// delegate to — just to reach its map would be wiring for nothing.
+pub struct WildcardRegistry {
+    map: Arc<WildcardMap>,
+}
+
+impl WildcardRegistry {
+    pub fn new(map: Arc<WildcardMap>) -> Self {
+        Self { map }
+    }
+}
+
+impl WildcardRecordRegistry for WildcardRegistry {
+    fn register(&self, suffix: &str, record_type: RecordType, address: IpAddr, ttl: u32) {
+        register_in(&self.map, suffix, record_type, address, ttl);
+    }
+
+    fn unregister(&self, suffix: &str, record_type: RecordType) {
+        let key = suffix.to_ascii_lowercase();
+
+        let emptied = match self.map.get_mut(key.as_str()) {
+            Some(mut entry) => {
+                entry.clear(record_type);
+                entry.is_empty()
+            }
+            None => return,
+        };
+
+        if emptied {
+            self.map.remove(key.as_str());
+        }
+    }
+}
+
+#[async_trait]
+impl DnsResolver for LocalWildcardResolver {
+    fn try_cache(&self, query: &DnsQuery) -> Option<DnsResolution> {
+        self.inner.try_cache(query)
+    }
+
+    fn try_cache_str(&self, domain: &str, record_type: RecordType) -> Option<DnsResolution> {
+        self.inner.try_cache_str(domain, record_type)
+    }
+
+    async fn resolve(&self, query: &DnsQuery) -> Result<DnsResolution, DomainError> {
+        if self.map.is_empty() {
+            return self.inner.resolve(query).await;
+        }
+
+        let Some(answer) = self.lookup(&query.domain) else {
+            return self.inner.resolve(query).await;
+        };
+
+        // An exact local record — or anything already cached for this precise
+        // name — is the closer match and wins over the wildcard.
+        if let Some(cached) = self.inner.try_cache(query) {
+            if cached.has_response_data() {
+                return Ok(cached);
+            }
+        }
+
+        match answer.get(query.record_type) {
+            Some((address, ttl)) => {
+                debug!(
+                    domain = %query.domain,
+                    %address,
+                    "LocalWildcardResolver: answered from a wildcard record"
+                );
+                Ok(local_answer(vec![address], Some(ttl)))
+            }
+            // The name is inside a covered subtree but the wildcard carries no
+            // record of this type. That is NODATA — an empty NOERROR built by
+            // the server from the client's own question — not a reason to ask
+            // upstream and leak an internal name (RFC 4592 §2.2.1).
+            None => {
+                debug!(
+                    domain = %query.domain,
+                    record_type = %query.record_type,
+                    "LocalWildcardResolver: NODATA from a wildcard record"
+                );
+                Ok(local_answer(Vec::new(), None))
+            }
+        }
+    }
+}
+
+fn register_in(
+    map: &WildcardMap,
+    suffix: &str,
+    record_type: RecordType,
+    address: IpAddr,
+    ttl: u32,
+) {
+    let type_matches = matches!(
+        (record_type, address),
+        (RecordType::A, IpAddr::V4(_)) | (RecordType::AAAA, IpAddr::V6(_))
+    );
+
+    if !type_matches {
+        warn!(
+            suffix,
+            %record_type,
+            %address,
+            "Wildcard record: A needs IPv4 and AAAA needs IPv6, skipping"
+        );
+        return;
+    }
+
+    map.entry(Box::from(suffix.to_ascii_lowercase().as_str()))
+        .or_default()
+        .set(record_type, address, ttl);
+}
+
+fn local_answer(addresses: Vec<IpAddr>, ttl: Option<u32>) -> DnsResolution {
+    DnsResolution {
+        addresses: Arc::new(addresses),
+        cache_hit: false,
+        // Marks the answer as locally authoritative: it keeps the rebinding
+        // guard from treating our own LAN address as an attack, and the query
+        // log from reporting the answer as an upstream one.
+        local_dns: true,
+        dnssec_status: None,
+        cname_chain: Arc::clone(&EMPTY_CNAME_CHAIN),
+        upstream_server: None,
+        upstream_pool: None,
+        min_ttl: ttl,
+        negative_soa_ttl: None,
+        upstream_wire_data: None,
+    }
+}
+
+fn normalize(domain: &str) -> Cow<'_, str> {
+    if domain.bytes().any(|b| b.is_ascii_uppercase()) {
+        Cow::Owned(domain.to_ascii_lowercase())
+    } else {
+        Cow::Borrowed(domain)
+    }
+}

--- a/crates/infrastructure/src/dns/resolver/mod.rs
+++ b/crates/infrastructure/src/dns/resolver/mod.rs
@@ -8,6 +8,7 @@ pub mod filtered_resolver;
 pub mod filters;
 pub mod legacy;
 pub mod local_ptr;
+pub mod local_wildcard;
 
 pub use builder::ResolverBuilder;
 pub use cache_layer::CachedResolver;
@@ -19,3 +20,4 @@ pub use filtered_resolver::FilteredResolver;
 pub use filters::QueryFilters;
 pub use legacy::HickoryDnsResolver;
 pub use local_ptr::LocalPtrResolver;
+pub use local_wildcard::{LocalWildcardResolver, WildcardAnswer, WildcardMap, WildcardRegistry};

--- a/crates/infrastructure/tests/cache_bloom_rotation_test.rs
+++ b/crates/infrastructure/tests/cache_bloom_rotation_test.rs
@@ -123,6 +123,7 @@ fn rotation_reseeds_permanent_entries() {
         "printer.lan",
         RecordType::A,
         make_cname_data("printer.local"),
+        300,
         None,
     );
 

--- a/crates/infrastructure/tests/cache_list_entries_test.rs
+++ b/crates/infrastructure/tests/cache_list_entries_test.rs
@@ -331,6 +331,7 @@ fn test_list_entries_permanent_entry_has_no_remaining_ttl() {
         "printer.lan",
         RecordType::A,
         make_ip_data("192.168.1.50"),
+        300,
         None,
     );
     cache.insert(

--- a/crates/infrastructure/tests/cache_permanent_entries_test.rs
+++ b/crates/infrastructure/tests/cache_permanent_entries_test.rs
@@ -1,0 +1,170 @@
+//! Permanent cache entries — the local DNS records preloaded from config.
+//!
+//! Nothing reloads them once they leave the cache, so they have to survive a
+//! `clear()`, and they have to report the TTL they were configured with rather
+//! than the distance to their sentinel `u64::MAX` expiry.
+
+use ferrous_dns_domain::RecordType;
+use ferrous_dns_infrastructure::dns::{
+    CachedAddresses, CachedData, DnsCache, DnsCacheConfig, EvictionStrategy,
+};
+use std::net::IpAddr;
+use std::sync::Arc;
+
+fn make_cache() -> DnsCache {
+    DnsCache::new(DnsCacheConfig {
+        max_entries: 100,
+        eviction_strategy: EvictionStrategy::HitRate,
+        min_threshold: 0.0,
+        refresh_threshold: 0.0,
+        batch_eviction_percentage: 0.2,
+        adaptive_thresholds: false,
+        min_frequency: 0,
+        min_lfuk_score: 0.0,
+        shard_amount: 4,
+        access_window_secs: 7200,
+        eviction_sample_size: 8,
+        lfuk_k_value: 0.5,
+        refresh_sample_rate: 1.0,
+        min_ttl: 0,
+        max_ttl: 86_400,
+    })
+}
+
+fn make_ip_data(ip: &str) -> CachedData {
+    let addr: IpAddr = ip.parse().unwrap();
+    CachedData::IpAddresses(CachedAddresses {
+        addresses: Arc::new(vec![addr]),
+    })
+}
+
+fn addresses_of(data: &CachedData) -> Vec<IpAddr> {
+    match data {
+        CachedData::IpAddresses(entry) => entry.addresses.as_ref().clone(),
+        _ => panic!("expected address data"),
+    }
+}
+
+#[test]
+fn test_permanent_entry_reports_its_configured_ttl() {
+    let cache = make_cache();
+    cache.insert_permanent(
+        "nas.home.lan",
+        RecordType::A,
+        make_ip_data("10.0.0.5"),
+        300,
+        None,
+    );
+
+    let (_, _, remaining) = cache
+        .get("nas.home.lan", &RecordType::A)
+        .expect("permanent entry must be readable");
+
+    assert_eq!(remaining, Some(300));
+}
+
+#[test]
+fn test_permanent_entry_ttl_survives_a_second_read_from_l1() {
+    let cache = make_cache();
+    cache.insert_permanent(
+        "printer.home.lan",
+        RecordType::A,
+        make_ip_data("10.0.0.6"),
+        120,
+        None,
+    );
+
+    // First read promotes into the thread-local L1; the second is served from it.
+    let _ = cache.get("printer.home.lan", &RecordType::A);
+    let (_, _, remaining) = cache
+        .get("printer.home.lan", &RecordType::A)
+        .expect("permanent entry must still be readable");
+
+    let remaining = remaining.expect("permanent entry has a TTL");
+    assert!(
+        (110..=120).contains(&remaining),
+        "L1 must not report the sentinel expiry: {remaining}"
+    );
+}
+
+#[test]
+fn test_clear_preserves_permanent_entries() {
+    let cache = make_cache();
+    cache.insert_permanent(
+        "nas.home.lan",
+        RecordType::A,
+        make_ip_data("10.0.0.5"),
+        300,
+        None,
+    );
+    cache.insert(
+        "example.com",
+        RecordType::A,
+        make_ip_data("93.184.216.34"),
+        300,
+        None,
+    );
+
+    cache.clear();
+
+    assert!(
+        cache.get("example.com", &RecordType::A).is_none(),
+        "an upstream answer must not survive a flush"
+    );
+
+    let (data, _, remaining) = cache
+        .get("nas.home.lan", &RecordType::A)
+        .expect("a local DNS record must survive a flush — nothing reloads it");
+    assert_eq!(
+        addresses_of(&data),
+        vec!["10.0.0.5".parse::<IpAddr>().unwrap()]
+    );
+    assert_eq!(remaining, Some(300));
+    assert!(cache.is_permanent("nas.home.lan", &RecordType::A));
+}
+
+#[test]
+fn test_is_permanent_distinguishes_the_two_kinds() {
+    let cache = make_cache();
+    cache.insert_permanent(
+        "nas.home.lan",
+        RecordType::A,
+        make_ip_data("10.0.0.5"),
+        300,
+        None,
+    );
+    cache.insert(
+        "example.com",
+        RecordType::A,
+        make_ip_data("93.184.216.34"),
+        300,
+        None,
+    );
+
+    assert!(cache.is_permanent("nas.home.lan", &RecordType::A));
+    assert!(cache.is_permanent("NAS.HOME.LAN", &RecordType::A));
+    assert!(!cache.is_permanent("nas.home.lan", &RecordType::AAAA));
+    assert!(!cache.is_permanent("example.com", &RecordType::A));
+    assert!(!cache.is_permanent("absent.home.lan", &RecordType::A));
+}
+
+#[test]
+fn test_removed_permanent_entry_is_no_longer_permanent() {
+    let cache = make_cache();
+    cache.insert_permanent(
+        "nas.home.lan",
+        RecordType::A,
+        make_ip_data("10.0.0.5"),
+        300,
+        None,
+    );
+
+    assert!(cache.remove("nas.home.lan", &RecordType::A));
+
+    assert!(!cache.is_permanent("nas.home.lan", &RecordType::A));
+    cache.clear();
+    assert!(
+        cache.get("nas.home.lan", &RecordType::A).is_none(),
+        "a removed entry must not come back through clear()"
+    );
+}

--- a/crates/infrastructure/tests/cache_ttl_bounds_test.rs
+++ b/crates/infrastructure/tests/cache_ttl_bounds_test.rs
@@ -85,13 +85,20 @@ fn test_ttl_within_bounds_unchanged() {
 #[test]
 fn test_permanent_records_ignore_bounds() {
     let cache = make_cache();
-    cache.insert_permanent("example.com", RecordType::A, make_ip_data("1.2.3.4"), None);
+    // A week, well past the cache's 86400 max_ttl.
+    let configured_ttl = 604_800;
+    cache.insert_permanent(
+        "example.com",
+        RecordType::A,
+        make_ip_data("1.2.3.4"),
+        configured_ttl,
+        None,
+    );
     let ttl = cache.get_ttl("example.com", &RecordType::A);
-    let permanent_ttl = 365u32 * 24 * 60 * 60;
     assert_eq!(
         ttl,
-        Some(permanent_ttl),
-        "Permanent records should retain their large TTL"
+        Some(configured_ttl),
+        "Permanent records keep their configured TTL, unclamped"
     );
 }
 

--- a/crates/infrastructure/tests/dns_cache_test.rs
+++ b/crates/infrastructure/tests/dns_cache_test.rs
@@ -651,7 +651,13 @@ fn test_refresh_candidates_skips_permanent_entries() {
     // passaria em todos os outros filtros.
     let cache = create_refresh_cache(u64::MAX);
 
-    cache.insert_permanent("forever.com", RecordType::A, make_ip_data("10.0.0.1"), None);
+    cache.insert_permanent(
+        "forever.com",
+        RecordType::A,
+        make_ip_data("10.0.0.1"),
+        300,
+        None,
+    );
     cache.insert(
         "ephemeral.com",
         RecordType::A,

--- a/crates/infrastructure/tests/local_wildcard_resolver_test.rs
+++ b/crates/infrastructure/tests/local_wildcard_resolver_test.rs
@@ -1,0 +1,356 @@
+//! `LocalWildcardResolver` — wildcard local DNS records (issue #223).
+//!
+//! The layer sits above the cache, so an exact record (which lives in the cache
+//! as a permanent entry) has to keep winning, and a wildcard answer must never
+//! be handed down for caching.
+
+use async_trait::async_trait;
+use ferrous_dns_application::ports::{
+    DnsResolution, DnsResolver, WildcardRecordRegistry, EMPTY_CNAME_CHAIN,
+};
+use ferrous_dns_domain::{DnsQuery, DomainError, LocalDnsRecord, RecordType};
+use ferrous_dns_infrastructure::dns::resolver::{
+    LocalWildcardResolver, WildcardMap, WildcardRegistry,
+};
+use std::net::IpAddr;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+
+fn record(hostname: &str, domain: &str, ip: &str, record_type: &str) -> LocalDnsRecord {
+    LocalDnsRecord {
+        hostname: hostname.to_string(),
+        domain: Some(domain.to_string()),
+        ip: ip.to_string(),
+        record_type: record_type.to_string(),
+        ttl: Some(120),
+    }
+}
+
+fn ip(value: &str) -> IpAddr {
+    IpAddr::from_str(value).unwrap()
+}
+
+fn upstream_resolution() -> DnsResolution {
+    DnsResolution {
+        addresses: Arc::new(vec![ip("93.184.216.34")]),
+        cache_hit: false,
+        local_dns: false,
+        dnssec_status: None,
+        cname_chain: Arc::clone(&EMPTY_CNAME_CHAIN),
+        upstream_server: Some(Arc::from("1.1.1.1:53")),
+        upstream_pool: None,
+        min_ttl: Some(300),
+        negative_soa_ttl: None,
+        upstream_wire_data: None,
+    }
+}
+
+/// Stands in for the cache layer below the wildcard resolver.
+#[derive(Default)]
+struct MockInner {
+    /// What `try_cache` hands back — the exact permanent records, in production.
+    cached: Option<DnsResolution>,
+    resolve_calls: Mutex<Vec<(String, RecordType)>>,
+    try_cache_calls: Mutex<usize>,
+}
+
+impl MockInner {
+    fn resolve_calls(&self) -> Vec<(String, RecordType)> {
+        self.resolve_calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl DnsResolver for MockInner {
+    fn try_cache(&self, _query: &DnsQuery) -> Option<DnsResolution> {
+        *self.try_cache_calls.lock().unwrap() += 1;
+        self.cached.clone()
+    }
+
+    async fn resolve(&self, query: &DnsQuery) -> Result<DnsResolution, DomainError> {
+        self.resolve_calls
+            .lock()
+            .unwrap()
+            .push((query.domain.to_string(), query.record_type));
+        Ok(upstream_resolution())
+    }
+}
+
+fn resolver_with(records: &[LocalDnsRecord]) -> (LocalWildcardResolver, Arc<MockInner>) {
+    let inner = Arc::new(MockInner::default());
+    let map = LocalWildcardResolver::map_from_local_records(records, &None);
+    (LocalWildcardResolver::new(inner.clone(), map), inner)
+}
+
+#[tokio::test]
+async fn test_wildcard_answers_a_subdomain() {
+    let (resolver, inner) = resolver_with(&[record("*", "home.lan", "192.168.1.10", "A")]);
+
+    let resolution = resolver
+        .resolve(&DnsQuery::new("anything.home.lan", RecordType::A))
+        .await
+        .unwrap();
+
+    assert_eq!(resolution.addresses.as_ref(), &[ip("192.168.1.10")]);
+    assert!(resolution.local_dns);
+    assert_eq!(resolution.min_ttl, Some(120));
+    assert!(inner.resolve_calls().is_empty());
+}
+
+#[tokio::test]
+async fn test_wildcard_answers_a_deep_subdomain() {
+    let (resolver, _inner) = resolver_with(&[record("*", "home.lan", "192.168.1.10", "A")]);
+
+    let resolution = resolver
+        .resolve(&DnsQuery::new("a.b.c.home.lan", RecordType::A))
+        .await
+        .unwrap();
+
+    assert_eq!(resolution.addresses.as_ref(), &[ip("192.168.1.10")]);
+}
+
+#[tokio::test]
+async fn test_wildcard_does_not_answer_the_apex() {
+    let (resolver, inner) = resolver_with(&[record("*", "home.lan", "192.168.1.10", "A")]);
+
+    let resolution = resolver
+        .resolve(&DnsQuery::new("home.lan", RecordType::A))
+        .await
+        .unwrap();
+
+    assert!(!resolution.local_dns);
+    assert_eq!(
+        inner.resolve_calls(),
+        vec![("home.lan".to_string(), RecordType::A)]
+    );
+}
+
+#[tokio::test]
+async fn test_longest_wildcard_wins() {
+    let (resolver, _inner) = resolver_with(&[
+        record("*", "home.lan", "192.168.1.10", "A"),
+        record("*.dev", "home.lan", "192.168.1.20", "A"),
+    ]);
+
+    let broad = resolver
+        .resolve(&DnsQuery::new("nas.home.lan", RecordType::A))
+        .await
+        .unwrap();
+    assert_eq!(broad.addresses.as_ref(), &[ip("192.168.1.10")]);
+
+    let specific = resolver
+        .resolve(&DnsQuery::new("api.dev.home.lan", RecordType::A))
+        .await
+        .unwrap();
+    assert_eq!(specific.addresses.as_ref(), &[ip("192.168.1.20")]);
+}
+
+#[tokio::test]
+async fn test_exact_cached_record_beats_the_wildcard() {
+    let inner = Arc::new(MockInner {
+        cached: Some(DnsResolution {
+            addresses: Arc::new(vec![ip("192.168.1.50")]),
+            cache_hit: true,
+            ..upstream_resolution()
+        }),
+        ..Default::default()
+    });
+    let map = LocalWildcardResolver::map_from_local_records(
+        &[record("*", "home.lan", "192.168.1.10", "A")],
+        &None,
+    );
+    let resolver = LocalWildcardResolver::new(inner.clone(), map);
+
+    let resolution = resolver
+        .resolve(&DnsQuery::new("nas.home.lan", RecordType::A))
+        .await
+        .unwrap();
+
+    assert_eq!(resolution.addresses.as_ref(), &[ip("192.168.1.50")]);
+    assert!(resolution.cache_hit);
+    assert!(inner.resolve_calls().is_empty());
+}
+
+#[tokio::test]
+async fn test_negative_cache_entry_does_not_beat_the_wildcard() {
+    let inner = Arc::new(MockInner {
+        cached: Some(DnsResolution {
+            addresses: Arc::new(vec![]),
+            upstream_wire_data: None,
+            ..upstream_resolution()
+        }),
+        ..Default::default()
+    });
+    let map = LocalWildcardResolver::map_from_local_records(
+        &[record("*", "home.lan", "192.168.1.10", "A")],
+        &None,
+    );
+    let resolver = LocalWildcardResolver::new(inner, map);
+
+    let resolution = resolver
+        .resolve(&DnsQuery::new("stale.home.lan", RecordType::A))
+        .await
+        .unwrap();
+
+    assert_eq!(resolution.addresses.as_ref(), &[ip("192.168.1.10")]);
+}
+
+#[tokio::test]
+async fn test_uncovered_record_type_returns_nodata() {
+    let (resolver, inner) = resolver_with(&[record("*", "home.lan", "192.168.1.10", "A")]);
+
+    let resolution = resolver
+        .resolve(&DnsQuery::new("anything.home.lan", RecordType::AAAA))
+        .await
+        .unwrap();
+
+    // Empty NOERROR: no addresses, no wire data for the server to relay, and
+    // nothing asked upstream.
+    assert!(resolution.addresses.is_empty());
+    assert!(resolution.upstream_wire_data.is_none());
+    assert!(resolution.local_dns);
+    assert!(inner.resolve_calls().is_empty());
+}
+
+#[tokio::test]
+async fn test_both_record_types_on_one_suffix() {
+    let (resolver, _inner) = resolver_with(&[
+        record("*", "home.lan", "192.168.1.10", "A"),
+        record("*", "home.lan", "fd00::1", "AAAA"),
+    ]);
+
+    let v4 = resolver
+        .resolve(&DnsQuery::new("host.home.lan", RecordType::A))
+        .await
+        .unwrap();
+    let v6 = resolver
+        .resolve(&DnsQuery::new("host.home.lan", RecordType::AAAA))
+        .await
+        .unwrap();
+
+    assert_eq!(v4.addresses.as_ref(), &[ip("192.168.1.10")]);
+    assert_eq!(v6.addresses.as_ref(), &[ip("fd00::1")]);
+}
+
+#[tokio::test]
+async fn test_uncovered_name_passes_through() {
+    let (resolver, inner) = resolver_with(&[record("*", "home.lan", "192.168.1.10", "A")]);
+
+    let resolution = resolver
+        .resolve(&DnsQuery::new("example.com", RecordType::A))
+        .await
+        .unwrap();
+
+    assert!(!resolution.local_dns);
+    assert_eq!(
+        inner.resolve_calls(),
+        vec![("example.com".to_string(), RecordType::A)]
+    );
+}
+
+#[tokio::test]
+async fn test_empty_index_passes_through_without_probing_the_cache() {
+    let (resolver, inner) = resolver_with(&[]);
+
+    resolver
+        .resolve(&DnsQuery::new("anything.home.lan", RecordType::A))
+        .await
+        .unwrap();
+
+    assert_eq!(*inner.try_cache_calls.lock().unwrap(), 0);
+    assert_eq!(inner.resolve_calls().len(), 1);
+}
+
+#[tokio::test]
+async fn test_query_name_case_is_ignored() {
+    let (resolver, _inner) = resolver_with(&[record("*", "Home.LAN", "192.168.1.10", "A")]);
+
+    let resolution = resolver
+        .resolve(&DnsQuery::new("AnyThing.HOME.lan", RecordType::A))
+        .await
+        .unwrap();
+
+    assert_eq!(resolution.addresses.as_ref(), &[ip("192.168.1.10")]);
+}
+
+#[tokio::test]
+async fn test_record_type_and_ip_family_must_agree() {
+    let (resolver, inner) = resolver_with(&[record("*", "home.lan", "fd00::1", "A")]);
+
+    let resolution = resolver
+        .resolve(&DnsQuery::new("anything.home.lan", RecordType::A))
+        .await
+        .unwrap();
+
+    assert!(!resolution.local_dns);
+    assert_eq!(inner.resolve_calls().len(), 1);
+}
+
+#[tokio::test]
+async fn test_wildcard_without_a_domain_is_not_indexed() {
+    let unanchored = LocalDnsRecord {
+        hostname: "*".to_string(),
+        domain: None,
+        ip: "192.168.1.10".to_string(),
+        record_type: "A".to_string(),
+        ttl: None,
+    };
+    let map = LocalWildcardResolver::map_from_local_records(&[unanchored], &None);
+
+    assert!(map.is_empty());
+}
+
+#[tokio::test]
+async fn test_register_and_unregister_take_effect_live() {
+    let inner = Arc::new(MockInner::default());
+    let map: Arc<WildcardMap> = LocalWildcardResolver::map_from_local_records(&[], &None);
+    let resolver = LocalWildcardResolver::new(inner.clone(), Arc::clone(&map));
+    let registry = WildcardRegistry::new(Arc::clone(&map));
+
+    registry.register("home.lan", RecordType::A, ip("192.168.1.10"), 60);
+
+    let answered = resolver
+        .resolve(&DnsQuery::new("nas.home.lan", RecordType::A))
+        .await
+        .unwrap();
+    assert_eq!(answered.addresses.as_ref(), &[ip("192.168.1.10")]);
+    assert_eq!(answered.min_ttl, Some(60));
+
+    registry.unregister("home.lan", RecordType::A);
+    assert!(map.is_empty());
+
+    let passed_through = resolver
+        .resolve(&DnsQuery::new("nas.home.lan", RecordType::A))
+        .await
+        .unwrap();
+    assert!(!passed_through.local_dns);
+}
+
+#[tokio::test]
+async fn test_unregister_one_type_keeps_the_other() {
+    let map = LocalWildcardResolver::map_from_local_records(
+        &[
+            record("*", "home.lan", "192.168.1.10", "A"),
+            record("*", "home.lan", "fd00::1", "AAAA"),
+        ],
+        &None,
+    );
+    let resolver = LocalWildcardResolver::new(Arc::new(MockInner::default()), Arc::clone(&map));
+    let registry = WildcardRegistry::new(Arc::clone(&map));
+
+    registry.unregister("home.lan", RecordType::A);
+
+    assert!(!map.is_empty());
+    let v6 = resolver
+        .resolve(&DnsQuery::new("host.home.lan", RecordType::AAAA))
+        .await
+        .unwrap();
+    assert_eq!(v6.addresses.as_ref(), &[ip("fd00::1")]);
+
+    let v4 = resolver
+        .resolve(&DnsQuery::new("host.home.lan", RecordType::A))
+        .await
+        .unwrap();
+    assert!(v4.addresses.is_empty());
+    assert!(v4.local_dns);
+}

--- a/docs/configuration/dns.md
+++ b/docs/configuration/dns.md
@@ -158,6 +158,45 @@ ttl = 300
 | `record_type` | `"A"` for IPv4, `"AAAA"` for IPv6 |
 | `ttl` | Time-to-live in seconds |
 
+### Wildcard Records
+
+Set `hostname` to `*` to answer for every subdomain of `domain`, instead of
+listing them one by one:
+
+```toml
+[[dns.local_records]]
+hostname = "*"
+domain = "home.lan"
+ip = "192.168.1.10"
+record_type = "A"
+ttl = 300
+```
+
+`anything.home.lan` and `deeper.still.home.lan` both resolve to `192.168.1.10`.
+
+The rules:
+
+- **The domain itself is not covered.** `*.home.lan` does not answer for
+  `home.lan` (RFC 4592). Add an exact record for the apex if you need one.
+- **An exact record wins.** With both `*.home.lan → 192.168.1.10` and
+  `nas.home.lan → 192.168.1.50`, a query for `nas.home.lan` gets `192.168.1.50`.
+- **The most specific wildcard wins.** `*.dev.home.lan` beats `*.home.lan` for
+  `api.dev.home.lan`.
+- **A type the wildcard does not carry is answered as NODATA** — an empty
+  `NOERROR`, not a query sent upstream. With only an A record defined, an `AAAA`
+  for `anything.home.lan` returns no answer instead of leaking the internal name
+  to your upstream resolver.
+- **Wildcards are matched before the cache and never cached**, so adding or
+  deleting one from the dashboard takes effect on the next query.
+- **No PTR is generated.** A wildcard has no single name for an address to
+  reverse to, so [Auto PTR Generation](#local-records) skips it.
+- `*` is accepted only as the leftmost label: `*` or `*.dev` in `hostname`, never
+  inside `domain`. Anything else is rejected with a `400`.
+
+A wildcard needs something to anchor it: set `domain`, or a global
+`dns.local_domain`. A bare `*` with neither is refused rather than stored as a
+record that would cover every query.
+
 ### Auto PTR Generation
 
 When you define a local A record, Ferrous DNS automatically creates a PTR record. For example, `server.local → 192.168.1.100` also creates `100.1.168.192.in-addr.arpa → server.local`.

--- a/ferrous-dns.toml
+++ b/ferrous-dns.toml
@@ -239,6 +239,12 @@ success_threshold = 2                   # Consecutive successes to mark a server
 
 # ── Local DNS Records ────────────────────────────────────────────────────────
 # Static A/AAAA records served directly from cache, bypassing upstream resolution.
+#
+# Set hostname = "*" to cover every subdomain of `domain`. A wildcard answers for
+# anything below the domain (including deeper names such as `a.b.home.lan`) but
+# never for the domain itself, and an exact record always beats it. A query type
+# the wildcard does not carry — AAAA when only an A is defined — is answered as
+# an empty NOERROR rather than being forwarded upstream.
 
 [[dns.local_records]]
 hostname = "viudes"
@@ -253,6 +259,13 @@ domain = "server"
 ip = "10.0.1.1"
 record_type = "A"
 ttl = 300
+
+# [[dns.local_records]]
+# hostname = "*"
+# domain = "home.lan"
+# ip = "10.0.10.1"
+# record_type = "A"
+# ttl = 300
 
 [[dns.pools]]
 name = "pool1"

--- a/web/static/cache-control.html
+++ b/web/static/cache-control.html
@@ -193,10 +193,16 @@
                     </td>
                     <td class="col-hit" style="font-size:13px" x-text="entry.hits"></td>
                     <td class="col-action">
-                        <button type="button" class="btn-action btn-action-remove"
-                            :disabled="removing === entry.domain + '|' + entry.type"
-                            @click="removeEntry(entry)">Remove
-                        </button>
+                        <template x-if="!entry.permanent">
+                            <button type="button" class="btn-action btn-action-remove"
+                                :disabled="removing === entry.domain + '|' + entry.type"
+                                @click="removeEntry(entry)">Remove
+                            </button>
+                        </template>
+                        <template x-if="entry.permanent">
+                            <span style="color:var(--text-secondary);font-size:12px"
+                                  title="Local DNS record — remove it in Local DNS settings">local record</span>
+                        </template>
                     </td>
                 </tr>
             </template>

--- a/web/static/local-dns-settings.css
+++ b/web/static/local-dns-settings.css
@@ -50,6 +50,7 @@
 
         .badge-blue { background: rgba(59,130,246,0.1); color: #3B82F6 }
         .badge-purple { background: rgba(168,85,247,0.1); color: #A855F7 }
+        .badge-amber { background: rgba(245,158,11,0.1); color: #F59E0B }
 
         .table { width: 100%; border-collapse: collapse }
 

--- a/web/static/local-dns-settings.html
+++ b/web/static/local-dns-settings.html
@@ -115,6 +115,7 @@
                     <div class="form-group">
                         <label class="form-label">Hostname <span style="color:var(--color-error)">*</span></label>
                         <input type="text" class="input" x-model="form.hostname" placeholder="e.g. server">
+                        <p style="margin:6px 0 0;font-size:12px;color:var(--text-tertiary)">Use <code style="padding:1px 4px;background:var(--bg-tertiary);border-radius:3px;font-family:monospace">*</code> to cover every subdomain of the domain beside it.</p>
                     </div>
                     <div class="form-group">
                         <label class="form-label">Domain <span style="color:var(--text-tertiary);font-weight:400">(optional)</span></label>
@@ -147,6 +148,7 @@
 
                 <div style="margin-top:20px;padding-top:20px;border-top:1px solid var(--border-color)">
                     <p style="font-size:13px;color:var(--text-secondary);margin:0 0 6px">Records are stored in <code style="padding:2px 6px;background:var(--bg-tertiary);border-radius:4px;font-family:monospace;font-size:12px">ferrous-dns.toml</code> and cached permanently in memory.</p>
+                    <p style="font-size:13px;color:var(--text-secondary);margin:0 0 6px">A wildcard record answers for every subdomain below its domain, but not for the domain itself. An exact record always wins over a wildcard covering the same name.</p>
                     <p style="font-size:12px;color:var(--text-tertiary);margin:0;font-style:italic">Changes are applied immediately and resolved in &lt;0.1ms. The config file can be version-controlled with Git.</p>
                 </div>
             </div>
@@ -168,6 +170,7 @@
                     <tr>
                         <td>
                             <span style="font-family:monospace;font-size:13px;color:var(--text-primary)" x-text="record.fqdn"></span>
+                            <span x-show="record.fqdn.startsWith('*.')" class="badge badge-amber" style="margin-left:8px">WILDCARD</span>
                         </td>
                         <td>
                             <span style="font-family:monospace;font-size:13px;color:var(--text-primary)" x-text="record.ip"></span>

--- a/web/static/local-dns-settings.js
+++ b/web/static/local-dns-settings.js
@@ -53,6 +53,39 @@
             get form() {
                 return this.editingRecord ?? this.newRecord;
             },
+            // Mirrors the server-side validator so a malformed hostname is caught
+            // before the round trip. Anything the browser cannot know — whether
+            // dns.local_domain can anchor a bare `*` — is left to the API.
+            validateRecord(record) {
+                const hostname = (record.hostname || '').trim();
+                const domain = (record.domain || '').trim();
+                const labels = /^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*$/;
+
+                if (!hostname || !record.ip) {
+                    return 'Hostname and IP address are required.';
+                }
+                if (hostname.includes('*') && hostname !== '*' && !hostname.startsWith('*.')) {
+                    return "Wildcard must be the leftmost label: use '*' or '*.sub'.";
+                }
+                if (hostname !== '*' && !labels.test(hostname.replace(/^\*\./, ''))) {
+                    return 'Hostname may only contain letters, digits, hyphens and underscores.';
+                }
+                if (domain.includes('*')) {
+                    return "Domain cannot contain a wildcard: put the '*' in the hostname.";
+                }
+                if (domain && !labels.test(domain)) {
+                    return 'Domain may only contain letters, digits, hyphens and underscores.';
+                }
+                return '';
+            },
+            async errorText(response, fallback) {
+                try {
+                    const body = await response.json();
+                    return body.error || fallback;
+                } catch (e) {
+                    return fallback;
+                }
+            },
             async loadRecords() {
                 try {
                     const r = await fetch(`${API_BASE}/local-records`);
@@ -78,11 +111,8 @@
                 this.addError = '';
             },
             async updateRecord() {
-                this.addError = '';
-                if (!this.editingRecord.hostname || !this.editingRecord.ip) {
-                    this.addError = 'Hostname and IP address are required.';
-                    return;
-                }
+                this.addError = this.validateRecord(this.editingRecord);
+                if (this.addError) return;
                 try {
                     const r = await fetch(`${API_BASE}/local-records/${this.editingRecord.id}`, {
                         method: 'PUT',
@@ -100,7 +130,7 @@
                         await this.loadRecords();
                         this.$nextTick(() => scheduleLucide());
                     } else {
-                        this.addError = await r.text() || 'Failed to update record';
+                        this.addError = await this.errorText(r, 'Failed to update record');
                     }
                 } catch (e) {
                     console.error(e);
@@ -108,11 +138,8 @@
                 }
             },
             async addRecord() {
-                this.addError = '';
-                if (!this.newRecord.hostname || !this.newRecord.ip) {
-                    this.addError = 'Hostname and IP address are required.';
-                    return;
-                }
+                this.addError = this.validateRecord(this.newRecord);
+                if (this.addError) return;
                 try {
                     const r = await fetch(`${API_BASE}/local-records`, {
                         method: 'POST',
@@ -130,7 +157,7 @@
                         this.newRecord = {hostname: '', domain: '', ip: '', record_type: 'A', ttl: 300};
                         this.$nextTick(() => scheduleLucide());
                     } else {
-                        this.addError = await r.text() || 'Failed to add record';
+                        this.addError = await this.errorText(r, 'Failed to add record');
                     }
                 } catch (e) {
                     console.error(e);


### PR DESCRIPTION
## Summary

A local DNS record with `hostname = "*"` was accepted at every layer, written to `ferrous-dns.toml`, loaded at boot, and installed in the DNS cache under the literal key `*.example.com`. Cache keys are matched exactly (`crates/infrastructure/src/dns/cache/key.rs:69-71`), so no query could ever reach it — the record was silently dead, with no error, no warning and no log line. That silence is what issue #223 ran into.

Working on it surfaced two more defects on the same path, both reachable from the dashboard; they are fixed here too and described below.

### Resolving wildcards

Wildcards are now served by `LocalWildcardResolver` (`crates/infrastructure/src/dns/resolver/local_wildcard.rs`), inserted between `FilteredResolver` and `CachedResolver` (`resolver/builder.rs`). It sits **above** the cache on purpose: an expansion of `*.home.lan` cached under a concrete name could never be enumerated again to invalidate when the wildcard is deleted. It costs one `is_empty()` check per query while no wildcard exists.

Lookup walks the query name upwards from its parent, so three properties fall out of the algorithm: the apex is never covered (RFC 4592), the longest wildcard wins, and a query name is never matched against a wildcard anchored on itself. Before answering it probes `inner.try_cache()`, so an exact record — which lives in the cache as a permanent entry — still beats a wildcard covering the same name.

A type the wildcard does not carry is answered as NODATA rather than forwarded: the server builds an empty NOERROR from the question the client sent, so an internal name never leaks to the upstream resolver.

Live CRUD goes through a new `WildcardRecordRegistry` port. The index is installed **unconditionally** at startup, unlike the PTR map (`crates/cli/src/wiring/dns/mod.rs` gates that on a non-empty `local_records`) — otherwise the first wildcard added from the dashboard would do nothing until a restart, which is exactly the experience being fixed.

### Rejecting what used to be swallowed

`LocalDnsRecord::validate_hostname` / `validate_domain` (`crates/domain/src/config/local_records.rs`) now enforce charset, label length and `*` only as the leftmost label, and the create/update use cases surface failures as `400`. A wildcard with nothing to anchor it (no `domain`, no `dns.local_domain`) is refused instead of stored as a record that would cover every query.

### Two cache defects on the permanent-entry path

**Absurd TTL.** The TTL handed to clients was the distance to the sentinel expiry of a permanent entry (`u64::MAX`), so `dig nas.home.lan` answered with a TTL of `2505911067` seconds — about eighty years — on both the L2 (`cache/storage.rs:271`) and L1 (`promote_to_l1`) paths. `insert_permanent` also threw away the TTL configured on the record in favour of a hardcoded 365 days; it now takes the real value and reports it back. `dig` returns `300`.

**Permanent entries could be evicted with no way back.** The Cache Control page rendered Remove on every row, and `delete_cache_entry` (`crates/api/src/handlers/cache.rs`) called `remove_record` without checking, so deleting a local DNS record from the cache unpublished the name until the next restart. The endpoint now refuses with a `400` pointing at Local DNS settings, and the button is replaced by a `local record` label. `DnsCache::clear` had the same hole — it wiped `permanent_keys` — and now restores the permanent entries it collected before clearing. `clear` has no caller in production code today, so that half was latent; it is closed before someone adds a flush endpoint on top of it.

### Deliberate tradeoffs

- Wildcard answers are not cached, so each one pays an index lookup instead of the cache fast path. For local records that is nanoseconds against a `DashMap`, and it buys instant deletes.
- Wildcards remain subject to the block filter, exactly as exact local records are today. Unchanged here.
- No PTR is generated for a wildcard — there is no single name an address could reverse to.
- `insert_permanent_record` gains a `ttl` parameter and `DnsCachePort` gains `is_permanent_record`. Both are internal ports with a single implementation.

## Related issues

Closes #223

## Test plan

- [x] `make ci` green — 2000 passed / 7 skipped, `cargo fmt --check` and `clippy --all-targets --all-features -D warnings` clean, doc tests clean, `cargo audit` exit 0 (3 pre-existing allowed warnings).
- [x] New tests:
  - `crates/domain/tests/local_records_test.rs` — 14 tests over the validator and the wildcard helpers: accepts `*` and `*.dev`, rejects `a.*.b`, `*x`, empty labels, oversized labels and non-ASCII; `wildcard_suffix` lowercases, honours `dns.local_domain`, and returns `None` for an unanchored `*`.
  - `crates/infrastructure/tests/local_wildcard_resolver_test.rs` — 15 tests: subdomain and deep-subdomain match, apex miss, longest-match, exact-beats-wildcard, a negative cache entry NOT beating the wildcard, NODATA on an uncovered type, pass-through on an uncovered name, no cache probe on an empty index, case-insensitive matching, A/AAAA family mismatch skipped, live register/unregister.
  - `crates/application/tests/local_records_wildcard_test.rs` — 13 tests: create/update/delete route to the wildcard index and never to the PTR map, exact records leave the index alone, update moves a record in both directions, every validation failure returns `InvalidDomainName`, and nothing registers on the save-failure rollback path.
  - `crates/infrastructure/tests/cache_permanent_entries_test.rs` — 5 tests: a permanent entry reports its configured TTL on the L2 and the L1 path, survives `clear()` while an upstream answer does not, `is_permanent` tells the two kinds apart case-insensitively, and a removed entry does not come back through `clear()`.
  - `crates/infrastructure/tests/cache_ttl_bounds_test.rs` — `test_permanent_records_ignore_bounds` now pins the configured TTL surviving unclamped past `max_ttl`, instead of the hardcoded 365 days it used to assert.
- [x] Manual, against a real build (`dig @127.0.0.1 -p 15353`, config with `*.home.lan` to `192.168.1.10`, `nas.home.lan` to `192.168.1.50`, `*.dev.home.lan` to `192.168.1.20`):
  - `anything.home.lan A` returns `192.168.1.10` (TTL 300); `deep.sub.home.lan A` returns `192.168.1.10`
  - `nas.home.lan A` returns `192.168.1.50` — exact wins
  - `api.dev.home.lan A` returns `192.168.1.20` — longest wildcard wins
  - `home.lan A` returns `NXDOMAIN` — apex not covered
  - `anything.home.lan AAAA` returns `NOERROR, ANSWER: 0` — NODATA, nothing sent upstream
  - `example.com A` resolved normally upstream
  - `nas.home.lan` TTL is `300` on the first and the second query (L2 then L1); it was `2505911067` before
  - `DELETE /api/cache/entries?domain=nas.home.lan&type=A` returns `400 {"error":"Invalid input: nas.home.lan A is a local DNS record — remove it in Local DNS settings"}`, and the same call on `example.com` still returns `204`
  - startup log: `Preloaded 1 local DNS record(s) ... wildcards=2`, `PTR auto-generation ... count=1`, `Wildcard local DNS records loaded count=2`
- [x] UI driven in a browser (Playwright, light theme, console clean): added `*` + `office.lan` from the form, the row rendered with the WILDCARD badge, `dig newhost.office.lan` answered `10.9.9.9` **without restarting the process**, then deleting the row from the UI made the next `dig` return NXDOMAIN while the other records kept resolving. Submitting `a.*.b` showed the inline error instead of storing a dead record. On Cache Control, the permanent row now shows `local record` in place of the Remove button.
- [x] Config round-trip: the wildcard entries survived a full config rewrite and a restart, and still resolved.

## Known follow-ups / out of scope

- Wildcards are limited to A and AAAA, matching what local records already supported.
- The wildcard index holds one address per suffix and record type; a second record for the same pair overwrites the first, which is what an exact record already does to its cache entry.